### PR TITLE
CIVIPLUS-776: Create credit card refunds

### DIFF
--- a/CRM/Financeextras/Form/Payment/Refund.php
+++ b/CRM/Financeextras/Form/Payment/Refund.php
@@ -1,0 +1,323 @@
+<?php
+
+use CRM_Finananceextras_ExtensionUtil as E;
+
+/**
+ * Page for redirecting to credit card refund form.
+ */
+class CRM_Financeextras_Form_Payment_Refund extends CRM_Core_Form {
+
+  /**
+   * @var int
+   *   Contribution id for adding submit refund button.
+   */
+  private $contributionID;
+
+  /**
+   * @var int
+   *   Available amount to display in payment info table.
+   */
+  private $availableAmount;
+
+  /**
+   * @var array
+   *   Payment processor with keys id, name, is_test
+   */
+  private $paymentProcessor;
+
+  /**
+   * @var array
+   *    Payment Transactions of A Contribution It Include main as well as refund transactions
+   */
+  private $paymentTransactions;
+
+  /**
+   * @var string
+   *   Charge id
+   */
+  private $chargeID;
+
+  /**
+   * @var string
+   *   currency
+   */
+  private $currency;
+
+  /**
+   * @var string
+   *   Refund Status from Payment Processor
+   */
+  private $refundStatus;
+
+  /**
+   * @var int
+   *   Main transaction id
+   */
+  private $mainTransactionId;
+
+  /**
+   * Prevent people double-submitting the form (e.g. by double-clicking).
+   * https://lab.civicrm.org/dev/core/-/issues/1773
+   *
+   * @var bool
+   */
+  public $submitOnce = TRUE;
+
+  /**
+   * This function is called prior to building and submitting the form
+   */
+  public function preProcess() {
+    $this->contributionID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
+    $paymentRefundPermission = new \Civi\Financeextras\Payment\Refund($this->contributionID);
+    if (!$paymentRefundPermission->contactHasRefundPermission()) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+      return;
+    }
+    $paymentInfos = [];
+    $this->paymentTransactions = civicrm_api3('Payment', 'get', [
+      'contribution_id' => $this->contributionID,
+      'status_id' => 1,
+    ])['values'];
+    foreach ($this->paymentTransactions as $trxn) {
+      $this->mainTransactionId[$trxn['id']] = $trxn['id'];
+      $this->availableAmount[$trxn['id']] = 0;
+      $this->chargeID[$trxn['id']] = $trxn['trxn_id'];
+      $this->currency = $trxn['currency'];
+      $this->paymentProcessor = $this->getPaymentProcessorNameById($trxn['payment_processor_id']);
+      $refundAmountMethod = TRUE;
+      $processor = Civi\Payment\System::singleton()->getById($this->paymentProcessor['id']);
+      if (!method_exists($processor, 'getRefundedAmountByChargeId')) {
+        $this->availableAmount = $trxn['total_amount'];
+        $refundAmountMethod = FALSE;
+      }
+      else {
+        $refundedAmount = $this->getRefundedAmount($this->chargeID[$trxn['id']], $this->paymentProcessor['id'], $this->mainTransactionId[$trxn['id']]);
+
+        $this->availableAmount[$trxn['id']] = $trxn['total_amount'] - $refundedAmount;
+      }
+      if (!isset($this->paymentProcessor['id']) || $this->paymentProcessor['id'] === "") {
+        return;
+      }
+      $paymentInfos[] = [
+        'date' => date('d-m-Y', strtotime($trxn['trxn_date'])),
+        'amount' => $trxn['total_amount'],
+        'available_amount' => $this->availableAmount[$trxn['id']],
+        'paymentProcessor' => $this->paymentProcessor['name'],
+        'transactionId' => $trxn['trxn_id'],
+        'financialTrxnId' => $trxn['id'],
+        'currency' => $trxn['currency'],
+        'paymentProcessorId' => $this->paymentProcessor['id'],
+      ];
+    }
+    $this->assign('refundAmountMethod', $refundAmountMethod);
+    $this->assign('paymentInfos', $paymentInfos);
+  }
+
+  /**
+   * Gets the payment processor name.
+   */
+  public function getPaymentProcessorNameById(int $Id) {
+    return civicrm_api3('PaymentProcessor', 'getsingle', [
+      'return' => ['name', 'is_test', 'id', 'payment_instrument_id'],
+      'id' => $Id,
+    ]);
+  }
+
+  /**
+   * Gets the refunded amount.
+   */
+  private function getRefundedAmount(string $chargeID, int $paymentProcessorId, int $transactonId) {
+    $refundedAmount = civicrm_api3('PaymentProcessor', 'get_refunded_amount', [
+      'payment_processor_id' => $paymentProcessorId,
+      'trxn_id' => $chargeID,
+      'financial_trxn_id' => $transactonId,
+      'currency' => $this->currency,
+    ])['values'][0];
+
+    return $refundedAmount;
+  }
+
+  /**
+   * The _fields var can be used by sub class to set/unset/edit the
+   * form fields based on their requirement
+   */
+  public function setFields() {
+    $reasons = [
+      'duplicate' => "Duplicate",
+      "fraudulent" => "Fraudulent",
+      "requested_by_customer" => "Requested by customer",
+    ];
+    $contribution = civicrm_api3('Contribution', 'getsingle', [
+      'id' => $this->contributionID,
+      'return' => ['contact_id'],
+    ]);
+    $contactId = $contribution['contact_id'];
+
+    $contact = civicrm_api3('Contact', 'getsingle', [
+      'contact_id' => $contactId,
+      'return' => ['display_name'],
+    ]);
+    $contactName = $contact['display_name'];
+    $this->_fields = [
+      'contact' => [
+        'type' => 'text',
+        'label' => ts('Contact'),
+        'attributes' => ['class' => 'huge', 'value' => $contactName, 'disabled' => 'disabled'],
+        'required' => FALSE,
+      ],
+
+      'currency' => [
+        'type' => 'text',
+        'label' => ts('Contact'),
+        'attributes' => ['disabled' => 'disabled'],
+        'required' => FALSE,
+      ],
+
+      'amount' => [
+        'type' => 'text',
+        'label' => ts('Refund Amount'),
+        'required' => TRUE,
+      ],
+
+      'reason' => [
+        'type' => 'select',
+        'label' => ts('Reason'),
+        'attributes' => ['' => '- ' . ts('select reason') . ' -'] + $reasons,
+        'extra' => ['class' => 'huge crm-select2'],
+        'required' => TRUE,
+
+      ],
+    ];
+  }
+
+  /**
+   * Will be called prior to outputting html (and prior to buildForm hook)
+   */
+  public function buildQuickForm() {
+    Civi::resources()->addStyleFile('io.compuco.financeextras', 'css/custom-civicrm.css');
+    Civi::resources()->addScriptFile('io.compuco.financeextras', 'js/custom.js');
+    $this->setFields();
+    foreach ($this->_fields as $field => $values) {
+      if (!empty($this->_fields[$field])) {
+        $attribute = $values['attributes'] ?? NULL;
+        $required = !empty($values['required']);
+
+        if ($values['type'] === 'select' && empty($attribute)) {
+          $this->addSelect($field, ['entity' => 'activity'], $required);
+        }
+        elseif ($values['type'] === 'entityRef') {
+          $this->addEntityRef($field, $values['label'], $attribute, $required);
+        }
+        else {
+          $this->add($values['type'], $field, $values['label'], $attribute, $required, CRM_Utils_Array::value('extra', $values));
+        }
+      }
+    }
+    $this->addFormRule(['CRM_Financeextras_Form_Payment_Refund', 'formRule'], $this);
+
+    $this->addButtons([
+      [
+        'type' => 'upload',
+        'name' => ts('Create'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+  }
+
+  /**
+   * Global form rule.
+   *
+   * @param array $fields
+   *   The input form values.
+   * @param array $files
+   *   The uploaded files if any.
+   * @param $self
+   *
+   * @return bool|array
+   *   true if no errors, else array of errors
+   */
+  public function formRule($fields, $files, $self) {
+    $errors = [];
+    if ($fields['amount'] <= 0) {
+      $errors['amount'] = ts('Please enter valid refund amount.');
+    }
+    elseif ($fields['amount'] > $self->availableAmount[$fields['payment_row']]) {
+      $errors['amount'] = ts('You cannot refund more than the original payment amount.');
+    }
+    if ($fields['reason'] == "") {
+      $errors['reason'] = ts('Please enter refund reason.');
+    }
+    if (count($errors) === 0) {
+      $self->triggerRefund($errors, $fields, $self);
+    }
+
+    return $errors;
+  }
+
+  /**
+   * Trigger Refund action of Payment Processor
+   */
+  private function triggerRefund(&$errors, $vals, $self) {
+    try {
+      $refundResult = civicrm_api3('PaymentProcessor', 'refund', [
+        'payment_processor_id' => $self->paymentProcessor['id'],
+        'contribution_id' => $self->contributionID,
+        'available_amount' => $self->availableAmount[$vals['payment_row']],
+        'trxn_id' => $self->chargeID[$vals['payment_row']],
+        'contact' => $vals['contact'],
+        'reason' => $vals['reason'],
+        'amount' => $vals['amount'],
+        'currency' => $vals['currency'],
+        'is_test' => $self->paymentProcessor['is_test'],
+      ])['values'];
+
+      $this->refundStatus = $refundResult[0];
+    }
+    catch (\Exception $e) {
+      $errors['amount'] = $e->getMessage();
+    }
+  }
+
+  /**
+   * Calls after form is successfully submitted.
+   */
+  public function postProcess($params = NULL) {
+    // Gets the submitted values as an array.
+
+    $vals = $this->controller->exportValues($this->_name);
+    if ($this->refundStatus['refund_status'] == "Completed") {
+      $this->createFinancialTrxnRefund($vals);
+    }
+  }
+
+  /**
+   * Creates financial transaction entries for refund
+   */
+  public function createFinancialTrxnRefund($vals) {
+    $financialTrxnId = CRM_Utils_Request::retrieve('payment_row', 'Positive', $this);
+    $eftParams = [
+      'entity_table' => 'civicrm_contribution',
+      'financial_trxn_id' => $this->mainTransactionId[$financialTrxnId],
+      'return' => ['entity', 'amount', 'entity_id', 'financial_trxn_id.check_number'],
+    ];
+    $entity = civicrm_api3('EntityFinancialTrxn', 'getsingle', $eftParams);
+    $paymentParams = [
+      'total_amount' => -$vals['amount'],
+      'contribution_id' => (int) $entity['entity_id'],
+      'is_send_contribution_notification' => FALSE,
+      'trxn_date' => 'now',
+      'trxn_id' => $this->refundStatus['refund_id'],
+      'payment_instrument_id' => $this->paymentProcessor['payment_instrument_id'],
+      'check_number' => $entity['financial_trxn_id.check_number'] ?? NULL,
+    ];
+
+    civicrm_api3('Payment', 'create', $paymentParams);
+    CRM_Core_Session::setStatus(ts('Refund has been requested successfully.'), ts('Success'), 'success');
+  }
+
+}

--- a/CRM/Financeextras/Hook/BuildForm/AdditionalPaymentButton.php
+++ b/CRM/Financeextras/Hook/BuildForm/AdditionalPaymentButton.php
@@ -78,7 +78,7 @@ class CRM_Financeextras_Hook_BuildForm__AdditionalPaymentButton {
     $formButtonValues = [
       "title" => ts('Submit Credit Card Refund'),
       "icon" => "fa-chevron-right",
-      "link" => "financeextras/payment/refund/card?reset=1&id=" . $this->contributionID,
+      "link" => CRM_Utils_System::url("civicrm/financeextras/payment/refund/card?reset=1&id=" . $this->contributionID),
     ];
     $this->form->assign('contributionSubmitRefundButton', $formButtonValues);
     CRM_Core_Region::instance('form-bottom')->add([

--- a/Civi/Financeextras/Payment/Refund.php
+++ b/Civi/Financeextras/Payment/Refund.php
@@ -33,13 +33,19 @@ class Refund {
     //API is likely to return more than one entity as CiviCRM separates financial
     //transactions for financial transaction for example, contribution amount is record
     //as one financial transaction and fee is record in another transaction.
+    $contribution = civicrm_api3('Contribution', 'getsingle', [
+      'id' => $this->contributionID,
+      'return' => ['contribution_status_id'],
+    ]);
+    if (isset($contribution['contribution_status_id']) && $contribution['contribution_status_id'] == 7) {
+      return FALSE;
+    }
     $entityFinancialTrxns = civicrm_api3('EntityFinancialTrxn', 'get', [
       'sequential' => 1,
       'entity_id' => $this->contributionID,
       'entity_table' => 'civicrm_contribution',
       'options' => ['limit' => 0],
     ])['values'];
-
     $supportRefundProcessorIDs = PaymentProcessor::singleton()->getRefundProcessorIDs();
     foreach ($entityFinancialTrxns as $entity) {
       $trxn = civicrm_api3('FinancialTrxn', 'get', [
@@ -59,6 +65,7 @@ class Refund {
     }
 
     return FALSE;
+
   }
 
   /**

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This extension provides CiviCRM finance improvement.
 
+The extension must implement get_refunded_amount API to supports refund payment.
+
+Currently only "Stripe Extension" supports refunded amount API. So, other payment processor only shows original amount as available amount.
+
+## Implementation details
+API action name : get_refunded_amount
+Parameters : payment_processor_id , trxn_id
+
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
 ## Requirements

--- a/api/v3/PaymentProcessor/GetRefundedAmount.php
+++ b/api/v3/PaymentProcessor/GetRefundedAmount.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Action get refundable balance.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result array.
+ *
+ * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
+ * @throws \Civi\Payment\Exception\PaymentProcessorException
+ */
+function civicrm_api3_payment_processor_get_refunded_amount($params) {
+  /** @var \CRM_Core_Payment $processor */
+  $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
+  $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', ['id' => $params['payment_processor_id']]));
+  if (!$processor->supportsRefund()) {
+    throw new API_Exception('Payment Processor does not support refund');
+  }
+  $result = $processor->getRefundedAmountByChargeId($params);
+  return civicrm_api3_create_success([$result], $params);
+}
+
+/**
+ * Action get refundable balance.
+ *
+ * @param array $params
+ *
+ */
+function _civicrm_api3_payment_processor_get_refunded_amount_spec(&$params) {
+  $params['payment_processor_id'] = [
+    'api.required' => TRUE,
+    'title' => ts('Payment processor'),
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+  $params['trxn_id'] = [
+    'api.required' => TRUE,
+    'title' => ts('Transaction id'),
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+}

--- a/css/custom-civicrm.css
+++ b/css/custom-civicrm.css
@@ -1,0 +1,9 @@
+.message.help{margin:10px;border-radius: 4px;}
+.payment-info th{text-transform: capitalize;}
+.CRM_Financeextras_Form_Payment_Refund .crm-payment-refund-form-block .form-layout-compressed .payment-info tr.selected {
+  background: #ddd !important;
+}
+.CRM_Financeextras_Form_Payment_Refund .crm-payment-refund-form-block .form-layout-compressed .payment-info {
+  border-bottom: solid 1px #e8eef0;
+}
+.crm-container.ui-dialog .ui-dialog-content .crm-payment-refund-form-block tr {border-bottom:solid 1px #e8eef0}

--- a/js/custom.js
+++ b/js/custom.js
@@ -1,0 +1,35 @@
+/*global CRM, ts */
+
+CRM.$(function ($) {
+  'use strict';
+  CRM.$(function ($) {
+    let paymentRowCount = $(".payment-info tbody tr").length;
+    if( paymentRowCount == 2 ) {
+        let id = $(".payment-info td input").val();
+        $(".payment-info td input").prop('checked',true);
+        let refundAmount = $("#refund_amount").val();
+        let amount = $(".payment-info td.available_amount_" + id).html();
+        let paymentProcessorId = $(".payment-info td input").attr('data-processorid');
+        let currency = $(".payment-info td input").attr('data-currency');
+        let amountSplit = amount.split(" ");
+        $("[name='currency']").val(currency);
+        if(!refundAmount){
+            $("[name='amount']").val(amountSplit[1]);
+        }
+    }
+    else {
+        $(".payment-info td input").click(function() {
+            let id = $(this).val();
+            let amount = $(".payment-info td.available_amount_" + id).html();
+            let amountSplit = amount.split(" ");
+            let paymentProcessorId = $(this).attr('data-processorid');
+            let currency = $(this).attr('data-currency');
+            $("[name='amount']").val(amountSplit[1]);
+            $("[name='currency']").val(currency);
+            $('.payment-info tr').removeClass('selected');
+            $('.payment-info #tr_'+id ).addClass('selected');
+        });
+    }
+  });
+
+});

--- a/templates/CRM/AdditionalPayment/Form/Payment/RefundButton.tpl
+++ b/templates/CRM/AdditionalPayment/Form/Payment/RefundButton.tpl
@@ -1,5 +1,5 @@
 <a 
- class="open-inline action-item crm-hover-button" 
+ class="action-item crm-hover-button"
  href="{$contributionSubmitRefundButton.link}">
     <i class="crm-i {$contributionSubmitRefundButton.icon}"></i> {$contributionSubmitRefundButton.title}
 </a>

--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -1,0 +1,52 @@
+{if !$refundAmountMethod }
+<div class="messages status no-popup">
+  <i aria-hidden="true" class="crm-i fa-info-circle"></i>
+  {ts}Currently only "Stripe Extension" supports refunded amount API. So, other payment processor only shows original amount as available amount.{/ts}
+</div>
+{/if}
+<div class="crm-block crm-form-block crm-payment-refund-form-block">
+  <div class="crm-accordion-body">
+    <div class="message help" >{ts}Refunds take 5-10 days to appear on a customer's statement{/ts}</div>
+  </div>
+  <table class="form-layout-compressed">
+    <tr class="crm-payment-refund-form-block-contact">
+      <td class="label">{$form.contact.label}</td>
+      <td>{$form.contact.html}</td>
+    </tr>
+    <tr class="crm-payment-refund-form-block-paymentinfos">
+      <td class="label"><label>{ts}Select Payment To Refund{/ts}</label></td>
+      <td><table class="selector row-highlight payment-info">
+        <tr>
+          <th></th>
+          <th>{ts}Date{/ts}</th>
+          <th>{ts}Original Amount{/ts}</th>
+          <th>{ts}Available Amount{/ts}</th>
+          <th>{ts}Payment Processor{/ts}</th>
+          <th>{ts}Processor Payment ID{/ts}</th>
+        </tr>
+        {foreach from=$paymentInfos item=paymentRow}
+        <tr id="tr_{$paymentRow.financialTrxnId}">
+          <td><input class="required crm-form-radio" value="{$paymentRow.financialTrxnId}" type="radio" id="{$paymentRow.transactionId}" data-processorid="{$paymentRow.paymentProcessorId}" data-currency="{$paymentRow.currency}" name="payment_row" ></td>
+          <td>{$paymentRow.date}</td>
+          <td>{$paymentRow.amount|crmMoney:$paymentRow.currency}</td>
+          <td class="available_amount_{$paymentRow.financialTrxnId}">{$paymentRow.available_amount|crmMoney:$paymentRow.currency}</td>
+          <td>{$paymentRow.paymentProcessor}</td>
+          <td>{$paymentRow.transactionId}</td>
+        </tr>
+        {/foreach}
+      </table>
+    </td>
+  </tr>
+  <tr  class="crm-payment-refund-form-block-refund_amount">
+    <td class="label">{$form.amount.label}</td>
+    <td>{$form.currency.html} {$form.amount.html}</td>
+  </tr>
+  <tr class="crm-payment-refund-form-block-reason">
+    <td class="label">{$form.reason.label}</td>
+    <td>{$form.reason.html}</td>
+  </tr>
+</table>
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>
+</div>

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/financeextras/payment/refund/card</path>
+    <page_callback>CRM_Financeextras_Form_Payment_Refund</page_callback>
+    <title>Record a credit card refund</title>
+    <access_arguments>make online contribution</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
## Overview
Credit card refund functionality
1. Add refund payment functionality for any payment processor.
2. After click on submit credit card refund button you will see the refund payment screen.

## Before
There is no available amount 
![before](https://user-images.githubusercontent.com/107249752/181450274-ca14d844-c270-4e1a-9cfb-ba4e3bbea775.png)


## After
We have added new api to get refund balance to calculate available amount to refund
![after](https://user-images.githubusercontent.com/107249752/181450422-49fd2dd3-4517-4747-99f0-fa07c632cc23.png)
Currently only "Stripe Extension" supports refunded amount API. So, other payment processor only shows original amount as available amount.
![processor](https://user-images.githubusercontent.com/107249752/182174984-b7d6c769-c2c6-4082-866f-e975157f5087.png)


## Technical Details
Added new action / api in Payment Processor to work as proxy to fetch Refunded / Remaining Transaction Amount ( Charged/Collected Amount - Partial Refunded amount(s) ) from Payment Processor using Payment Processors -> getRefundedAmountByChargeId() method

This API action need Transaction ID (`trxn_id`)  from Transaction ( `civicrm_financial_trxn` ) as Param and It will call Payment Processors -> getRefundedAmountByChargeId(trxn_id)