### PR TITLE
CIVIPLUSIB-1012: Fix issue related to permission

### DIFF
--- a/Civi/Financeextras/Payment/Refund.php
+++ b/Civi/Financeextras/Payment/Refund.php
@@ -75,7 +75,7 @@ class Refund {
    */
   public function contactHasRefundPermission(): bool {
     $permissions = [
-      'access CiviCRM backend and API',
+      'access CiviCRM',
       'access CiviContribute',
       'edit contributions',
     ];


### PR DESCRIPTION
## Overview
Fix Permission Name

## Before
The Permission name was checked as "access CiviCRM backend and API" which did not exist. That's why returning false every time for a non-administrator user.

## After
The Permission name updated to "access CiviCRM" which correct name.

