### PR TITLE
CIVIPLUSIB-1012: Fix Permission Issue in Menu

### DIFF
--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -4,6 +4,6 @@
     <path>civicrm/financeextras/payment/refund/card</path>
     <page_callback>CRM_Financeextras_Form_Payment_Refund</page_callback>
     <title>Record a credit card refund</title>
-    <access_arguments>make online contribution</access_arguments>
+    <access_arguments>edit contributions</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
Fix Permission issue

## Before
Update Permission from "make online contribution" to "edit contributions"

## After
Now it will display a button only if it's allowed.
