### PR TITLE
CIWEMB-289: Add CreditNote allocation type and status option group

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
+use Civi\Financeextras\Setup\Manage\CreditNoteAllocationTypeManager;
 
 /**
  * Collection of upgrade steps.
@@ -13,6 +14,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function install() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteAllocationTypeManager(),
     ];
 
     foreach ($steps as $step) {
@@ -26,6 +28,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function uninstall() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteAllocationTypeManager(),
     ];
 
     foreach ($steps as $step) {
@@ -39,6 +42,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function enable() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteAllocationTypeManager(),
     ];
 
     foreach ($steps as $step) {
@@ -52,6 +56,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function disable() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteAllocationTypeManager(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -1,9 +1,62 @@
 <?php
-use CRM_Financeextras_ExtensionUtil as E;
+
+use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
 
 /**
  * Collection of upgrade steps.
  */
 class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
+
+  /**
+   * Tasks to perform when the extension is installed.
+   */
+  public function install() {
+    $steps = [
+      new CreditNoteStatusManager(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->create();
+    }
+  }
+
+  /**
+   * Tasks to perform when the extension is uninstalled.
+   */
+  public function uninstall() {
+    $steps = [
+      new CreditNoteStatusManager(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->remove();
+    }
+  }
+
+  /**
+   * Tasks to perform when the extension is enanled.
+   */
+  public function enable() {
+    $steps = [
+      new CreditNoteStatusManager(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->enable();
+    }
+  }
+
+  /**
+   * Tasks to perform when the extension is disabled.
+   */
+  public function disable() {
+    $steps = [
+      new CreditNoteStatusManager(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->disable();
+    }
+  }
 
 }

--- a/Civi/Financeextras/Setup/Manage/AbstractManager.php
+++ b/Civi/Financeextras/Setup/Manage/AbstractManager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+/**
+ * Interface to manage entities.
+ *
+ * Describes the interface for entities that are
+ * to be managed (created, removed ..etc) during the
+ * extension installations, disabling ..etc.
+ */
+abstract class AbstractManager {
+
+  /**
+   * Creates the entity.
+   */
+  abstract public function create(): void;
+
+  /**
+   * Removes the entity.
+   */
+  abstract public function remove(): void;
+
+  /**
+   * Disables the entity.
+   */
+  public function disable(): void {
+    $this->toggle(FALSE);
+  }
+
+  /**
+   * Enables the entity.
+   */
+  public function enable() {
+    $this->toggle(TRUE);
+  }
+
+  /**
+   * Enables/Disables the entity based on the passed status.
+   *
+   * @params boolean $status
+   *  True to enable the entity, False to disable the entity.
+   */
+  abstract protected function toggle($status): void;
+
+}

--- a/Civi/Financeextras/Setup/Manage/CreditNoteAllocationTypeManager.php
+++ b/Civi/Financeextras/Setup/Manage/CreditNoteAllocationTypeManager.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+/**
+ * Manages the option group and values that stores credit note allocation types.
+ */
+class CreditNoteAllocationTypeManager extends AbstractManager {
+
+  const NAME = 'financeextras_credit_note_allocation_type';
+
+  /**
+   * Ensures Credit note allocation type option group and default option values exists.
+   *
+   * The option values in the option group will store the available allocation types
+   * for credit note.
+   */
+  public function create(): void {
+    \CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => self::NAME,
+      'title' => ts('Credit Note Allocation Type'),
+      'is_reserved' => 1,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::NAME,
+      'name' => 'invoice',
+      'label' => 'Invoice',
+      'is_default' => TRUE,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::NAME,
+      'name' => 'manual_refund_payment',
+      'label' => 'Refund payment (manual)',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::NAME,
+      'name' => 'online_refund_payment',
+      'label' => 'Refund payment (online)',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * Removes the entity.
+   */
+  public function remove(): void {
+    civicrm_api3('OptionGroup', 'get', [
+      'return' => ['id'],
+      'name' => self::NAME,
+      'api.OptionGroup.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function toggle($status): void {
+    civicrm_api3('OptionGroup', 'get', [
+      'sequential' => 1,
+      'name' => self::NAME,
+      'api.OptionGroup.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+
+}

--- a/Civi/Financeextras/Setup/Manage/CreditNoteStatusManager.php
+++ b/Civi/Financeextras/Setup/Manage/CreditNoteStatusManager.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+/**
+ * Manages the option group and values that stores credit note statuses.
+ */
+class CreditNoteStatusManager extends AbstractManager {
+
+  const NAME = 'financeextras_credit_note_status';
+
+  /**
+   * Ensures Credit note Status option group and default option values exists.
+   *
+   * The option values in the option group will store the available statuses
+   * for credit note.
+   */
+  public function create(): void {
+    \CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => self::NAME,
+      'title' => ts('Credit Note Status'),
+      'is_reserved' => 1,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::NAME,
+      'name' => 'open',
+      'label' => 'Open',
+      'is_default' => TRUE,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::NAME,
+      'name' => 'fully_allocated',
+      'label' => 'Fully allocated',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::NAME,
+      'name' => 'void',
+      'label' => 'Void',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * Removes the entity.
+   */
+  public function remove(): void {
+    civicrm_api3('OptionGroup', 'get', [
+      'return' => ['id'],
+      'name' => self::NAME,
+      'api.OptionGroup.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function toggle($status): void {
+    civicrm_api3('OptionGroup', 'get', [
+      'sequential' => 1,
+      'name' => self::NAME,
+      'api.OptionGroup.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Overview
This pull request introduces changes related to the management of credit note status and allocation type option groups based on the extension lifecycle. It includes the addition of new classes and methods for managing these entities during installation, uninstallation, enabling, and disabling of the extension.

## Before
Previously, there was no dedicated management for credit note status and allocation type option groups.

## After
With this pull request, the management of credit note status and allocation type option groups is implemented. and the option group and values will be added/removed/disabled/enabled based on the extension state.

## Technical Details
- The `CreditNoteStatusManager` class is responsible for managing the credit note status option group and its associated option values. It provides methods to create, remove, enable, and disable the option group and option values.
- The `CreditNoteAllocationTypeManager` class handles the credit note allocation type option group and its option values. It provides methods to create, remove, enable, and disable the option group and option values.
- The `CRM_Financeextras_Upgrader` class now includes tasks for the `CreditNoteStatusManager` and `CreditNoteAllocationTypeManager` during installation, uninstallation, enabling, and disabling of the extension. The relevant manager methods are called accordingly.

The option group and their values are:

`financeextras_credit_note_allocation_type`:
- Invoice
- Refund payment (manual)
- Refund payment (online)

`financeextras_credit_note_status`:
 - Open
 - Fully allocated
 - Void

Please note, these option groups and their values are reserved and their values or names are not meant to be edited or changed.