### PR TITLE
CIVIPLUS-1030: Add Info Icon for information message in Refund form

### DIFF
--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -6,7 +6,10 @@
 {/if}
 <div class="crm-block crm-form-block crm-payment-refund-form-block">
   <div class="crm-accordion-body">
-    <div class="message help" >{ts}Refunds take 5-10 days to appear on a customer's statement{/ts}</div>
+    <div class="message help" >
+      <i aria-hidden="true" class="crm-i fa-info-circle"></i>
+      {ts}Refunds take 5-10 days to appear on a customer's statement{/ts}
+    </div>
   </div>
   <table class="form-layout-compressed">
     <tr class="crm-payment-refund-form-block-contact">


### PR DESCRIPTION
## Overview
There is an information message in the Refund form, as per the design info icon was missing.

## Before
The info icon was not added before the information message.
<img width="1113" alt="Screenshot 2022-10-21 at 5 28 06 PM" src="https://user-images.githubusercontent.com/107249752/197192578-eaa614ad-39fb-44a3-8f2e-a021c0dfc2a9.png">

## After
The info icon was added before the information message.
<img width="1124" alt="Screenshot 2022-10-21 at 5 22 36 PM" src="https://user-images.githubusercontent.com/107249752/197190202-fc7eee0b-f859-43ba-a04c-5c3d991d51e6.png">

