### PR TITLE
CIVIPLUS-1031: Diable amount to refund row when remaining amount is zero

### DIFF
--- a/financeextras.php
+++ b/financeextras.php
@@ -143,6 +143,10 @@ function financeextras_civicrm_themes(&$themes) {
  * Implements hook_civicrm_links().
  */
 function financeextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+  if (is_null($objectId)) {
+    return;
+  }
+
   $hooks = [
     new \Civi\Financeextras\Hook\Links\Contribution($op, $objectId, $objectName, $links),
   ];

--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -29,7 +29,13 @@
         </tr>
         {foreach from=$paymentInfos item=paymentRow}
         <tr id="tr_{$paymentRow.financialTrxnId}">
-          <td><input class="required crm-form-radio" value="{$paymentRow.financialTrxnId}" type="radio" id="payment-row" data-processorid="{$paymentRow.paymentProcessorId}" data-currency="{$paymentRow.currency}" name="payment_row" ></td>
+          <td><input class="required crm-form-radio"
+                     value="{$paymentRow.financialTrxnId}"
+                     type="radio" id="payment-row"
+                     data-processorid="{$paymentRow.paymentProcessorId}"
+                     data-currency="{$paymentRow.currency}" name="payment_row"
+                     {if $paymentRow.available_amount == "0.00"} disabled {/if}>
+          </td>
           <td>{$paymentRow.date}</td>
           <td>{$paymentRow.amount|crmMoney:$paymentRow.currency}</td>
           <td class="available_amount_{$paymentRow.financialTrxnId}">{$paymentRow.available_amount|crmMoney:$paymentRow.currency}</td>


### PR DESCRIPTION
## Overview

This PR disables a row(s) on Select Payment To Refund list when available amount is zero.

The PR also includes bug fixes and code improvements.

## Before

![civiplus-1031-before](https://user-images.githubusercontent.com/208713/231996198-4d42471e-bd19-4e2b-9227-a517d4f579b4.png)

## After

![screenshot-dev localhost_8020-2023 04 14-09_25_23](https://user-images.githubusercontent.com/208713/231996234-4a1c79de-93f2-4a6f-9fe7-f9bb57f608b4.png)
