### PR TITLE
CIWEMB-289: Show real time amounts updates when updating line items on credit note creating form

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -1,5 +1,4 @@
 <?php
-use CRM_Financeextras_ExtensionUtil as E;
 
 class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote {
 
@@ -8,19 +7,79 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
    *
    * @param array $params key-value pairs
    * @return CRM_Financeextras_DAO_CreditNote|NULL
+   */
+  public static function create($params) {
+    $className = 'CRM_Financeextras_DAO_CreditNote';
+    $entityName = 'CreditNote';
+    $hook = empty($params['id']) ? 'create' : 'edit';
+
+    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    $instance = new $className();
+    $instance->copyValues($params);
+    $instance->save();
+    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
+
+    return $instance;
+  }
+
+  /**
+   * Computes the credit note line item total.
    *
-   * public static function create($params) {
-   * $className = 'CRM_Financeextras_DAO_CreditNote';
-   * $entityName = 'CreditNote';
-   * $hook = empty($params['id']) ? 'create' : 'edit';
+   * @param array $items
+   *   Array of credit note line items.
    *
-   * CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-   * $instance = new $className();
-   * $instance->copyValues($params);
-   * $instance->save();
-   * CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
+   * @return array
+   *   ['totalAfterTax' => <value>, 'totalBeforeTax' => <value>]
+   */
+  public static function computeTotalAmount(array $items) {
+    $totalBeforeTax = round(array_reduce($items, fn ($a, $b) => $a + self::getLineItemSubTotal($b), 0), 2);
+    $totalAfterTax = round(array_reduce($items,
+      fn ($a, $b) => $a + ($b['tax_amount'] ?? (($b['tax_rate'] * self::getLineItemSubTotal($b)) / 100)),
+      0
+    ) + $totalBeforeTax, 2);
+
+    return [
+      'taxRates' => self::computeLineItemsTaxRates($items),
+      'totalAfterTax' => $totalAfterTax,
+      'totalBeforeTax' => $totalBeforeTax,
+    ];
+  }
+
+  /**
+   * Computes the sub total of a single line item.
    *
-   * return $instance;
-   * } */
+   * @param array $item
+   *   Single credit note line item.
+   *
+   * @return int
+   *   The line item subtotal.
+   */
+  private static function getLineItemSubTotal(array $item) {
+    return $item['unit_price'] * $item['quantity'] ?? 0;
+  }
+
+  /**
+   * Computes the tax rates of each line item.
+   *
+   * @param array $items
+   *   Single credit note line item.
+   *
+   * @return array
+   *   Returned sorted array of line items tax rates.
+   */
+  private static function computeLineItemsTaxRates(array $items) {
+    $items = array_filter($items, fn ($a) => !empty($a['tax_rate']) && $a['tax_rate'] > 0);
+    usort($items, fn ($a, $b) => $a['tax_rate'] <=> $b['tax_rate']);
+
+    return array_map(
+      fn ($a) =>
+      [
+        'tax_name' => $a['tax_name'] ?? '',
+        'rate' => round($a['tax_rate'], 2),
+        'value' => round(($a['tax_rate'] * self::getLineItemSubTotal($a)) / 100, 2),
+      ],
+      $items
+    );
+  }
 
 }

--- a/Civi/Api4/Action/CreditNote/ComputeTotalAction.php
+++ b/Civi/Api4/Action/CreditNote/ComputeTotalAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNote;
+
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use CRM_Financeextras_BAO_CreditNote as CreditNoteBAO;
+
+/**
+ * Computes the total of a credit note.
+ */
+class ComputeTotalAction extends AbstractAction {
+  use DAOActionTrait;
+
+  /**
+   * credit note line items.
+   *
+   * @var array
+   */
+  protected $lineItems;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    if (is_array($this->lineItems)) {
+      $result[] = CreditNoteBAO::computeTotalAmount($this->lineItems);
+    }
+  }
+
+}

--- a/Civi/Api4/CreditNote.php
+++ b/Civi/Api4/CreditNote.php
@@ -2,6 +2,9 @@
 
 namespace Civi\Api4;
 
+use Civi\Api4\Action\CreditNote\ComputeTotalAction;
+use Civi\Api4\Action\CreditNote\CreditNoteSaveAction;
+
 /**
  * CreditNote entity.
  *
@@ -10,5 +13,33 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class CreditNote extends Generic\DAOEntity {
+
+  /**
+   * Creates or Updates a CreditNote with the line items.
+   *
+   * @param bool $checkPermissions
+   *   Should permission be checked for the user.
+   *
+   * @return Civi\Api4\Action\CreditNote\CreditNoteSaveAction
+   *   returns save order action
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new CreditNoteSaveAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * Compute the sum of the line items value.
+   *
+   * @param bool $checkPermissions
+   *   Should permission be checked for the user.
+   *
+   * @return Civi\Api4\Action\CreditNote\ComputeTotalAction
+   *   returns compute total action
+   */
+  public static function computeTotal($checkPermissions = FALSE) {
+    return (new ComputeTotalAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
 }

--- a/Civi/Financeextras/Utils/CurrencyUtils.php
+++ b/Civi/Financeextras/Utils/CurrencyUtils.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Civi\Financeextras\Utils;
+
+use CRM_Core_DAO;
+use CRM_Utils_Money;
+
+/**
+ * Utility class to manage CiviCRM currency table.
+ */
+class CurrencyUtils {
+
+  /**
+   * CiviCRM Currencies.
+   *
+   * @var array
+   */
+  private static $currencies;
+
+  /**
+   * Returns a list of currencies supported by CiviCRM.
+   *
+   * @return array
+   *   array reference of all currency names and symbols
+   */
+  public static function getCurrencies() {
+    if (!self::$currencies) {
+      $query = "SELECT name, symbol FROM civicrm_currency";
+      $dao = CRM_Core_DAO::executeQuery($query);
+      self::$currencies = [];
+      while ($dao->fetch()) {
+        self::$currencies[] = [
+          'name' => $dao->name,
+          'symbol' => $dao->symbol,
+          'format' => CRM_Utils_Money::format(1234.56, $dao->name),
+        ];
+      }
+    }
+
+    return self::$currencies;
+  }
+
+}

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -105,9 +105,9 @@
             </tr>
             <tr ng-repeat="item in creditnotes.items track by $index">
               <td>
-                <input type="text" name="item_description_{{$index}}" ng-model="creditnotes.items[$index].item_description" class="form-control" style="resize: none" required />
+                <input type="text" name="description_{{$index}}" ng-model="creditnotes.items[$index].description" class="form-control" style="resize: none" required />
                 <br />
-                <span class="crm-inline-error" ng-show="creditnotesForm.item_description_{{$index}}.$dirty && creditnotesForm.item_description_{{$index}}.$invalid && creditnotesForm.item_description_{{$index}}.$error.required">Description is required</span>
+                <span class="crm-inline-error" ng-show="creditnotesForm.description_{{$index}}.$dirty && creditnotesForm.description_{{$index}}.$invalid && creditnotesForm.description_{{$index}}.$error.required">Description is required</span>
               </td>
               <td style="max-width: 15em;">
                 <input class="form-control"
@@ -127,7 +127,7 @@
                 <span class="crm-inline-error" ng-show="creditnotesForm.financial_type_{{$index}}.$dirty && creditnotesForm.financial_type_{{$index}}.$invalid && creditnotesForm.financial_type_{{$index}}.$error.required">Financial Type is required</span>
               </td>
               <td>
-                <input type="number" min="0" name="quantity_{{$index}}" required placeholder="Quantity" ng-model="creditnotes.items[$index].quantity" class="form-control" ng-change="calculateSubtotal($index)" style="width: 6em" step="0.01" />
+                <input type="number" min="0" name="quantity_{{$index}}" required placeholder="Quantity" ng-model="creditnotes.items[$index].quantity" class="form-control" ng-change="calculateSubtotal($index)" style="width: 6em" step="0.0001" />
                 <br />
                 <span class="crm-inline-error" ng-show="creditnotesForm.quantity_{{$index}}.$dirty && (creditnotesForm.quantity_{{$index}}.$invalid || creditnotesForm.quantity_{{$index}}.$error.required)">Quantity is invalid</span>
               </td>
@@ -139,10 +139,12 @@
                 <br />
                 <span class="crm-inline-error" ng-show="creditnotesForm.unit_price_{{$index}}.$dirty && (creditnotesForm.unit_price_{{$index}}.$invalid || creditnotesForm.unit_price_{{$index}}.$error.required)">Unit price is invalid</span>
               </td>
-              <td>
-                {{ roundTo(creditnotes.items[$index].tax_rate, 4) }}
+              <td style="width: 10em">
+                <input type="text" value="{{ creditnotes.items[$index].tax_rate > 0 ? roundTo(creditnotes.items[$index].tax_rate, 4) : '' }}" class="form-control" disabled>
               </td>
-              <td>{{ formatMoney(creditnotes.items[$index].subtotal_amount, creditnotes.currency) }}</td>
+              <td style="width: 10em">
+                <input type="text" value="{{ formatMoney(creditnotes.items[$index].line_total, creditnotes.currency) }}" class="form-control" disabled>
+              </td>
               <td><a ng-if="creditnotes.items.length > 1" href ng-click="removeCreditnotesItem($index)" ><i class="fa fa-trash"></i></a></td>
             </tr>
            </table>
@@ -158,11 +160,11 @@
         <div class="form-group">
           <div class="col-sm-7">
             <div class="row">
-                <div class="col-sm-3 pull-right">
+                <div class="col-sm-4 pull-right">
                   <table class="table">
                     <tr><th>Subtotal</th><td>{{ currencySymbol }} {{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
                       <tr ng-repeat="i in taxRates">
-                        <th>Tax @ {{ i.rate }}%</th>
+                        <th>*{{ i.tax_name }} @ {{ i.rate }}%</th>
                         <td>{{ currencySymbol }} {{ formatMoney(i.value, creditnotes.currency) }}</td>
                       </tr>
                     <tr><th>Total</th><td>{{ currencySymbol }} {{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>

--- a/ang/fe-creditnote/services/currency-codes.service.js
+++ b/ang/fe-creditnote/services/currency-codes.service.js
@@ -1,0 +1,28 @@
+(function (angular, $, _, CRM) {
+  var module = angular.module('fe-creditnote');
+
+  module.service('CurrencyCodes', CurrencyCodes);
+
+  /**
+   * CurrencyCodes Service
+   */
+  function CurrencyCodes () {
+    this.getAll = function () {
+      return CRM['fe-creditnote'].currencyCodes;
+    };
+
+    this.getSymbol = function (name) {
+      return CRM['fe-creditnote']
+        .currencyCodes
+        .filter(currency => currency.name === name)
+        .pop().symbol || '£';
+    };
+
+    this.getFormat = function (name) {
+      return CRM['fe-creditnote']
+        .currencyCodes
+        .filter(currency => currency.name === name)
+        .pop().format || null;
+    };
+  }
+})(angular, CRM.$, CRM._, CRM);

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/ComputeTotalActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/ComputeTotalActionTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+
+/**
+ * CreditNote.ComputeTotalAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CreditNote_ComputeTotalActionTest extends BaseHeadlessTest {
+
+  use CreditNoteTrait;
+
+  /**
+   * Test credit note compute action returns expected fields.
+   */
+  public function testComputeTotalActionReturnsExpectedFields() {
+    $items = [];
+    $items[] = $this->getCreditNoteLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10, 'tax_name' => 'taxes']
+    );
+    $items[] = $this->getCreditNoteLineData(
+      ['quantity' => 5, 'unit_price' => 10]
+    );
+
+    $computedTotal = CreditNote::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertArrayHasKey('taxRates', $computedTotal);
+    $this->assertArrayHasKey('totalBeforeTax', $computedTotal);
+    $this->assertArrayHasKey('totalAfterTax', $computedTotal);
+  }
+
+  /**
+   * Test credit note total is calculated appropraitely.
+   */
+  public function testComputeTotalActionReturnsExpectedTotal() {
+    $items = [];
+    $items[] = $this->getCreditNoteLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10, 'tax_name' => 'taxes']
+    );
+    $items[] = $this->getCreditNoteLineData(
+      ['quantity' => 5, 'unit_price' => 10]
+    );
+
+    $computedTotal = CreditNote::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertEquals($computedTotal['totalBeforeTax'], 150);
+    $this->assertEquals($computedTotal['totalAfterTax'], 160);
+  }
+
+  /**
+   * Test credit note tax rates is computed as epxected.
+   */
+  public function testComputeTotalActionReturnsExpectedTaxRates() {
+    $items = [];
+    $items[] = $this->getCreditNoteLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10, 'tax_name' => 'taxes']
+    );
+    $items[] = $this->getCreditNoteLineData(
+      ['quantity' => 5, 'unit_price' => 10, 'tax_rate' => 2, 'tax_name' => 'taxes']
+    );
+
+    $computedTotal = CreditNote::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertNotEmpty($computedTotal['taxRates']);
+    $this->assertCount(2, $computedTotal['taxRates']);
+
+    // Ensure the tax rates are sorted in ascending order of rate.
+    $this->assertEquals($computedTotal['taxRates'][0]['rate'], 2);
+    $this->assertEquals($computedTotal['taxRates'][0]['value'], 1);
+    $this->assertEquals($computedTotal['taxRates'][1]['rate'], 10);
+    $this->assertEquals($computedTotal['taxRates'][1]['value'], 10);
+  }
+
+  /**
+   * Test compute action doesn't throw error for empty line items.
+   */
+  public function testComputeTotalActionReturnsEmptyResultForEmptyLineItems() {
+    $items = [];
+
+    $computedTotal = CreditNote::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertArrayHasKey('taxRates', $computedTotal);
+    $this->assertArrayHasKey('totalBeforeTax', $computedTotal);
+    $this->assertArrayHasKey('totalAfterTax', $computedTotal);
+
+    $this->assertEmpty($computedTotal['taxRates']);
+    $this->assertEmpty($computedTotal['totalAfterTax']);
+    $this->assertEmpty($computedTotal['totalBeforeTax']);
+  }
+
+}

--- a/tests/phpunit/Civi/Financeextras/Test/Helper/CreditNoteTrait.php
+++ b/tests/phpunit/Civi/Financeextras/Test/Helper/CreditNoteTrait.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Civi\Financeextras\Test\Helper;
+
+use Civi\Api4\CreditNote;
+use Civi\Api4\OptionValue;
+use Civi\Financeextras\Test\Fabricator\ContactFabricator;
+
+/**
+ * Credit note helper trait.
+ */
+trait CreditNoteTrait {
+
+  /**
+   * Returns list of available statuses.
+   *
+   * @return array
+   *   Array of credit note statuses
+   */
+  public function getCreditNoteStatus() {
+    $status = OptionValue::get()
+      ->addSelect('id', 'value', 'name', 'label')
+      ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_status')
+      ->execute();
+
+    return $status;
+  }
+
+  /**
+   * Returns fabricated crdit note data.
+   *
+   * @param array $default
+   *   Default value.
+   *
+   * @return array
+   *   Key-Value pair of a crdit note fields and values
+   */
+  public function getCreditNoteData(array $default = []) {
+    $client = ContactFabricator::fabricate();
+
+    return array_merge([
+      'contact_id' => $client['id'],
+      'cn_number' => NULL,
+      'reference' => 'NILO',
+      'currency' => 'GBP',
+      'status_id' => $this->getCreditNoteStatus()[0]['value'],
+      'description' => 'test',
+      'comment' => 'test',
+      'tax' => 0,
+      'subtotal' => 0,
+      'total_credit' => 0,
+      'date' => '2022-08-09',
+      'items' => [],
+    ], $default);
+  }
+
+  /**
+   * Returns fabricated credit note line data.
+   *
+   * @param array $default
+   *   Default value.
+   *
+   * @return array
+   *   Key-Value pair of a credit note line item fields and values
+   */
+  public function getCreditNoteLineData(array $default = []) {
+    $quantity = rand(2, 9);
+    $unitPrice = rand(50, 1000);
+
+    return array_merge([
+      'financial_type_id' => 1,
+      'description' => 'test',
+      'quantity' => $quantity,
+      'unit_price' => $unitPrice,
+      'tax_rate' => 0,
+      'line_total' => $quantity * $unitPrice,
+    ], $default);
+  }
+
+  /**
+   * Creates credit note.
+   *
+   * @param array $params
+   *   Extra paramters.
+   *
+   * @return array
+   *   Created credit note
+   */
+  public function createCreditNote(array $params = []): array {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    if (!empty($params['items']['tax_rate'])) {
+      $creditNote['items'][0]['tax_rate'] = $params['items']['tax_rate'];
+    }
+
+    $creditNote['id'] = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    return $creditNote;
+  }
+
+}


### PR DESCRIPTION
## Overview
This pull request introduces the following changes as a sequel to this PR https://github.com/compucorp/io.compuco.financeextras/pull/28:
 - Pass available currency to credit note view via a provider.
- Compute tax rates and total on total change when creating a credit note.

## Before
The credit note line items' total amount was not calculated in real-time.

## After
The credit note line items' total amount is calculated in real-time.
![44545](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/3edb4230-feea-4c6c-b967-55b3c6fb23bd)

## Technical Details
An additional API endpoint action, named `ComputeTotalAction`, was introduced in the Credit Note entity. This action is designed to facilitate the recalculation of the total amount when a user makes changes that affect the overall amount. These changes can include modifying the quantity of a line item or selecting a different financial type.

The `ComputeTotalAction` requires an array of line items as input and provides an output that consists of the following elements: an array of tax rates, along with the values for totalBeforeTax and totalAfterTax.

