### PR TITLE
CIWEMB-289: Add Create credit note form

### DIFF
--- a/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
+++ b/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class CRM_Financeextras_Page_Contribute_CreditNoteAngular.
+ *
+ * Define an Angular base-page for Crediitnotes Module.
+ */
+class CRM_Financeextras_Page_Contribute_CreditNoteAngular extends \CRM_Core_Page {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function run() {
+    $route = $this->getRoute();
+    $loader = Civi::service('angularjs.loader');
+    $loader->addModules(['crmApp', 'fe-creditnote']);
+
+    CRM_Utils_System::setTitle(ts($route['title']));
+
+    return parent::run();
+  }
+
+  private function getRoute() {
+    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
+    $routes = [CRM_Core_Action::ADD => ['name' => 'new', 'title' => 'New Credit Note']];
+    return $routes[$action] ?? 'new';
+  }
+
+}

--- a/ang/fe-creditnote.ang.php
+++ b/ang/fe-creditnote.ang.php
@@ -1,0 +1,38 @@
+<?php
+// This file declares an Angular module which can be autoloaded
+// in CiviCRM. See also:
+// \https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules/n
+
+use Civi\Financeextras\Utils\CurrencyUtils;
+
+$options = [];
+
+/**
+ * Exposes currency codes to Angular.
+ */
+function financeextras_set_currency_codes(&$options) {
+  $options['currencyCodes'] = CurrencyUtils::getCurrencies();
+}
+
+financeextras_set_currency_codes($options);
+
+return [
+  'js' => [
+    'ang/fe-creditnote.module.js',
+    'ang/fe-creditnote/*.js',
+    'ang/fe-creditnote/*/*.js',
+  ],
+  'css' => [
+    'css/fe-creditnote.css',
+  ],
+  'partials' => [
+    'ang/fe-creditnote',
+  ],
+  'requires' => [
+    'api4',
+    'crmUi',
+    'crmUtil',
+    'ngRoute',
+  ],
+  'settings' => $options,
+];

--- a/ang/fe-creditnote.module.js
+++ b/ang/fe-creditnote.module.js
@@ -1,0 +1,4 @@
+(function(angular) {
+  // Declare a list of dependencies.
+  angular.module('fe-creditnote', CRM.angRequires('fe-creditnote'));
+})(angular);

--- a/ang/fe-creditnote/app.routes.js
+++ b/ang/fe-creditnote/app.routes.js
@@ -1,0 +1,14 @@
+(function (angular) {
+  var module = angular.module('fe-creditnote');
+
+  module.config(function ($routeProvider) {
+    $routeProvider.when('/add', {
+      template: function () {
+        return `
+          <creditnote-create></creditnote-create>
+        `;
+      }
+    });
+
+  });
+})(angular);

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -1,0 +1,204 @@
+<div id="bootstrap-theme" class="creditnote__container">
+  <h1 class="hidden" crm-page-title>{{ ts('New Credit Note') }}</h1>
+
+  <div class="panel panel-default" id="creditnote__create">
+    <div class="panel-body">
+      <form name="creditnotesForm" class="form-horizontal">
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ ts('Contact') }}
+          </label>
+          <div class="col-sm-5">
+            <input class="form-control"
+              ng-model="creditnotes.contact_id"
+              placeholder="Select Contact"
+              name="contact"
+              crm-entityref="{
+                create: true,
+                entity: 'Contact',
+                select: { multiple: false, allowClear: true }
+              }"
+              required
+              ng-minlength="1"
+            />
+            <span class="crm-inline-error" ng-show="creditnotesForm.contact.$dirty && creditnotesForm.contact.$invalid && creditnotesForm.contact.$error.required">Contact is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ ts('Number') }}
+          </label>
+          <div class="col-sm-5">
+              <input
+                class="form-control"" id="creditnotes_number"
+                ng-model="creditnotes.number" placeholder="Number" name="number" type="text" disabled/>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ ts('Date') }}
+          </label>
+          <div class="col-sm-5 creditnotes__ui-range">
+              <input
+                class="form-control" crm-ui-datepicker="{time: false}" id="creditnotes_date"
+                ng-model="creditnotes.date" placeholder="Date" name="date" required/>
+                <span class="crm-inline-error" ng-show="creditnotesForm.date.$dirty && creditnotesForm.date.$invalid">Date is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ ts('Description') }}
+            <a crm-ui-help="hs({title:ts('Description'), id:'creditnotes_description'})"></a>
+          </label>
+          <div class="col-sm-5">
+            <textarea name="description" ng-model="creditnotes.description" class="crm-form-wysiwyg" id="creditnotes-description" required></textarea>
+            <span class="crm-inline-error" ng-show="creditnotesForm.description.$dirty && creditnotesForm.description.$invalid && creditnotesForm.description.$error.required">Description is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ ts('Reference') }}
+          </label>
+          <div class="col-sm-5 civicase__ui-range">
+              <input
+                class="form-control"" id="creditnotes_reference"
+                ng-model="creditnotes.reference" placeholder="Reference" name="reference" type="text"/>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ts('Currency')}}
+          </label>
+          <div class="col-sm-5">
+            <select class="form-control"
+              ng-model="creditnotes.currency"
+              ng-change="handleCurrencyChange()"
+              placeholder="Currency"
+              name="currency"
+              required
+            >
+            <option value="">{{ ts('Currency') }}</option>
+            <option ng-repeat="currency in currencyCodes track by $index" value="{{ currencyCodes[$index].name }}">{{ currencyCodes[$index].name }}</option>
+            </select>
+            <span class="crm-inline-error" ng-show="creditnotesForm.currency.$dirty && creditnotesForm.currency.$invalid && creditnotesForm.currency.$error.required">Currency is required</span>
+          </div>
+        </div>
+
+        <div class="row">
+          <label class="col-sm-2 control-label required-mark">
+            {{ts('Line Items:')}}
+          </label>
+          <br />
+          <br />
+        </div>
+        <div class="form-group">
+          <div class="col-sm-7" style="overflow: scroll;">
+           <table class="table table-bordered">
+            <tr>
+              <th class="required-mark">Item</th>
+              <th class="required-mark">Financial Type</th>
+              <th class="required-mark">Quantity</th>
+              <th class="required-mark">Unit Price</th>
+              <th>Tax</th>
+              <th>Subtotal</th>
+              <th></th>
+            </tr>
+            <tr ng-repeat="item in creditnotes.items track by $index">
+              <td>
+                <input type="text" name="item_description_{{$index}}" ng-model="creditnotes.items[$index].item_description" class="form-control" style="resize: none" required />
+                <br />
+                <span class="crm-inline-error" ng-show="creditnotesForm.item_description_{{$index}}.$dirty && creditnotesForm.item_description_{{$index}}.$invalid && creditnotesForm.item_description_{{$index}}.$error.required">Description is required</span>
+              </td>
+              <td style="max-width: 15em;">
+                <input class="form-control"
+                style="width: 100%"
+                  ng-model="creditnotes.items[$index].financial_type_id"
+                  ng-change="handleFinancialTypeChange($index)"
+                  name="financial_type_{{$index}}"
+                  placeholder="Financial Type"
+                  crm-entityref="{
+                    entity: 'Financial Type',
+                    select: { allowClear: true, 'minimumInputLength': 0 }
+                  }"
+                  required
+                  ng-minlength="1"
+                />
+                <br />
+                <span class="crm-inline-error" ng-show="creditnotesForm.financial_type_{{$index}}.$dirty && creditnotesForm.financial_type_{{$index}}.$invalid && creditnotesForm.financial_type_{{$index}}.$error.required">Financial Type is required</span>
+              </td>
+              <td>
+                <input type="number" min="0" name="quantity_{{$index}}" required placeholder="Quantity" ng-model="creditnotes.items[$index].quantity" class="form-control" ng-change="calculateSubtotal($index)" style="width: 6em" step="0.01" />
+                <br />
+                <span class="crm-inline-error" ng-show="creditnotesForm.quantity_{{$index}}.$dirty && (creditnotesForm.quantity_{{$index}}.$invalid || creditnotesForm.quantity_{{$index}}.$error.required)">Quantity is invalid</span>
+              </td>
+              <td>
+                <div class="input-group" style="width: 10em">
+                  <span class="input-group-addon">{{ currencySymbol }}</span>
+                  <input type="number" min="0" name="unit_price_{{$index}}" required placeholder="Unit Price" ng-model="creditnotes.items[$index].unit_price" ng-change="calculateSubtotal($index)" class="form-control" step="0.01" />
+                </div>
+                <br />
+                <span class="crm-inline-error" ng-show="creditnotesForm.unit_price_{{$index}}.$dirty && (creditnotesForm.unit_price_{{$index}}.$invalid || creditnotesForm.unit_price_{{$index}}.$error.required)">Unit price is invalid</span>
+              </td>
+              <td>
+                {{ roundTo(creditnotes.items[$index].tax_rate, 4) }}
+              </td>
+              <td>{{ formatMoney(creditnotes.items[$index].subtotal_amount, creditnotes.currency) }}</td>
+              <td><a ng-if="creditnotes.items.length > 1" href ng-click="removeCreditnotesItem($index)" ><i class="fa fa-trash"></i></a></td>
+            </tr>
+           </table>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-3">
+            <button class="btn btn-secondary" ng-click="newCreditnotesItem()" type="button"><span><i class="fa fa-plus"></i></span>{{ ts(' Add another item') }}</button>
+          </div>
+          <label class="col-sm-2"></label>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-7">
+            <div class="row">
+                <div class="col-sm-3 pull-right">
+                  <table class="table">
+                    <tr><th>Subtotal</th><td>{{ currencySymbol }} {{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
+                      <tr ng-repeat="i in taxRates">
+                        <th>Tax @ {{ i.rate }}%</th>
+                        <td>{{ currencySymbol }} {{ formatMoney(i.value, creditnotes.currency) }}</td>
+                      </tr>
+                    <tr><th>Total</th><td>{{ currencySymbol }} {{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>
+                  </table>
+                </div>
+            </div>
+          </div>
+        </div>
+
+
+        <div class="row">
+          <label class="col-sm-2 control-label">
+            {{ts('Comment')}}
+            <a crm-ui-help="hs({title:ts('Notes'), id:'creditnotes_comment'})"></a>
+          </label>
+          <br />
+          <br />
+        </div>
+        <div class="form-group">
+          <div class="col-sm-7">
+            <textarea name="notes" rows="5" cols="20" style="width: 100%;" ng-model="creditnotes.comment"></textarea>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="panel-footer flex-between crm-submit-buttons">
+        <button type="button" class="btn btn-primary-outline cancel crm-form-submit crm-button crm-button-type-cancel" history-back>
+          <span class="btn-icon"></span> {{ts('Cancel')}}</button>
+        <button type="submit" class="btn btn-primary crm-form-submit crm-button crm-button-type-submit" ng-disabled="submitInProgress" ng-click="saveCreditnotes()">
+          <span class="btn-icon"></span> {{ts('Create')}}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  #creditnote__create .table>tbody>tr>td {
+    padding: 10px 10px;
+  }
+</style>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -1,0 +1,171 @@
+(function (angular, $, _) {
+  var module = angular.module('fe-creditnote');
+
+  module.directive('creditnoteCreate', function ($timeout) {
+    return {
+      restrict: 'E',
+      controller: 'creditnoteCreateController',
+      templateUrl: '~/fe-creditnote/directives/creditnote-create.directive.html',
+      link: function() {
+        $timeout(function() {
+          if (CRM.$("div.ui-dialog").length) {
+            const buttonPane = CRM.$("<div>").addClass("ui-dialog-buttonpane ui-widget-content ui-helper-clearfix");
+            const buttonSet = CRM.$("<div>").addClass("ui-dialog-buttonset flex-between");
+            buttonSet.append(CRM.$('.crm-submit-buttons > button'))
+            buttonPane.append(buttonSet);
+
+            CRM.$("div.ui-dialog").append(buttonPane);
+          }
+        }, 20);
+      }
+    };
+  });
+
+  module.controller('creditnoteCreateController', creditnoteCreateController);
+
+  /**
+   * @param {object} $scope the controller scope
+   * @param {object} $location the location service
+   * @param {object} $window window object of the browser
+   * @param {object} CurrencyCodes CurrencyCodes service
+   * @param {object} crmUiHelp crm ui help service
+   * @param {object} crmApi4 crm api V4 service
+   */
+  function creditnoteCreateController ($scope, $location, $window, CurrencyCodes, crmUiHelp, crmApi4) {
+    const defaultCurrency = 'GBP';
+    $scope.isUpdate = false;
+    $scope.formValid = true;
+
+    $scope.ts = CRM.ts();
+    $scope.saveCreditnotes = saveCreditnotes;
+    $scope.currencyCodes = CurrencyCodes.getAll();
+    $scope.hs = crmUiHelp({ file: 'CRM/Financeextras/CreditNoteCtrl' });
+    $scope.currencySymbol = CurrencyCodes.getSymbol(defaultCurrency);
+
+    (function init () {
+      initializeCreditnotes();
+      $scope.newCreditnotesItem = newCreditnotesItem;
+      CRM.wysiwyg.create('#creditnotes-description');
+      $scope.removeCreditnotesItem = removeCreditnotesItem;
+
+      $scope.$on('totalChange', _.debounce(handleTotalChange, 250));
+    }());
+
+    /**
+     * Initializess the creditnotes object
+     */
+    function initializeCreditnotes () {
+      $scope.creditnotes = {
+        currency: defaultCurrency,
+        contact_id: null,
+        date: $.datepicker.formatDate('yy-mm-dd', new Date()),
+        items: [{
+          item_description: null,
+          financial_type_id: null,
+          unit_price: null,
+          quantity: null,
+          tax_rate: 0,
+          subtotal_amount: 0
+        }],
+        total: 0,
+        grandTotal: 0
+      };
+      $scope.total = 0;
+      $scope.taxRates = [];
+    }
+
+    /**
+     * Initializes empty creditnotes item
+     */
+    function newCreditnotesItem () {
+      $scope.creditnotes.items.push({
+        description: null,
+        financial_type_id: null,
+        unit_price: null,
+        quantity: null,
+        tax_rate: 0,
+        subtotal_amount: 0
+      });
+    }
+
+    /**
+     * Removes a creditnotes line item
+     *
+     * @param {number} index element index to be removed
+     */
+    function removeCreditnotesItem (index) {
+      $scope.creditnotes.items.splice(index, 1);
+      $scope.$emit('totalChange');
+    }
+
+    /**
+     * Computes total and tax rates from API
+     */
+    function handleTotalChange () {
+      crmApi4('Creditnotes', 'computeTotal', {
+        lineItems: $scope.creditnotes.items
+      }).then(function (results) {
+        $scope.taxRates = results[0].taxRates;
+        $scope.creditnotes.total = results[0].totalBeforeTax;
+        $scope.creditnotes.grandTotal = results[0].totalAfterTax;
+      }, function () {
+        // handle failure
+      });
+    }
+
+    /**
+     * Persists creditnotes and redirects on success
+     */
+    function saveCreditnotes () {
+      if (!validateForm()) {
+        return;
+      }
+
+      $scope.submitInProgress = true;
+      crmApi4('Creditnotes', 'save', { records: [$scope.creditnotes] })
+        .then(function () {
+          showSucessNotification();
+          redirectToAppropraitePage();
+        }, function () {
+          $scope.submitInProgress = false;
+          CRM.alert('Unable to create credit notes', ts('Error'), 'error');
+        });
+    }
+
+    /**
+     * Validates form before saving
+     *
+     * @returns {boolean} true if form is valid, otherwise false
+     */
+    function validateForm () {
+      angular.forEach($scope.creditnotesForm.$$controls, function (control) {
+        control.$setDirty();
+        control.$validate();
+      });
+
+      return $scope.creditnotesForm.$valid;
+    }
+
+    /**
+     * Handles page rediection after successfully creating creditnotes.
+     */
+    function redirectToAppropraitePage () {
+      if ($scope.isUpdate) {
+        $window.location.href = $window.document.referrer;
+        return;
+      }
+
+      $window.location.href = 'a#/';
+    }
+
+    /**
+     * Show Ceditnotes success create notification.
+     */
+    function showSucessNotification () {
+      const msg = !$scope.isUpdate ? 'Credit Note has been created successfully.' : 'Details updated successfully';
+      CRM.alert(msg, ts('Saved'), 'success');
+    }
+
+
+  }
+})(angular, CRM.$, CRM._);

--- a/css/fe-creditnote.css
+++ b/css/fe-creditnote.css
@@ -1,0 +1,19 @@
+/* Add any CSS rules for Angular module "crmFinanceextras" */
+#bootstrap-theme .creditnotes__ui-range .crm-form-date {
+  display: inline-block;
+  width: 134px;
+}
+.ui-dialog #bootstrap-theme.creditnote__container > div#creditnote__create.panel {
+  box-shadow: none;
+}
+.ui-dialog #bootstrap-theme.creditnote__container > div#creditnote__create.panel > .panel-body {
+  border: none;
+  padding: 0;
+}
+.ui-dialog #bootstrap-theme.creditnote__container > div#creditnote__create.panel .col-sm-7 {
+  width: 100%;
+}
+.flex-between {
+  display: flex;
+  justify-content: space-between;
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -111,3 +111,15 @@ function financeextras_civicrm_links($op, $objectName, $objectId, &$links, &$mas
     }
   }
 }
+
+/**
+ * Implements hook_civicrm_tabset().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_tabset
+ */
+function financeextras_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    $loader = Civi::service('angularjs.loader');
+    $loader->addModules(['crmApp', 'fe-creditnote']);
+  }
+}

--- a/mixin/ang-php@1.0.0.mixin.php
+++ b/mixin/ang-php@1.0.0.mixin.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Auto-register "ang/*.ang.php" files.
+ *
+ * @mixinName ang-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::angularModules()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_angularModules', function ($e) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive() || !is_dir($mixInfo->getPath('ang'))) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('ang/*.ang.php'));
+    foreach ($files as $file) {
+      $name = preg_replace(':\.ang\.php$:', '', basename($file));
+      $module = include $file;
+      if (empty($module['ext'])) {
+        $module['ext'] = $mixInfo->longName;
+      }
+      $e->angularModules[$name] = $module;
+    }
+  });
+
+};

--- a/templates/CRM/Financeextras/CreditNoteCtrl.hlp
+++ b/templates/CRM/Financeextras/CreditNoteCtrl.hlp
@@ -1,0 +1,11 @@
+{htxt id="creditnotes_comment"}
+<p>
+  {ts}An optional internal comment that will not be shown on the printed credit note.{/ts}
+</p>
+{/htxt}
+
+{htxt id="creditnotes_description}
+<p>
+  {ts}An optional public description that will be shown on the printed credit note.{/ts}
+</p>
+{/htxt}

--- a/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
+++ b/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
@@ -1,0 +1,21 @@
+<div id="creditnote-tab">
+  <div class="container">
+  <view></view>
+  </div>
+</div>
+{literal}
+<script type="text/javascript">
+    (function(angular, $, _) {
+      const app = angular.module('creditnoteTab', ['fe-creditnote']);
+      app.directive('view', function () {
+      return {
+        template: `<creditnote-create></creditnote-create>`,
+      }
+    });
+    })(angular, CRM.$, CRM._);
+
+    CRM.$(document).one('crmLoad', function() {
+      angular.bootstrap(document.getElementById('creditnote-tab'), ['creditnoteTab']);
+    });
+</script>
+{/literal}


### PR DESCRIPTION
## Overview
This pull request adds a page to create credit note.

## Before
The page to create credit note did not exist. 


## After
The page to create new credit notes now exists.
![errr](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/e186a748-baea-4f80-9f39-55ce7d0d62f9)

## Technical Details
The added Angular module `fe-creditnote` enables the creation of credit notes, and this module will also be used in the future for other credit note features that are more suitable for Angular templates than Smarty. The `CreditNoteAngular` class in `CRM/Financeextras/Page/Contribute/CreditNoteAngular.php` sets up the Angular environment and handles common page functionalities

The `templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl` is responsible for rendering the Angular template for the credit note create form.