### PR TITLE
CIWEMB-289: Save Credit Note and create financial accounting entries

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteLine.php
+++ b/CRM/Financeextras/BAO/CreditNoteLine.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Financeextras\Utils\FinancialAccountUtils;
+
 class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditNoteLine {
 
   /**
@@ -20,6 +22,91 @@ class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditN
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
+  }
+
+  /**
+   * Creates credit note line items and their corresponding accounting entry.
+   *
+   * @param array $items
+   *  Array of line items.
+   *
+   * @param array $creditNote
+   *  The credit note entity to create line items for
+   *
+   * @param array $financialTrxn
+   *  The credit note financial transaction entity.
+   *
+   * @return array
+   *   Created line items.
+   */
+  public static function createWithAcountingEntries($items, $creditNote, $financialTrxn) {
+    $result = [];
+    array_walk($items, function (&$lineItem) use ($creditNote, $financialTrxn, &$result) {
+      $lineTotal = $lineItem['unit_price'] * $lineItem['quantity'];
+      $lineItemParams = [
+        'credit_note_id' => $creditNote['id'],
+        'description' => $lineItem['description'],
+        'quantity' => $lineItem['quantity'],
+        'unit_price' => $lineItem['unit_price'],
+        'tax_amount' => empty($lineItem['tax_rate']) ? 0 : self::calculateTaxAmount($lineItem['tax_rate'], $lineTotal),
+        'line_total' => $lineTotal,
+        'financial_type_id' => $lineItem['financial_type_id'],
+      ];
+
+      $lineItem = self::create($lineItemParams)->toArray();
+      self::createAccountingEntries($lineItem, $creditNote, $financialTrxn);
+
+      $result[] = $lineItem;
+    });
+
+    return $result;
+  }
+
+  private static function createAccountingEntries($lineItem, $creditNote, $financialTrxn) {
+    $incomeAccount = FinancialAccountUtils::getFinancialTypeAccount($lineItem['financial_type_id'], 'Income Account is');
+    $itemParams = [
+      'transaction_date' => $creditNote['date'],
+      'contact_id' => $creditNote['contact_id'],
+      'currency' => $creditNote['currency'],
+      'amount' => ($lineItem['quantity'] * $lineItem['unit_price']) * -1,
+      'description' => $lineItem['description'],
+      'status_id' => 'Unpaid',
+      'financial_account_id' => $incomeAccount,
+      'entity_table' => \CRM_Financeextras_DAO_CreditNoteLine::$_tableName,
+      'entity_id' => $lineItem['id'],
+    ];
+    \CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $financialTrxn);
+
+    if (!empty($lineItem['tax_amount']) && $lineItem['tax_amount'] > 0) {
+      $taxAccount = FinancialAccountUtils::getFinancialTypeAccount($lineItem['financial_type_id'], 'Sales Tax Account is');
+      $taxAccountDesc = \Civi\Api4\FinancialAccount::get()
+        ->addSelect('description')
+        ->addWhere('id', '=', $taxAccount)
+        ->execute()
+        ->first()['description'] ?? "";
+
+      $itemParams['amount'] = $lineItem['tax_amount'] * -1;
+      $itemParams['financial_account_id'] = $taxAccount;
+      $itemParams['description'] = $lineItem['description'] . " - " . $taxAccountDesc;
+      \CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $financialTrxn);
+    }
+  }
+
+  /**
+   * Calculates the percentage tax amount.
+   *
+   * E.g. 5% of 10.
+   *
+   * @param float $percentage
+   *   Percentage to calculate.
+   * @param float $value
+   *   The value to get percentage of.
+   *
+   * @return float
+   *   Calculated Percentage in float
+   */
+  private static function calculateTaxAmount(float $percentage, float $value) {
+    return (floatval($percentage) / 100) * floatval($value);
   }
 
 }

--- a/Civi/Api4/Action/CreditNote/CreditNoteSaveAction.php
+++ b/Civi/Api4/Action/CreditNote/CreditNoteSaveAction.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNote;
+
+use CRM_Core_Transaction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\AbstractSaveAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use CRM_Financeextras_BAO_CreditNote as CreditNoteBAO;
+use CRM_Financeextras_BAO_CreditNoteLine as CreditNoteLineBAO;
+
+/**
+ * {@inheritDoc}
+ */
+class CreditNoteSaveAction extends AbstractSaveAction {
+  use DAOActionTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    foreach ($this->records as &$record) {
+      $record += $this->defaults;
+      $this->formatWriteValues($record);
+      $this->matchExisting($record);
+      if (empty($record['id'])) {
+        $this->fillDefaults($record);
+      }
+    }
+    $this->validateValues();
+
+    $resultArray = $this->writeRecord($this->records);
+
+    $result->exchangeArray($resultArray);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function writeRecord($items) {
+    $transaction = CRM_Core_Transaction::create();
+
+    try {
+      $output = [];
+      foreach ($items as $creditNote) {
+        $output[] = $this->createCreditNoteWithAccountingEntries($creditNote);
+      }
+
+      return $output;
+    }
+    catch (\Exception $e) {
+      $transaction->rollback();
+
+      throw $e;
+    }
+  }
+
+  /**
+   * Creates new Credit note entity with financial entities
+   *
+   * @param array $data
+   *  The credit note param
+   *
+   * @return array
+   *   created credit note entity
+   */
+  public function createCreditNoteWithAccountingEntries(array $data) {
+    $result = $this->createCreditNote($data);
+    $creditNote = $result['creditNote'];
+    $financialTrxn = $result['financialTrxn'];
+
+    if (!empty($creditNote) && !empty($data['items'])) {
+      $creditNote['items'] = CreditNoteLineBAO::createWithAcountingEntries($data['items'], $creditNote, $financialTrxn);
+    }
+
+    return $creditNote;
+  }
+
+  /**
+   * Creates credit note entity
+   *
+   * @param array $data
+   *  The credit note params
+   *
+   * @return array
+   *   created credit note entity
+   */
+  private function createCreditNote(array $data) {
+    $optionValues = \Civi\Api4\OptionValue::get()
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_status')
+      ->addWhere('name', '=', 'open')
+      ->execute();
+    $data['status_id'] = $optionValues->first()['value'];
+
+    $total = CreditNoteBAO::computeTotalAmount($data['items']);
+    $data['subtotal'] = $total['totalBeforeTax'];
+    $data['total_credit'] = $total['totalAfterTax'];
+    $data['sales_tax'] = array_sum(array_column($total['taxRates'], 'value'));
+
+    $finacialTypeId = $data['items'][0]['financial_type_id'];
+
+    return CreditNoteBAO::createWithAccountingEntries($data, $finacialTypeId);
+  }
+
+}

--- a/Civi/Financeextras/Utils/FinancialAccountUtils.php
+++ b/Civi/Financeextras/Utils/FinancialAccountUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Civi\Financeextras\Utils;
+
+class FinancialAccountUtils {
+
+  /**
+   * Returns the Financial Account for a Financial Type By Name
+   *
+   * @param int $financialTypeId
+   *  The Financial Type to get account for.
+   *
+   * @param string $accountName
+   *  The name of the account to be retrieved
+   *
+   * @return int
+   *   The account ID
+   */
+  public static function getFinancialTypeAccount($financialTypeId, $accountName) {
+    return \CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $financialTypeId,
+      $accountName
+    );
+  }
+
+}

--- a/ang/fe-creditnote.ang.php
+++ b/ang/fe-creditnote.ang.php
@@ -3,6 +3,7 @@
 // in CiviCRM. See also:
 // \https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules/n
 
+use Civi\Api4\OptionValue;
 use Civi\Financeextras\Utils\CurrencyUtils;
 
 $options = [];
@@ -14,7 +15,20 @@ function financeextras_set_currency_codes(&$options) {
   $options['currencyCodes'] = CurrencyUtils::getCurrencies();
 }
 
+/**
+ * Exposes credit note statuses to Angular.
+ */
+function financeextras_set_credit_note_status(&$options) {
+  $optionValues = OptionValue::get()
+    ->addSelect('id', 'value', 'name', 'label')
+    ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_status')
+    ->execute();
+
+  $options['creditNoteStatus'] = $optionValues->getArrayCopy();
+}
+
 financeextras_set_currency_codes($options);
+financeextras_set_credit_note_status($options);
 
 return [
   'js' => [

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -30,8 +30,9 @@
    * @param {object} CurrencyCodes CurrencyCodes service
    * @param {object} crmUiHelp crm ui help service
    * @param {object} crmApi4 crm api V4 service
+   * @param {object} CreditNoteStatus service
    */
-  function creditnoteCreateController ($scope, $location, $window, CurrencyCodes, crmUiHelp, crmApi4) {
+  function creditnoteCreateController ($scope, $location, $window, CurrencyCodes, crmUiHelp, crmApi4, CreditNoteStatus) {
     const defaultCurrency = 'GBP';
     $scope.isUpdate = false;
     $scope.formValid = true;
@@ -64,6 +65,7 @@
         currency: defaultCurrency,
         contact_id: null,
         date: $.datepicker.formatDate('yy-mm-dd', new Date()),
+        status_id: CreditNoteStatus.getValueByName('open'),
         items: [{
           description: null,
           financial_type_id: null,

--- a/ang/fe-creditnote/services/credit-note-status.service.js
+++ b/ang/fe-creditnote/services/credit-note-status.service.js
@@ -1,0 +1,22 @@
+(function (angular, $, _, CRM) {
+  var module = angular.module('fe-creditnote');
+
+  module.service('CreditNoteStatus', CreditNoteStatus);
+
+  /**
+   * CreditNoteStatus Service
+   */
+  function CreditNoteStatus () {
+    this.getAll = function () {
+      return CRM['fe-creditnote'].creditNoteStatus;
+    };
+
+    this.getValueByName = function (name) {
+      console.log(CRM['fe-creditnote'])
+      return CRM['fe-creditnote']
+        .creditNoteStatus
+        .filter(status => status.name === name)
+        .pop().value || '';
+    };
+  }
+})(angular, CRM.$, CRM._, CRM);

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
@@ -1,0 +1,274 @@
+<?php
+
+use Civi\Api4\CreditNoteLine;
+use Civi\Api4\CreditNote;
+use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+use CRM_Financeextras_BAO_CreditNote as CreditNoteBAO;
+
+/**
+ * CreditNote.CreditNoteSaveAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CreditNote_CreditNoteSaveActionTest extends BaseHeadlessTest {
+
+  use CreditNoteTrait;
+
+  /**
+   * Test credit note and line item can be saved with the save action.
+   */
+  public function testCanSaveCreditNote() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNote['total_credit'] = CreditNoteBAO::computeTotalAmount($creditNote['items'])['totalAfterTax'];
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    $results = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->jsonSerialize();
+
+    $this->assertNotEmpty($results);
+    foreach (['contact_id', 'comment', 'total_credit', 'reference'] as $key) {
+      $this->assertEquals($creditNote[$key], $results[0][$key]);
+    }
+  }
+
+  /**
+   * Test credit note and line item can be saved with the save action.
+   */
+  public function testCanSaveCreditNoteAndLineItems() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    $results = CreditNoteLine::get()
+      ->addWhere('credit_note_id', '=', $creditNoteId)
+      ->execute()
+      ->jsonSerialize();
+
+    $this->assertCount(2, $results);
+    foreach ($results as $result) {
+      $this->assertEquals($result['credit_note_id'], $creditNoteId);
+    }
+  }
+
+  /**
+   * Test credit note total is calculated appropraitely.
+   */
+  public function testSaveCreditNoteTotalIsCorrect() {
+    $creditNoteData = $this->getCreditNoteData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10]
+    );
+    $creditNoteData['items'][] = $this->getCreditNoteLineData(
+      ['quantity' => 5, 'unit_price' => 10]
+    );
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    $creditNote = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertEquals($creditNote['subtotal'], 150);
+    $this->assertEquals($creditNote['total_credit'], 160);
+  }
+
+  /**
+   * Test credit note save action updates credit note as expected.
+   */
+  public function testCreditNoteIsUpdatedWithSaveAction() {
+    $creditNoteData = $this->getCreditNoteData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData();
+
+    // Create credit note.
+    $creditNote = CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    // Update credit note.
+    $creditNoteData['id'] = $creditNote['id'];
+    $creditNoteData['items'] = $creditNote['items'];
+    $creditNoteData['comment'] = substr(md5(mt_rand()), 0, 7);
+    $creditNoteData['description'] = substr(md5(mt_rand()), 0, 7);
+    CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    // Assert that credit note was updated.
+    $updatedSalesOrder = CreditNote::get()
+      ->addWhere('id', '=', $creditNote['id'])
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertEquals($creditNoteData['id'], $updatedSalesOrder['id']);
+    $this->assertEquals($creditNoteData['comment'], $updatedSalesOrder['comment']);
+    $this->assertEquals($creditNoteData['description'], $updatedSalesOrder['description']);
+  }
+
+  /**
+   * Tests that the expected accounting entries are created for the credit note.
+   *
+   * For a credit note entity:
+   *  A Finacial trnasaction should be created.
+   *  A Entity Financial transaction linked to credit note  should be created.
+   */
+  public function testExpectedAccountingEntriesAreCreatedForCrediNote() {
+    $creditNoteData = $this->getCreditNoteData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData();
+
+    $expectedToAccount = \CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $creditNoteData['items'][0]['financial_type_id'],
+      'Accounts Receivable Account is'
+    );
+
+    // Create credit note.
+    $creditNote = CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_id', '=', $creditNote['id'])
+      ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNote::$_tableName)
+      ->execute()
+      ->first();
+
+    $this->assertNotEmpty($entityFinancialTrxn);
+
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('id', '=', $entityFinancialTrxn['financial_trxn_id'])
+      ->addWhere('total_amount', '=', $creditNote['total_credit'] * -1)
+      ->addWhere('status_id:name', '=', 'Pending')
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('check_number', 'IS NULL')
+      ->addWhere('currency', '=', $creditNote['currency'])
+      ->addWhere('to_financial_account_id', '=', $expectedToAccount)
+      ->addWhere('is_payment', '=', FALSE)
+      ->execute()
+      ->first();
+
+    $this->assertNotEmpty($financialTrxn);
+  }
+
+  /**
+   * Tests that the expected accounting entries are created for the credit note line items.
+   *
+   * For each credit note line entity:
+   *  A Financial Item should be created.
+   *  A Entity Financial transaction linking to financial item should be created.
+   */
+  public function testExpectedAccountingEntriesAreCreatedForCrediNoteLine() {
+    $creditNoteData = $this->getCreditNoteData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData();
+
+    // Create credit note.
+    $creditNote = CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->first();
+
+    foreach ($creditNote['items'] as $lineItem) {
+      // Credit note line item a financial item should be created.
+      $financialItem = \Civi\Api4\FinancialItem::get(FALSE)
+        ->addWhere('entity_id', '=', $lineItem['id'])
+        ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNoteLine::$_tableName)
+        ->execute()
+        ->first();
+
+      $this->assertNotEmpty($financialItem);
+      $this->assertEquals($financialItem['amount'] * -1, $lineItem['quantity'] * $lineItem['unit_price']);
+      $this->assertEquals($financialItem['contact_id'], $creditNote['contact_id']);
+      $this->assertEquals($financialItem['currency'], $creditNote['currency']);
+
+      // Financial item should have a entity financial transaction.
+      $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+        ->addWhere('entity_id', '=', $financialItem['id'])
+        ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+        ->execute()
+        ->first();
+
+      $this->assertNotEmpty($entityFinancialTrxn);
+    }
+  }
+
+  /**
+   * Tests that the expected accounting entries are created for the credit note line items with tax.
+   *
+   * For each credit note line entity with tax:
+   *  A Financial Item should be created for the amount - tax.
+   *  A Entity Financial transaction linking to financial item of the amount - tax should be created.
+   *
+   *  A Financial Item should be created for the tax amount.
+   *  A Entity Financial transaction linking to financial item of the tax amount should be created.
+   */
+  public function testExpectedAccountingEntriesAreCreatedForCrediNoteLineWithTax() {
+    $creditNoteData = $this->getCreditNoteData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData(['tax_rate' => 10]);
+    $creditNoteData['items'][] = $this->getCreditNoteLineData(['tax_rate' => 15]);
+
+    // Create credit note.
+    $creditNote = CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->first();
+
+    foreach ($creditNote['items'] as $lineItem) {
+      // Financial item should be created for Credit note line item.
+      $financialItemAPI = \Civi\Api4\FinancialItem::get(FALSE)
+        ->addWhere('entity_id', '=', $lineItem['id'])
+        ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNoteLine::$_tableName)
+        ->addWhere('currency', '=', $creditNote['currency'])
+        ->addWhere('contact_id', '=', $creditNote['contact_id']);
+
+      $all = \Civi\Api4\FinancialItem::get(FALSE)
+        ->addWhere('entity_id', '=', $lineItem['id'])
+        ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNoteLine::$_tableName)
+        ->addWhere('currency', '=', $creditNote['currency'])
+        ->addWhere('contact_id', '=', $creditNote['contact_id'])->execute();
+
+      $financialItemForMainAmount = (clone $financialItemAPI)->addWhere('amount', '=', ($lineItem['quantity'] * $lineItem['unit_price']) * -1)
+        ->execute()
+        ->first();
+      $this->assertNotEmpty($financialItemForMainAmount);
+
+      $financialItemForTax = (clone $financialItemAPI)->addWhere('amount', '=', $lineItem['tax_amount'] * -1)
+        ->execute()
+        ->first();
+      $this->assertNotEmpty($financialItemForTax);
+
+      foreach ([$financialItemForMainAmount, $financialItemForTax] as $financialItem) {
+        $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+          ->addWhere('entity_id', '=', $financialItem['id'])
+          ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+          ->execute()
+          ->first();
+
+        // Financial item should have a entity financial transaction.
+        $this->assertNotEmpty($entityFinancialTrxn);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
This pull request adds an endpoint to save a Credit Note. 

## Before
Before this pull request, there was no specific implementation for saving credit notes.

## After
Credit notes are persisted to DB, and the expected financial accounting entries are credited.

## Technical Details
A new Credit Note API action `CreditNoteSaveAction` is introduced in this PR for saving credit notes as a follow-up to this PR https://github.com/compucorp/io.compuco.financeextras/pull/28.

For accounting purposes when a new credit note is created,  the following financial accounting entries are also created :

- A Financial Transaction record for the Credit Note.
  - A Entity Financial Transaction for the Credit Note Financial Transaction.
- A Financial Item entity record is created for each credit note line item (Without tax amount).
  - A Entity Financial Transaction for the Financial Item.
 - A Financial Item entity record is created for each credit note line item tax.
   - A Entity Financial Transaction for the Financial Item.

Additionally, tests are added to ensure that credit notes are created appropriately.