### PR TITLE
CIWEMB-289: Add tab and contribution row link for create credit note

### DIFF
--- a/CRM/Financeextras/Hook/PageRun/ContributionPageTab.php
+++ b/CRM/Financeextras/Hook/PageRun/ContributionPageTab.php
@@ -1,0 +1,44 @@
+<?php
+
+use CRM_Financeextras_ExtensionUtil as E;
+use CRM_Financeextras_Hook_PageRun_PageRunInterface as PageRunInterface;
+
+class CRM_Financeextras_Hook_PageRun_ContributionPageTab implements PageRunInterface {
+
+  /**
+   * Handles the hook invocation.
+   *
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page) {
+    $this->addResources();
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param CRM_Core_Page $page
+   *
+   * @return bool
+   */
+  public static function shouldHandle($page) {
+    return $page instanceof CRM_Contribute_Page_Tab && $page->_action == CRM_Core_Action::BROWSE;
+  }
+
+  /**
+   * Adds page resources.
+   *
+   * @param $region
+   */
+  private function addResources() {
+    Civi::resources()->add([
+      'template' => 'CRM/Financeextras/Page/Contribute/CreditNoteTab.tpl',
+      'region' => 'page-header',
+    ]);
+    Civi::resources()->add([
+      'scriptFile' => [E::LONG_NAME, 'js/creditnote.js'],
+      'region' => 'page-header',
+    ]);
+  }
+
+}

--- a/CRM/Financeextras/Hook/PageRun/PageRunInterface.php
+++ b/CRM/Financeextras/Hook/PageRun/PageRunInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+interface CRM_Financeextras_Hook_PageRun_PageRunInterface {
+
+  /**
+   * @param CRM_Core_Page $page
+   */
+  public static function shouldHandle($page);
+
+  /**
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page);
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -78,3 +78,36 @@ function financeextras_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 function financeextras_civicrm_entityTypes(&$entityTypes) {
   _financeextras_civix_civicrm_entityTypes($entityTypes);
 }
+
+/**
+ * Implements hook_civicrm_pageRun().
+ *
+ * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_pageRun/
+ */
+function financeextras_civicrm_pageRun($page) {
+  $hooks = [
+    CRM_Financeextras_Hook_PageRun_ContributionPageTab::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($page)) {
+      (new $hook())->handle($page);
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_links().
+ */
+function financeextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+  if ($op == 'contribution.selector.row' && $objectName == 'Contribution') {
+    if (CRM_Core_Permission::check('edit contributions')) {
+      $links[] = [
+        'name' => 'Add Credit Note',
+        'url' => 'civicrm/contribution/creditnote',
+        'qs' => 'reset=1&action=add',
+        'title' => 'Add Credit Note',
+      ];
+    }
+  }
+}

--- a/info.xml
+++ b/info.xml
@@ -2,7 +2,7 @@
 <extension key="io.compuco.financeextras" type="module">
   <file>financeextras</file>
   <name>Finance Extras</name>
-  <description>Thi extension provides CiviCRM financial improvement</description>
+  <description>This extension provides CiviCRM financial improvement</description>
   <license>AGPL-3.0</license>
   <maintainer>
     <author>Compuco</author>
@@ -23,4 +23,8 @@
     <angularModule>crmFinanceextras</angularModule>
     <format>22.05.2</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>ang-php@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/js/creditnote.js
+++ b/js/creditnote.js
@@ -1,0 +1,13 @@
+CRM.$(function () {
+  CRM.$(function () {
+    moveCreditNoteTabNextToContributionTab();
+  });
+
+  /**
+   * Moves the credit note tab to the appropratie position
+   */
+  function moveCreditNoteTabNextToContributionTab() {
+    CRM.$('#tab_contributions').after(CRM.$('#tab_credit_note'));
+    CRM.$('#contributions-subtab').after(CRM.$('#credit_note_subtab'));
+  }
+});

--- a/mixin/menu-xml@1.0.0.mixin.php
+++ b/mixin/menu-xml@1.0.0.mixin.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Auto-register "xml/Menu/*.xml" files.
+ *
+ * @mixinName menu-xml
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::xmlMenu()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_xmlMenu', function ($e) use ($mixInfo) {
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('xml/Menu/*.xml'));
+    foreach ($files as $file) {
+      $e->files[] = $file;
+    }
+  });
+
+};

--- a/templates/CRM/Financeextras/Page/Contribute/CreditNoteTab.tpl
+++ b/templates/CRM/Financeextras/Page/Contribute/CreditNoteTab.tpl
@@ -1,0 +1,24 @@
+
+<li id="tab_credit_note" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
+  <a href="#credit_note_subtab" title="{ts}Credit Notes{/ts}">
+    {ts}Credit Notes{/ts}
+  </a>
+</li>
+
+<div id="credit_note_subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
+
+  {if $action eq 16 and $permission EQ 'edit'}
+  {capture assign=newCreditnotesURL}{crmURL p="civicrm/contribution/creditnote" q="reset=1&action=add&cid=`$contactId`&context=contribution"}{/capture}
+    <div class="action-link">
+      <a accesskey="N" href="{$newCreditnotesURL|smarty:nodefaults}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Create New Credit Note{/ts}</span></a>
+      <br /><br />
+    </div>
+    <div class='clear'></div>
+  {/if}
+
+  <div class="messages status no-popup">
+    {icon icon="fa-info-circle"}{/icon}
+    {ts}No credit notes have been recorded for this contact.{/ts}
+  </div>
+</div>
+

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/creditnote/a</path>
+    <page_callback>CRM_Financeextras_Page_Contribute_CreditNoteAngular</page_callback>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/contribution/creditnote</path>
+    <page_callback>CRM_Financeextras_Page_Contribute_CreditNoteAngular</page_callback>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
## Overview
This PR includes the following changes
- Adds a new tab called `Credit Notes` to the contact contribution view.
- Adds a new action link to the contribution list with the title `Add Credit Note`.


## Before
This new tab and action row link don't exist.
![sqq](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/9e4dcdb3-fe13-42eb-9b24-2d36e74f5d4d)


## After
The tab called `Credit Notes` is now added to the contribution view and the contribution list now has a new action `Add Credit Note`.
![ser](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/f49f86a9-bce8-4a85-a504-88a71ce7f608)


## Technical Details
The `Add Credit Note` action links to the new path `civicrm/contribution/creditnote` added in this PR.
