### PR TITLE
CIWEM-18: Hide the payment method when contribution status is pending

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -35,7 +35,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   }
 
   public function uninstall() {
-    $removalSteps  = [
+    $removalSteps = [
       new AccountsReceivablePaymentMethod(),
     ];
     foreach ($removalSteps as $step) {

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -1,9 +1,46 @@
 <?php
-use CRM_Financeextras_ExtensionUtil as E;
+
+use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod;
 
 /**
  * Collection of upgrade steps.
  */
 class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
+
+  public function install() {
+    $creationSteps = [
+      new AccountsReceivablePaymentMethod(),
+    ];
+    foreach ($creationSteps as $step) {
+      $step->create();
+    }
+  }
+
+  public function enable() {
+    $steps = [
+      new AccountsReceivablePaymentMethod(),
+    ];
+    foreach ($steps as $step) {
+      $step->activate();
+    }
+  }
+
+  public function disable() {
+    $steps = [
+      new AccountsReceivablePaymentMethod(),
+    ];
+    foreach ($steps as $step) {
+      $step->deactivate();
+    }
+  }
+
+  public function uninstall() {
+    $removalSteps  = [
+      new AccountsReceivablePaymentMethod(),
+    ];
+    foreach ($removalSteps as $step) {
+      $step->remove();
+    }
+  }
 
 }

--- a/Civi/Financeextras/Hook/alterContent/PaymentStatus.php
+++ b/Civi/Financeextras/Hook/alterContent/PaymentStatus.php
@@ -2,6 +2,9 @@
 
 namespace Civi\Financeextras\Hook\alterContent;
 
+use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod as AccountsReceivablePaymentMethod;
+use CRM_Financeextras_ExtensionUtil as ExtensionUtil;
+
 class PaymentStatus {
 
   private $callerPageTemplate;
@@ -50,18 +53,18 @@ class PaymentStatus {
     // JS variables are not available on contact page tabs when using something like this:
     // https://docs.civicrm.org/dev/en/latest/framework/resources/#add-javascript-variables, so I had
     // to assign them this way instead.
-    $helperVars =  "<script>
+    $helperVars = "<script>
                      var pendingStatusId = {$this->getPendingStatusId()};
                      var accountsReceivablePaymentMethodId = '{$this->getAccountsReceivablePaymentMethodId()}';
                      var paymentDetailsSectionSelector = '{$this->getPaymentDetailsSectionSelector()}';
                    </script>";
     $this->callerPageContent .= $helperVars;
 
-    $url = \CRM_Core_Resources::singleton()->getUrl('io.compuco.financeextras', 'js/payment_status.js');
+    $url = ExtensionUtil::url('js/payment_status.js');
     $this->callerPageContent .= "<script src='{$url}'></script>";
   }
 
-  private function getPendingStatusId(): int {
+  private function getPendingStatusId(): string {
     return civicrm_api3('OptionValue', 'getvalue', [
       'return' => 'value',
       'name' => 'Pending',
@@ -73,7 +76,7 @@ class PaymentStatus {
     return civicrm_api3('OptionValue', 'getvalue', [
       'return' => 'value',
       'option_group_id' => 'payment_instrument',
-      'name' => 'accounts_receivable',
+      'name' => AccountsReceivablePaymentMethod::NAME,
     ]);
   }
 
@@ -90,9 +93,11 @@ class PaymentStatus {
       case self::TARGET_PAGES_TEMPLATES['contribution-form']:
         $selector = '.payment-details_group';
         break;
+
       case self::TARGET_PAGES_TEMPLATES['membership-form']:
         $selector = '.crm-membership-form-block-payment_instrument_id, .crm-membership-form-block-billing';
         break;
+
       case self::TARGET_PAGES_TEMPLATES['event-registration']:
         $selector = '.crm-event-eventfees-form-block-payment_instrument_id, #billing-payment-block';
         break;

--- a/Civi/Financeextras/Hook/alterContent/PaymentStatus.php
+++ b/Civi/Financeextras/Hook/alterContent/PaymentStatus.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Civi\Financeextras\Hook\alterContent;
+
+class PaymentStatus {
+
+  private $callerPageTemplate;
+
+  private $callerPageContent;
+
+  /**
+   * The pages that are affected
+   * by this hook and their templates path.
+   */
+  const TARGET_PAGES_TEMPLATES = [
+    'contribution-form' => 'CRM/Contribute/Page/Tab.tpl',
+    'membership-form' => 'CRM/Member/Page/Tab.tpl',
+    'event-registration' => 'CRM/Event/Page/Tab.tpl',
+  ];
+
+  public function __construct($callerPageTemplate, &$callerPageContent) {
+    $this->callerPageTemplate = $callerPageTemplate;
+    $this->callerPageContent = &$callerPageContent;
+  }
+
+  public function run(): void {
+    if (!$this->shouldRun()) {
+      return;
+    }
+
+    $this->enforceAccountReceivablePaymentMethodOnPendingContribution();
+  }
+
+  private function shouldRun(): bool {
+    if (in_array($this->callerPageTemplate, self::TARGET_PAGES_TEMPLATES)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Adds JS code that when Pending status for the contribution is selected,
+   * defaults the payment method to 'Account Receivable' enforce it
+   * at the user level by hiding the field.
+   *
+   * @return void
+   */
+  private function enforceAccountReceivablePaymentMethodOnPendingContribution(): void {
+    // JS variables are not available on contact page tabs when using something like this:
+    // https://docs.civicrm.org/dev/en/latest/framework/resources/#add-javascript-variables, so I had
+    // to assign them this way instead.
+    $helperVars =  "<script>
+                     var pendingStatusId = {$this->getPendingStatusId()};
+                     var accountsReceivablePaymentMethodId = '{$this->getAccountsReceivablePaymentMethodId()}';
+                     var paymentDetailsSectionSelector = '{$this->getPaymentDetailsSectionSelector()}';
+                   </script>";
+    $this->callerPageContent .= $helperVars;
+
+    $url = \CRM_Core_Resources::singleton()->getUrl('io.compuco.financeextras', 'js/payment_status.js');
+    $this->callerPageContent .= "<script src='{$url}'></script>";
+  }
+
+  private function getPendingStatusId(): int {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'name' => 'Pending',
+      'option_group_id' => 'contribution_status',
+    ]);
+  }
+
+  private function getAccountsReceivablePaymentMethodId(): string {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'payment_instrument',
+      'name' => 'accounts_receivable',
+    ]);
+  }
+
+  /**
+   * Gets the CSS selector for the payment method section
+   * for the page that called this hook. Which will be used
+   * in JS to show/hide this section.
+   *
+   * @return void
+   */
+  private function getPaymentDetailsSectionSelector(): string {
+    $selector = '';
+    switch ($this->callerPageTemplate) {
+      case self::TARGET_PAGES_TEMPLATES['contribution-form']:
+        $selector = '.payment-details_group';
+        break;
+      case self::TARGET_PAGES_TEMPLATES['membership-form']:
+        $selector = '.crm-membership-form-block-payment_instrument_id, .crm-membership-form-block-billing';
+        break;
+      case self::TARGET_PAGES_TEMPLATES['event-registration']:
+        $selector = '.crm-event-eventfees-form-block-payment_instrument_id, #billing-payment-block';
+        break;
+    }
+
+    return $selector;
+  }
+
+}

--- a/Civi/Financeextras/Setup/Manage/AbstractManager.php
+++ b/Civi/Financeextras/Setup/Manage/AbstractManager.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+/**
+ * Describes the interface for entities that are
+ * to be managed (created, removed ..etc) during the
+ * extension installations, disabling ..etc.
+ *
+ */
+abstract class AbstractManager {
+
+  /**
+   * Creates the entity.
+   */
+  abstract public function create();
+
+  /**
+   * Removes the entity.
+   */
+  abstract public function remove();
+
+  /**
+   * Deactivates the entity.
+   */
+  public function deactivate() {
+    $this->toggle(FALSE);
+  }
+
+  /**
+   * Activates the entity.
+   */
+  public function activate() {
+    $this->toggle(TRUE);
+  }
+
+  /**
+   * Activates/Deactivates the entity based on the passed status.
+   * You just need to implement this method for active() and deactivate()
+   * methods to work.
+   *
+   * @params boolean $status
+   *  True to activate the entity, False to deactivate the entity.
+   */
+  abstract protected function toggle($status);
+
+}

--- a/Civi/Financeextras/Setup/Manage/AbstractManager.php
+++ b/Civi/Financeextras/Setup/Manage/AbstractManager.php
@@ -13,24 +13,24 @@ abstract class AbstractManager {
   /**
    * Creates the entity.
    */
-  abstract public function create();
+  abstract public function create(): void;
 
   /**
    * Removes the entity.
    */
-  abstract public function remove();
+  abstract public function remove(): void;
 
   /**
    * Deactivates the entity.
    */
-  public function deactivate() {
+  public function deactivate(): void {
     $this->toggle(FALSE);
   }
 
   /**
    * Activates the entity.
    */
-  public function activate() {
+  public function activate(): void {
     $this->toggle(TRUE);
   }
 
@@ -42,6 +42,6 @@ abstract class AbstractManager {
    * @params boolean $status
    *  True to activate the entity, False to deactivate the entity.
    */
-  abstract protected function toggle($status);
+  abstract protected function toggle($status): void;
 
 }

--- a/Civi/Financeextras/Setup/Manage/AbstractSetupManager.php
+++ b/Civi/Financeextras/Setup/Manage/AbstractSetupManager.php
@@ -8,7 +8,7 @@ namespace Civi\Financeextras\Setup\Manage;
  * extension installations, disabling ..etc.
  *
  */
-abstract class AbstractManager {
+abstract class AbstractSetupManager {
 
   /**
    * Creates the entity.

--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -4,33 +4,53 @@ namespace Civi\Financeextras\Setup\Manage;
 
 class AccountsReceivablePaymentMethod extends AbstractManager {
 
-  public function create() {
+  public function create(): void {
     $accountsReceivableFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
       'return' => 'id',
-      'name' => "Accounts Receivable",
+      'name' => 'Accounts Receivable',
     ]);
 
-    civicrm_api3('OptionValue', 'create', [
-      'option_group_id' => 'payment_instrument',
-      'label' => 'Accounts Receivable',
-      'value' => 'accounts_receivable',
-      'financial_account_id' => $accountsReceivableFinancialAccountId,
-      'is_reserved' => 1,
-      'is_active' => 1,
-    ]);
+    if (empty($this->getAccountsReceivablePaymentMethodId())) {
+      civicrm_api3('OptionValue', 'create', [
+        'option_group_id' => 'payment_instrument',
+        'label' => 'Accounts Receivable',
+        'name' => 'accounts_receivable',
+        'financial_account_id' => $accountsReceivableFinancialAccountId,
+        'is_reserved' => 1,
+        'is_active' => 1,
+      ]);
+    }
   }
 
-  public function remove() {
-    civicrm_api3('OptionValue', 'get', [
-      'name' => "accounts_receivable",
-      'api.OptionValue.delete' => ['id' => '$value.id'],
-    ]);
+  public function remove(): void {
+    $accountsReceivablePaymentMethodId = $this->getAccountsReceivablePaymentMethodId();
+    if (!empty($accountsReceivablePaymentMethodId)) {
+      civicrm_api3('OptionValue', 'delete', [
+        'id' => $accountsReceivablePaymentMethodId,
+      ]);
+    }
   }
 
-  protected function toggle($status) {
+  protected function toggle($status): void {
     civicrm_api3('OptionValue', 'get', [
       'name' => "accounts_receivable",
       'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => $status],
     ]);
   }
+
+  private function getAccountsReceivablePaymentMethodId(): ?int {
+    $paymentMethod = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'option_group_id' => 'payment_instrument',
+      'name' => 'accounts_receivable',
+    ]);
+
+    if (!empty($paymentMethod['id'])) {
+      return  $paymentMethod['id'];
+    }
+
+    return NULL;
+  }
+
 }

--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+class AccountsReceivablePaymentMethod extends AbstractManager {
+
+  public function create() {
+    $accountsReceivableFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
+      'return' => 'id',
+      'name' => "Accounts Receivable",
+    ]);
+
+    civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => 'payment_instrument',
+      'label' => 'Accounts Receivable',
+      'value' => 'accounts_receivable',
+      'financial_account_id' => $accountsReceivableFinancialAccountId,
+      'is_reserved' => 1,
+      'is_active' => 1,
+    ]);
+  }
+
+  public function remove() {
+    civicrm_api3('OptionValue', 'get', [
+      'name' => "accounts_receivable",
+      'api.OptionValue.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  protected function toggle($status) {
+    civicrm_api3('OptionValue', 'get', [
+      'name' => "accounts_receivable",
+      'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+}

--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -2,19 +2,29 @@
 
 namespace Civi\Financeextras\Setup\Manage;
 
-class AccountsReceivablePaymentMethod extends AbstractManager {
+class AccountsReceivablePaymentMethod extends AbstractSetupManager {
+
+  /**
+   * The machine name of the payment method.
+   */
+  const NAME = 'accounts_receivable';
+
+  /**
+   * The title/label of the payment method.
+   */
+  const TITLE = 'Accounts Receivable';
 
   public function create(): void {
     $accountsReceivableFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
       'return' => 'id',
-      'name' => 'Accounts Receivable',
+      'name' => self::TITLE,
     ]);
 
     if (empty($this->getAccountsReceivablePaymentMethodId())) {
       civicrm_api3('OptionValue', 'create', [
         'option_group_id' => 'payment_instrument',
-        'label' => 'Accounts Receivable',
-        'name' => 'accounts_receivable',
+        'label' => self::TITLE,
+        'name' => self::NAME,
         'financial_account_id' => $accountsReceivableFinancialAccountId,
         'is_reserved' => 1,
         'is_active' => 1,
@@ -33,7 +43,7 @@ class AccountsReceivablePaymentMethod extends AbstractManager {
 
   protected function toggle($status): void {
     civicrm_api3('OptionValue', 'get', [
-      'name' => "accounts_receivable",
+      'name' => self::NAME,
       'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => $status],
     ]);
   }
@@ -43,11 +53,11 @@ class AccountsReceivablePaymentMethod extends AbstractManager {
       'sequential' => 1,
       'return' => ['id'],
       'option_group_id' => 'payment_instrument',
-      'name' => 'accounts_receivable',
+      'name' => self::NAME,
     ]);
 
     if (!empty($paymentMethod['id'])) {
-      return  $paymentMethod['id'];
+      return $paymentMethod['id'];
     }
 
     return NULL;

--- a/financeextras.php
+++ b/financeextras.php
@@ -170,3 +170,15 @@ function financeextras_civicrm_buildForm($formName, &$form) {
     $hook->buildForm();
   }
 }
+
+/**
+ * Implements hook_civicrm_alterContent().
+ */
+function financeextras_civicrm_alterContent(&$content, $context, $tplName, &$object) {
+  $hooks = [
+    new \Civi\Financeextras\Hook\alterContent\PaymentStatus($tplName, $content),
+  ];
+  foreach ($hooks as $hook) {
+    $hook->run();
+  }
+}

--- a/js/payment_status.js
+++ b/js/payment_status.js
@@ -1,0 +1,20 @@
+CRM.$(function () {
+  var currentContributionStatus = CRM.$('#contribution_status_id').val();
+  if (currentContributionStatus == pendingStatusId) {
+    handlePendingStatusSelection();
+  }
+
+  CRM.$('#contribution_status_id').on('change', function() {
+    if (this.value == pendingStatusId) {
+      handlePendingStatusSelection();
+    }
+    else {
+      CRM.$(paymentDetailsSectionSelector).show();
+    }
+  });
+
+  function handlePendingStatusSelection() {
+    CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethodId).change();
+    CRM.$(paymentDetailsSectionSelector).hide();
+  }
+});

--- a/js/payment_status.js
+++ b/js/payment_status.js
@@ -1,4 +1,6 @@
 CRM.$(function () {
+  // pendingStatusId, accountsReceivablePaymentMethodId and handlePendingStatusSelection
+  // variables are coming from the backend, and assigned in alterContent hook.
   var currentContributionStatus = CRM.$('#contribution_status_id').val();
   if (currentContributionStatus == pendingStatusId) {
     handlePendingStatusSelection();

--- a/js/payment_status.js
+++ b/js/payment_status.js
@@ -15,6 +15,14 @@ CRM.$(function () {
     }
   });
 
+  // Show the payment method if "Payment Plan" option is selected on the membership form.
+  CRM.$('#payment_plan_fields_tabs').on('click', function() {
+    var contributionToggleValue = CRM.$('[name=contribution_type_toggle]').val();
+    if (contributionToggleValue == 'payment_plan') {
+      CRM.$(paymentDetailsSectionSelector).show();
+    }
+  });
+
   function handlePendingStatusSelection() {
     CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethodId).change();
     CRM.$(paymentDetailsSectionSelector).hide();

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,95 @@
+{
+  "name": "financeextras-e2e-tests",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@playwright/test": "^1.22.0",
+        "@types/node": "^17.0.35",
+        "playwright": "^1.22.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.0.tgz",
+      "integrity": "sha512-ExcAjiECo3uTG5Sl5H4a7rKp/5TEHTI87dv9NHYEoUFuOHPhSVxB7QsuM70ktO+wTTZ9KzhwzcegxAGRmUFKEA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.22.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+      "dev": true
+    },
+    "node_modules/playwright": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.22.0.tgz",
+      "integrity": "sha512-T2UqJAuvJip7TfYwvl7h3gUWtEE5D950PKd96POhUpumG3BkMfiLmXOe6Ja6UP39Ab3wEvatUJYBXvZCkocfpg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.22.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.0.tgz",
+      "integrity": "sha512-XnDPiV4NCzTtXWxQdyJ6Wg8xhST3ciUjt5mITaxoqOoYggmRtofKm0PXLehfbetXh2ppPYj5U8UhtUpdIE4wag==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
+  "dependencies": {
+    "@playwright/test": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.0.tgz",
+      "integrity": "sha512-ExcAjiECo3uTG5Sl5H4a7rKp/5TEHTI87dv9NHYEoUFuOHPhSVxB7QsuM70ktO+wTTZ9KzhwzcegxAGRmUFKEA==",
+      "dev": true,
+      "requires": {
+        "playwright-core": "1.22.0"
+      }
+    },
+    "@types/node": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+      "dev": true
+    },
+    "playwright": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.22.0.tgz",
+      "integrity": "sha512-T2UqJAuvJip7TfYwvl7h3gUWtEE5D950PKd96POhUpumG3BkMfiLmXOe6Ja6UP39Ab3wEvatUJYBXvZCkocfpg==",
+      "dev": true,
+      "requires": {
+        "playwright-core": "1.22.0"
+      }
+    },
+    "playwright-core": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.0.tgz",
+      "integrity": "sha512-XnDPiV4NCzTtXWxQdyJ6Wg8xhST3ciUjt5mITaxoqOoYggmRtofKm0PXLehfbetXh2ppPYj5U8UhtUpdIE4wag==",
+      "dev": true
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "@playwright/test": "^1.22.0",
+    "@types/node": "^17.0.35",
+    "playwright": "^1.22.0"
+  },
+  "scripts": {}
+}

--- a/tests/e2e/pages/base.page.ts
+++ b/tests/e2e/pages/base.page.ts
@@ -1,0 +1,43 @@
+import { Page, Response } from 'playwright';
+import config from '../playwright.config';
+
+/**
+ * Base Page.
+ */
+export abstract class BasePage {
+  protected abstract url: string;
+  public animationTransitionTime = 500;
+  public selectors: TestPageSelectors = {};
+
+  /**
+   * Constructor.
+   */
+  constructor(
+    protected page: Page,
+  ) {
+    this.page = page;
+  }
+
+  /**
+   * Navigate to the page.
+   */
+  async navigate(): Promise<Response | null> {
+    return this.page.goto(this.getPageUrl());
+  }
+
+  /**
+   * Get page url.
+   */
+  getPageUrl(): string {
+    return this.url;
+  }
+
+  /**
+   * Get absolute page url.
+   */
+  getAbsolutePageUrl(): string {
+    return config.use.baseURL + '/' + this.url;
+  }
+}
+
+export type TestPageSelectors = Record<string, string>;

--- a/tests/e2e/pages/contact-view.page.ts
+++ b/tests/e2e/pages/contact-view.page.ts
@@ -1,0 +1,16 @@
+import { BasePage } from './base.page';
+
+/**
+ * Contact view Page
+ */
+export class ContactView extends BasePage {
+  url = 'civicrm/contact/view?reset=1&cid=';
+
+  selectors = {
+    membershipsTab: 'text=Memberships 0',
+  };
+
+  async goToMembershipsTab(): Promise<void> {
+    await this.page.locator(this.selectors.membershipsTab).click();
+  }
+}

--- a/tests/e2e/pages/individual-create.page.ts
+++ b/tests/e2e/pages/individual-create.page.ts
@@ -1,0 +1,33 @@
+import { BasePage } from './base.page';
+
+/**
+ * Individual contact creation form
+ */
+export class IndividualCreatePage extends BasePage {
+  url = 'civicrm/contact/add?reset=1&ct=Individual';
+
+  /**
+   * Creates new individual contact with random name.
+   */
+  async createNew(): Promise<void> {
+    await this.page.goto(this.getAbsolutePageUrl());
+
+    let contactName = this.makeRandomString(6);
+    await this.page.locator('input[name="first_name"]').fill(contactName);
+    await this.page.locator('input[name="last_name"]').fill(contactName);
+
+    await this.page.locator('input[name="last_name"]').press('Enter');
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  makeRandomString(length): string {
+    var outputString = '';
+    var characters  = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+      outputString += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+
+    return outputString;
+  }
+}

--- a/tests/e2e/pages/login.page.ts
+++ b/tests/e2e/pages/login.page.ts
@@ -1,0 +1,25 @@
+import { BasePage } from './base.page';
+
+/**
+ * Login Page
+ */
+export class LoginPage extends BasePage {
+  url = 'user';
+  selectors = {
+    userNameField: 'input[name="name"]',
+    passwordField: 'input[name="pass"]',
+  };
+  credentials = {
+    admin: { user: 'compucorp_admin', password: 'compucorp_admin' },
+  };
+
+  /**
+   * Logs In the website.
+   */
+  async logInAsAdmin(): Promise<void> {
+    await this.page.goto(this.getAbsolutePageUrl());
+    await this.page.fill(this.selectors.userNameField, this.credentials.admin.user);
+    await this.page.fill(this.selectors.passwordField, this.credentials.admin.password);
+    await this.page.locator(this.selectors.passwordField).press('Enter');
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,42 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const E2E_SERVER_URL = getServerUrl();
+const E2E_SERVER_PORT = getPort();
+
+const portString = E2E_SERVER_PORT !== '80' ? `:${E2E_SERVER_PORT}` : '';
+const baseURL = `${E2E_SERVER_URL}${portString}`;
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ * @type {import('@playwright/test').PlaywrightTestConfig}
+ */
+const config: PlaywrightTestConfig  = {
+  testDir: './tests',
+  outputDir: './report',
+  reporter: 'list',
+  timeout: 40000,
+  use: {
+    baseURL,
+    browserName: 'chromium',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    trace: 'retain-on-failure',
+  },
+};
+
+export default config;
+
+
+/**
+ * Get the server url.
+ */
+function getServerUrl(): string {
+  return process.env.E2E_SERVER_URL || 'http://localhost';
+}
+
+/**
+ * Get the port number.
+ */
+function getPort(): string {
+  return process.env.E2E_SERVER_PORT || '80';
+}

--- a/tests/e2e/tests/payment-pending-status-selection.spec.ts
+++ b/tests/e2e/tests/payment-pending-status-selection.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../pages/login.page';
+import { IndividualCreatePage } from '../pages/individual-create.page';
+import { ContactView } from '../pages/contact-view.page';
+
+test.describe('Payment "Pending" status selection', async () => {
+  let loginPage: LoginPage;
+  let individualCreatePage: IndividualCreatePage;
+  let contactView: ContactView;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await loginPage.logInAsAdmin();
+
+    individualCreatePage = new IndividualCreatePage(page);
+    await individualCreatePage.createNew();
+
+    contactView = new ContactView(page);
+  });
+
+  test('Selecting pending status on new contribution page sets payment method to "Accounts Receivable" and hides payment method section', async ({ page }) => {
+    var PendingStatusId = '2';
+    await page.locator('text=Contributions 0').click();
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('a:has-text("Record Contribution")').first().click();
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('select[name="financial_type_id"]').selectOption('1');
+    await page.locator('input[name="total_amount"]').fill('100');
+
+    await expect(page.locator('.payment-details_group')).toBeVisible();
+
+    await page.locator('select[name="contribution_status_id"]').selectOption(PendingStatusId);
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.locator('.payment-details_group')).toBeHidden();
+
+    await page.locator('.ui-dialog-buttonset > button').first().click();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.locator('a[title="View Contribution"]').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    var paymentMethodSelector = page.locator('td:right-of(#ContributionView td:has-text("Payment Method"))').first();
+    await expect(paymentMethodSelector).toHaveText("Accounts Receivable");
+  });
+
+  test('Selecting pending payment status on new membership page sets payment method to "Accounts Receivable" and hides payment method section', async ({ page }) => {
+    var PendingStatusId = '2';
+    await page.locator('text=Memberships 0').click();
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('span:has-text("Add Membership")').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.locator('select[name="membership_type_id\\[0\\]"]').selectOption('3');
+    await page.locator('select[name="membership_type_id\\[1\\]"]').selectOption('1');
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.locator('.crm-membership-form-block-join_date input:nth-of-type(2)').fill('01/01/2022');
+    await page.locator('.crm-membership-form-block-start_date input:nth-of-type(2)').fill('01/01/2022');
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('.crm-membership-form-block-payment_instrument_id')).toBeVisible();
+    await expect(page.locator('.crm-membership-form-block-billing')).toBeVisible();
+
+    await page.locator('select[name="contribution_status_id"]').selectOption(PendingStatusId);
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.locator('.crm-membership-form-block-payment_instrument_id')).toBeHidden();
+    await expect(page.locator('.crm-membership-form-block-billing')).toBeHidden();
+
+    await page.locator('.ui-dialog-buttonset > button').first().click();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.locator('text=Contributions 1').click();
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('a[title="View Contribution"]').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    var paymentMethodSelector = page.locator('td:right-of(#ContributionView td:has-text("Payment Method"))').first();
+    await expect(paymentMethodSelector).toHaveText("Accounts Receivable");
+  });
+
+  test('Selecting pending payment status on admin event registration sets payment method to "Accounts Receivable" and hides payment method section', async ({ page }) => {
+    var PendingStatusId = '2';
+    await page.locator('text=Events 0').click();
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('span:has-text("Add Event Registration")').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.locator('text=- select Event -').click();
+    await page.locator('text=Event * Searching... >> input[role="combobox"]').fill('test');
+    await page.locator('div[role="option"] >> text=test').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('.crm-event-eventfees-form-block-payment_instrument_id')).toBeVisible();
+    await expect(page.locator('#billing-payment-block')).toBeVisible();
+
+    await page.locator('select[name="contribution_status_id"]').selectOption(PendingStatusId);
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('.crm-event-eventfees-form-block-payment_instrument_id')).toBeHidden();
+    await expect(page.locator('#billing-payment-block')).toBeHidden();
+
+    await page.locator('.ui-dialog-buttonset > button').first().click();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.locator('text=Contributions 1').click();
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('a[title="View Contribution"]').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    var paymentMethodSelector = page.locator('td:right-of(#ContributionView td:has-text("Payment Method"))').first();
+    await expect(paymentMethodSelector).toHaveText("Accounts Receivable");
+  });
+});


### PR DESCRIPTION
## Overview

Its seem that the ability to select the payment method when the contribution status is set to pending  (which is a CiviCRM core behavior) is confusing to users, since no payment is taken yet, so the method used is not known yet until the payment is recorded.

The goal of this PR is to simplify that by hiding the ability to select the payment method., but since CiviCRM still requires a payment method to be provided (it is a required field), we also creating new Payment method called "Accounts Receivable", and all pending contributions (unless they are for a payment plan membership) will be have this payment method by default.


## Before

When creating a contribution , membership (non payment plan), or registering an event participant from the admin form, users are required to fill in the payment method field and some other fields based on the payment method selected, even when in the contribution status is Pending:

![image](https://user-images.githubusercontent.com/6275540/173129022-d8fb0176-932b-49e5-b09c-ee4c256169a7.png)


## After
New payment method is created when this extension is installed called "Accounts Receivable":

![2022-06-10 19_40_05-Payment Methods Options _ compuclient129](https://user-images.githubusercontent.com/6275540/173129870-9c507c03-3364-4ccc-b088-956b4044c8ff.png)

On contribution, membership (non payment plan), and event participant registration forms, the payment method will default to  "Accounts Receivable", and the whole payment method section will be hidden.

Contribution Form:
![1](https://user-images.githubusercontent.com/6275540/173130391-f52df2c3-c564-4a04-8d71-4fda273c21eb.gif)

Membership Form:
![2](https://user-images.githubusercontent.com/6275540/173131470-95a9cc06-900e-49e2-bac6-79ef9723b871.gif)

Event participant  registration Form:

![4](https://user-images.githubusercontent.com/6275540/173132334-f16465f8-1e39-43b8-b772-0384bafe5cf0.gif)


## Technical Details

I used alterContent() hook since it what allowed me to write a code that is shared across these 3 forms, I tried buildForm and pageRun() hooks but each had some issues. I used alterContent to inject a JS code that handles selecting "Accounts Receivable " as payment method as well as showing and hiding the payment details section. 

I did not add any backend validation on the payment method, given that it really does not affect anything if the user altered the Dom to change the payment method to something else, since the whole point of hiding it is to make things less confusing to users.

Finally I've added configuration files for Playwright, as well as 3 E2E tests to validate that the functionality work on all the 3 forms I mentioned above, and until I figure out a way to run them in a GitHub action, these tests should be run manually for the time being.
