### PR TITLE
CIWEMB-286: Return credit note allocated and remaining credit via API

### DIFF
--- a/Civi/Api4/Action/CreditNote/GetAction.php
+++ b/Civi/Api4/Action/CreditNote/GetAction.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNote;
+
+use Civi\Api4\Generic\DAOGetAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ * {@inheritDoc}
+ */
+class GetAction extends DAOGetAction {
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  protected function getObjects(Result $result) {
+    parent::getObjects($result);
+
+    if ($result->count() > 0) {
+      $items = $result->getArrayCopy();
+
+      foreach ($items as &$item) {
+        $allocatedCredits = $this->getAllocations($item['id']);
+        $item = array_merge($item, $allocatedCredits);
+
+        if (!empty($item['total_credit'])) {
+          $item['remaining_credit'] = $item['total_credit'] - array_sum($allocatedCredits);
+        }
+      }
+
+      $result->exchangeArray($items);
+    }
+  }
+
+  private function getAllocations($id) {
+    $allocations = \Civi\Api4\CreditNoteAllocation::get()
+      ->addSelect('*', 'type_id:name')
+      ->addWhere('credit_note_id', '=', $id)
+      ->execute()
+      ->getArrayCopy();
+
+    $allocatedInvoices = array_filter($allocations, fn ($allocation) => $allocation['type_id:name'] == 'invoice');
+    $allocatedManualRefunds = array_filter($allocations, fn ($allocation) => $allocation['type_id:name'] == 'manual_refund_payment');
+    $allocatedOnlineRefunds = array_filter($allocations, fn ($allocation) => $allocation['type_id:name'] == 'online_refund_payment');
+
+    return [
+      'allocated_invoice' => array_sum(array_column($allocatedInvoices, 'amount')),
+      'allocated_manual_refund' => array_sum(array_column($allocatedManualRefunds, 'amount')),
+      'allocated_online_refund' => array_sum(array_column($allocatedOnlineRefunds, 'amount')),
+    ];
+  }
+
+}

--- a/Civi/Api4/CreditNote.php
+++ b/Civi/Api4/CreditNote.php
@@ -5,6 +5,7 @@ namespace Civi\Api4;
 use Civi\Api4\Action\CreditNote\ComputeTotalAction;
 use Civi\Api4\Action\CreditNote\CreditNoteSaveAction;
 use Civi\Api4\Action\CreditNote\DeleteWithItemsAction;
+use Civi\Api4\Action\CreditNote\GetAction;
 
 /**
  * CreditNote entity.
@@ -54,6 +55,17 @@ class CreditNote extends Generic\DAOEntity {
    */
   public static function deleteWithItems($checkPermissions = TRUE) {
     return (new DeleteWithItemsAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param bool $checkPermissions
+   * @return DAOGetAction
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new GetAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/GetActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/GetActionTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+
+/**
+ * CreditNote.CreditNoteGetAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CreditNote_GetActionTest extends BaseHeadlessTest {
+
+  use CreditNoteTrait;
+
+  public function testCreditNoteGetReturnsIncludeAllocatedFields() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $result = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $this->assertArrayHasKey('allocated_invoice', $result);
+    $this->assertArrayHasKey('allocated_manual_refund', $result);
+    $this->assertArrayHasKey('allocated_online_refund', $result);
+    $this->assertArrayHasKey('remaining_credit', $result);
+  }
+
+  public function testCreditNoteGetReturnsExpectedAllocatedInvoice() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $otherCreditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $this->allocateToCreditNote($creditNoteId, 'invoice', 200);
+    $this->allocateToCreditNote($creditNoteId, 'invoice', 300);
+    $this->allocateToCreditNote($otherCreditNoteId, 'invoice', 200);
+
+    $result = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $this->assertEquals($result['allocated_invoice'], 500);
+  }
+
+  public function testCreditNoteGetReturnsExpectedAllocatedManualRefund() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $otherCreditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $this->allocateToCreditNote($creditNoteId, 'manual_refund_payment', 200);
+    $this->allocateToCreditNote($creditNoteId, 'manual_refund_payment', 100);
+    $this->allocateToCreditNote($otherCreditNoteId, 'manual_refund_payment', 200);
+
+    $result = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $this->assertEquals($result['allocated_manual_refund'], 300);
+  }
+
+  public function testCreditNoteGetReturnsExpectedAllocatedOnlineRefund() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $otherCreditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $this->allocateToCreditNote($creditNoteId, 'online_refund_payment', 200);
+    $this->allocateToCreditNote($creditNoteId, 'online_refund_payment', 200);
+    $this->allocateToCreditNote($otherCreditNoteId, 'online_refund_payment', 200);
+
+    $result = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $this->assertEquals($result['allocated_online_refund'], 400);
+  }
+
+  public function testCreditNoteGetReturnsExpectedRemainingCredit() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData(['quantity' => 2, 'unit_price' => 600]);
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $otherCreditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $this->allocateToCreditNote($creditNoteId, 'invoice', 100);
+    $this->allocateToCreditNote($creditNoteId, 'online_refund_payment', 200);
+    $this->allocateToCreditNote($creditNoteId, 'manual_refund_payment', 300);
+    $this->allocateToCreditNote($otherCreditNoteId, 'online_refund_payment', 200);
+
+    $result = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $this->assertEquals($result['remaining_credit'], 600);
+  }
+
+  public function testCreditNoteGetNotIncludeRemainingCreditWithoutTotalCredit() {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData();
+
+    $creditNoteId = CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first()['id'];
+
+    $this->allocateToCreditNote($creditNoteId, 'invoice', 100);
+
+    $result = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->addSelect('id')
+      ->execute()
+      ->first();
+
+    $this->assertArrayHasKey('allocated_invoice', $result);
+    $this->assertArrayHasKey('allocated_manual_refund', $result);
+    $this->assertArrayHasKey('allocated_online_refund', $result);
+    $this->assertArrayNotHasKey('remaining_credit', $result);
+  }
+
+  private function allocateToCreditNote($creditNoteId, $allocationType, $amount) {
+    $type = \Civi\Api4\OptionValue::get()
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_allocation_type')
+      ->addWhere('name', '=', $allocationType)
+      ->execute()
+      ->first()['value'];
+
+    \Civi\Api4\CreditNoteAllocation::create()
+      ->addValue('credit_note_id', $creditNoteId)
+      ->addValue('type_id', $type)
+      ->addValue('currency', 'GBP')
+      ->addValue('amount', $amount)
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
## Overview
This pull request adds functionality to return the credit note allocated and the remaining credit via API.

## Before
Currently, the Credit Note Get API does not provide information about the allocated and remaining credit for credit notes.

```php
[
  {
    "id": 2,
    "contact_id": 2,
    "cn_number": null,
    "date": "2023-06-06",
    "status_id": 1,
    "reference": "Licom po...",
    "currency": "GBP",
    "description": "<p>Police Profile drut</p>",
    "comment": "Police",
    "subtotal": 408,
    "sales_tax": 0,
    "total_credit": 408,
  }
]
```

## After
With this pull request, the Credit Note Get API is enhanced to include the allocated and remaining credit for credit notes. 

```php
[
  {
    "id": 2,
    "contact_id": 2,
    "cn_number": null,
    "date": "2023-06-06",
    "status_id": 1,
    "reference": "Licom po...",
    "currency": "GBP",
    "description": "<p>Police Profile drut</p>",
    "comment": "Police",
    "subtotal": 408,
    "sales_tax": 0,
    "total_credit": 408,
    "allocated_invoice": 0,
    "allocated_manual_refund": 0,
    "allocated_online_refund": 0,
    "remaining_credit": 408
  }
]
```

## Technical Details
The `Civi\Api4\Action\CreditNote\GetAction` class was extended to handle the logic for retrieving the allocations and calculating the remaining credit. 

It is known that if the `total_credit` field is explicitly excluded from the API response using the select method, the `remaining_credit` field will also be excluded.