### PR TITLE
CIVIPLUS-769: Add submit refund button in contribution records

### DIFF
--- a/CRM/Financeextras/Hook/BuildForm/AdditionalPaymentButton.php
+++ b/CRM/Financeextras/Hook/BuildForm/AdditionalPaymentButton.php
@@ -1,0 +1,89 @@
+<?php
+
+use CRM_Financeextras_ExtensionUtil as E;
+
+/**
+ * Implements Refund Button if supported Refund by Payment Processor
+ */
+class CRM_Financeextras_Hook_BuildForm__AdditionalPaymentButton {
+
+  /**
+   * @var string
+   *   Path where template with javascript stored for adding new Refund Button.
+   */
+  private $templatePath;
+
+  /**
+   * @var int
+   *   Contribution id for adding submit refund button.
+   */
+  private $contributionID;
+
+  /**
+   * @var \CRM_Contribute_Form_AdditionalPayment
+   *   Form object that is being altered.
+   */
+  private $form;
+
+  /**
+   * @var string
+   *   form name
+   */
+  private $formName;
+
+  /**
+   * CRM_Financeextras_Hook_BuildForm__AdditionalPaymentButton constructor.
+   *
+   * @param \CRM_Contribute_Form_AdditionalPayment $form
+   * @param string $formName
+   */
+  public function __construct(&$form, $formName) {
+    $this->form = $form;
+    $this->formName = $formName;
+    $this->templatePath = E::path() . '/templates/CRM/AdditionalPayment/Form/Payment';
+  }
+
+  public function buildForm(): void {
+    if (!$this->validate()) {
+      return;
+    }
+
+    $this->addRefundButton();
+  }
+
+  private function validate(): bool {
+    if ($this->formName !== 'CRM_Contribute_Form_AdditionalPayment') {
+      return FALSE;
+    }
+
+    $this->contributionID = $this->form->getVar('_id');
+
+    $paymentRefund = new \Civi\Financeextras\Payment\Refund($this->contributionID);
+
+    if (!$paymentRefund->contactHasRefundPermission()) {
+      return FALSE;
+    }
+
+    if (!$paymentRefund->isEligibleForRefund()) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Adds template to add the button for submit refund using form-bottom region
+   */
+  private function addRefundButton() {
+    $formButtonValues = [
+      "title" => ts('Submit Credit Card Refund'),
+      "icon" => "fa-chevron-right",
+      "link" => "financeextras/payment/refund/card?reset=1&id=" . $this->contributionID,
+    ];
+    $this->form->assign('contributionSubmitRefundButton', $formButtonValues);
+    CRM_Core_Region::instance('form-bottom')->add([
+      'template' => "{$this->templatePath}/RefundButton.tpl",
+    ]);
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -151,3 +151,18 @@ function financeextras_civicrm_links($op, $objectName, $objectId, &$links, &$mas
     $hook->run();
   }
 }
+
+/**
+ * Implements hook_civicrm_buildForm().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_buildForm
+ */
+function financeextras_civicrm_buildForm($formName, &$form) {
+  $hooks = [
+    new CRM_Financeextras_Hook_BuildForm__AdditionalPaymentButton($form, $formName),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->buildForm();
+  }
+}

--- a/templates/CRM/AdditionalPayment/Form/Payment/RefundButton.tpl
+++ b/templates/CRM/AdditionalPayment/Form/Payment/RefundButton.tpl
@@ -1,0 +1,5 @@
+<a 
+ class="open-inline action-item crm-hover-button" 
+ href="{$contributionSubmitRefundButton.link}">
+    <i class="crm-i {$contributionSubmitRefundButton.icon}"></i> {$contributionSubmitRefundButton.title}
+</a>

--- a/tests/phpunit/Civi/Financeextras/Hook/BuildForm/AdditionalPaymentButtonTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/BuildForm/AdditionalPaymentButtonTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Civi\Financeextras\Test\Fabricator\ContactFabricator;
+use Civi\Financeextras\Test\Fabricator\ContributionFabricator;
+use Civi\Financeextras\Test\Fabricator\PaymentProcessorFabricator;
+
+/**
+ * Class CRM_Financeextras_Hook_BuildForm_AdditionalPaymentButtonTest
+ *
+ * @group headless
+ */
+class CRM_Financeextras_Hook_BuildForm_AdditionalPaymentButtonTest extends BaseHeadlessTest {
+
+  private $additionalPaymentForm;
+
+  public function setUp() {
+    $formController = new CRM_Core_Controller();
+    $this->additionalPaymentForm = new CRM_Contribute_Form_AdditionalPayment();
+    $this->additionalPaymentForm->controller = $formController;
+  }
+
+  public function testSubmitRefundButtonLinkAddedToAdditionalPaymentForm() {
+    $contact = ContactFabricator::fabricate();
+    $paymentProcessor = PaymentProcessorFabricator::fabricate([
+      'payment_processor_type_id' => "Dummy",
+      'financial_account_id' => "Payment Processor Account",
+    ]);
+    $contributionParams = [
+      'financial_type_id' => 'Donation',
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 200,
+      'contact_id' => $contact['id'],
+      'payment_instrument_id' => 'Credit Card',
+      'trxn_id' => md5(time()),
+      'payment_processor' => $paymentProcessor['id'],
+      'currency' => 'GBP',
+    ];
+
+    $contribution = ContributionFabricator::fabricate($contributionParams);
+    $this->additionalPaymentForm->setVar('_id', $contribution['id']);
+
+    $additionalBuildFormHook = new CRM_Financeextras_Hook_BuildForm__AdditionalPaymentButton($this->additionalPaymentForm, 'CRM_Contribute_Form_AdditionalPayment');
+    $additionalBuildFormHook->buildForm();
+
+    $html = CRM_Core_Region::instance('form-bottom')->render('');
+    $this->assertTrue((boolean) $html);
+  }
+
+  public function testRefundButtonAddedToNotLiveAdditionalPaymentForm() {
+    $contact = ContactFabricator::fabricate();
+    $contributionParams = [
+      'financial_type_id' => 'Donation',
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 200,
+      'contact_id' => $contact['id'],
+      'payment_instrument_id' => 'Credit Card',
+      'trxn_id' => md5(time()),
+      'currency' => 'GBP',
+    ];
+
+    $contribution = ContributionFabricator::fabricate($contributionParams);
+    $this->additionalPaymentForm->setVar('_id', $contribution['id']);
+
+    $additionalBuildFormHook = new CRM_Financeextras_Hook_BuildForm__AdditionalPaymentButton($this->additionalPaymentForm, 'CRM_Contribute_Form_AdditionalPayment');
+    $additionalBuildFormHook->buildForm();
+
+    $html = CRM_Core_Region::instance('form-bottom')->render('');
+    $this->assertFalse((boolean) $html);
+  }
+
+}


### PR DESCRIPTION
## Overview
Add Refund submit button in contribution page

## Before

![without_sbmit_refund](https://user-images.githubusercontent.com/107249752/176918219-cc9ad7ad-f257-46ee-b5d6-bb8912a04191.png)


## After

![submit_refund](https://user-images.githubusercontent.com/107249752/176918381-6c13a90f-6396-4bf2-baeb-f0a95b14bb84.png)


## Technical Details
Added hook for AdditionalPayment Form to add javascript code to add Submit Refund button

