### PR TITLE
CIVIPLUS-1272: Ignore offline transaction

### DIFF
--- a/CRM/Financeextras/Form/Payment/Refund.php
+++ b/CRM/Financeextras/Form/Payment/Refund.php
@@ -77,6 +77,13 @@ class CRM_Financeextras_Form_Payment_Refund extends CRM_Core_Form {
 
     $refundAmountMethod = TRUE;
     foreach ($this->paymentTransactions as $trxn) {
+      // Ignore if payment processor ID is not present.
+      // This is the edge case for the transaction that may have been paid
+      // offline e.g. cash or cheque.
+      if (empty($trxn['payment_processor_id'])) {
+        continue;
+      }
+
       $this->mainTransactionId[$trxn['id']] = $trxn['id'];
       $this->availableAmount[$trxn['id']] = 0;
       $this->chargeID[$trxn['id']] = $trxn['trxn_id'];

--- a/Civi/Financeextras/Payment/Refund.php
+++ b/Civi/Financeextras/Payment/Refund.php
@@ -33,13 +33,15 @@ class Refund {
     //API is likely to return more than one entity as CiviCRM separates financial
     //transactions for financial transaction for example, contribution amount is record
     //as one financial transaction and fee is record in another transaction.
-    $contribution = civicrm_api3('Contribution', 'getsingle', [
+    $contribution = civicrm_api3('Contribution', 'get', [
       'id' => $this->contributionID,
       'return' => ['contribution_status_id'],
-    ]);
-    if (isset($contribution['contribution_status_id']) && $contribution['contribution_status_id'] == 7) {
+    ])['values'][$this->contributionID];
+
+    if (isset($contribution['contribution_status_id']) && $contribution['contribution_status'] === 'Refunded') {
       return FALSE;
     }
+
     $entityFinancialTrxns = civicrm_api3('EntityFinancialTrxn', 'get', [
       'sequential' => 1,
       'entity_id' => $this->contributionID,


### PR DESCRIPTION
## Overview

This PR fixes an error when trying to record a refund with a contribution's payment transactions have both online and offline payments.  i.e. one with Stripe and one with cash. 

The PR also includes the code improvement that avoid unexpected error and increase readability. 

## Before

![CIVIPLUS-1272](https://user-images.githubusercontent.com/208713/232015413-524b0573-dddc-4eb9-a58b-9f80223b0e67.gif)

## After
[screencast-dev.localhost_8020-2023.04.14-10_21_45.webm](https://user-images.githubusercontent.com/208713/232015358-9ae65c69-18bb-4a77-bf87-b2075a937551.webm)
