### PR TITLE
CIVIPLUS-1031: Disable already refunded Payment Row

### DIFF
--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -26,7 +26,7 @@
         </tr>
         {foreach from=$paymentInfos item=paymentRow}
         <tr id="tr_{$paymentRow.financialTrxnId}">
-          <td><input class="required crm-form-radio" value="{$paymentRow.financialTrxnId}" type="radio" id="{$paymentRow.transactionId}" data-processorid="{$paymentRow.paymentProcessorId}" data-currency="{$paymentRow.currency}" name="payment_row" ></td>
+          <td><input class="required crm-form-radio" {if !$paymentRow.available_amount} disabled=disabled {/if} value="{$paymentRow.financialTrxnId}" type="radio" id="{$paymentRow.transactionId}" data-processorid="{$paymentRow.paymentProcessorId}" data-currency="{$paymentRow.currency}" name="payment_row" ></td>
           <td>{$paymentRow.date}</td>
           <td>{$paymentRow.amount|crmMoney:$paymentRow.currency}</td>
           <td class="available_amount_{$paymentRow.financialTrxnId}">{$paymentRow.available_amount|crmMoney:$paymentRow.currency}</td>


### PR DESCRIPTION
## Overview
In the Refund Form, User Need to select Payment Row if there are multiple Payment Rows/Transactions.

## Before
Users can select Already Refund Transaction (Even if it will be an error from the server side). but possible to choose on the frontend side. 
<img width="1107" alt="Screenshot 2022-10-21 at 5 41 55 PM" src="https://user-images.githubusercontent.com/107249752/197192919-64473aee-dfb0-46e3-b83a-35a3bdb79367.png">


## After
Make Payment Row selection Radio button disable if there is no available amount to refund. 
<img width="1116" alt="Screenshot 2022-10-21 at 5 35 41 PM" src="https://user-images.githubusercontent.com/107249752/197192719-efa36dfd-f794-45af-8f91-a6c4db692d07.png">

