### PR TITLE
CIVIPLUS-1033: Fix validation error for Required Payment row

### DIFF
--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -14,7 +14,7 @@
       <td>{$form.contact.html}</td>
     </tr>
     <tr class="crm-payment-refund-form-block-paymentinfos">
-      <td class="label"><label>{ts}Select Payment To Refund{/ts}</label></td>
+      <td class="label"><label for="payment-row">{ts}Select Payment To Refund{/ts}</label></td>
       <td><table class="selector row-highlight payment-info">
         <tr>
           <th></th>
@@ -26,7 +26,7 @@
         </tr>
         {foreach from=$paymentInfos item=paymentRow}
         <tr id="tr_{$paymentRow.financialTrxnId}">
-          <td><input class="required crm-form-radio" value="{$paymentRow.financialTrxnId}" type="radio" id="{$paymentRow.transactionId}" data-processorid="{$paymentRow.paymentProcessorId}" data-currency="{$paymentRow.currency}" name="payment_row" ></td>
+          <td><input class="required crm-form-radio" value="{$paymentRow.financialTrxnId}" type="radio" id="payment-row" data-processorid="{$paymentRow.paymentProcessorId}" data-currency="{$paymentRow.currency}" name="payment_row" ></td>
           <td>{$paymentRow.date}</td>
           <td>{$paymentRow.amount|crmMoney:$paymentRow.currency}</td>
           <td class="available_amount_{$paymentRow.financialTrxnId}">{$paymentRow.available_amount|crmMoney:$paymentRow.currency}</td>


### PR DESCRIPTION
## Overview
Payment Row Selection is Required. But The Validation message is not displayed properly. 

## Before
Payment Row Error is not displayed properly. 
<img width="1709" alt="Screenshot 2022-10-21 at 5 37 15 PM" src="https://user-images.githubusercontent.com/107249752/197193198-c27989ca-d7ec-4be9-ba29-763b08673a89.png">

## After
Payment Row Error display and highlight properly if not selected. 
<img width="1710" alt="Screenshot 2022-10-21 at 5 38 53 PM" src="https://user-images.githubusercontent.com/107249752/197193209-6a1bc55b-f26b-4922-9cfa-b35963f7a457.png">

## Technical Overview
It was not displaying the title as there is no label for those inputs( radios ).
So, added the id and label "for" relation to get the proper title for errors.

