### PR TITLE
CIWEMB-300: User can allocate credit notes to invoices

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Api4\CreditNote;
 use Civi\Financeextras\Utils\OptionValueUtils;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
 use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager as CreditNoteStatus;
@@ -180,6 +181,27 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
     $trxn->deleteRecord(['id' => $entityTrxn->financial_trxn_id]);
 
     $entityTrxn->delete();
+  }
+
+  /**
+   * Updates a cedit note status appropraitely post allocation
+   *
+   * @param int $creditNoteId
+   *  The credit note for which allocation was made.
+   */
+  public static function updateCreditNoteStatusPostAllocation($creditNoteId) {
+    $creditNote = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->addWhere('status_id:name', '=', 'open')
+      ->execute()
+      ->first();
+
+    if (!empty($creditNote) && $creditNote['remaining_credit'] <= 0) {
+      \Civi\Api4\CreditNote::update()
+        ->addValue('status_id:name', 'fully_allocated')
+        ->addWhere('id', '=', $creditNoteId)
+        ->execute();
+    }
   }
 
 }

--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -1,4 +1,6 @@
 <?php
+
+use Civi\Financeextras\Utils\FinancialAccountUtils;
 use CRM_Financeextras_ExtensionUtil as E;
 
 class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_CreditNoteAllocation {
@@ -8,19 +10,77 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
    *
    * @param array $params key-value pairs
    * @return CRM_Financeextras_DAO_CreditNoteAllocation|NULL
+   */
+  public static function create($params) {
+    $className = 'CRM_Financeextras_DAO_CreditNoteAllocation';
+    $entityName = 'CreditNoteAllocation';
+    $hook = empty($params['id']) ? 'create' : 'edit';
+
+    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    $instance = new $className();
+    $instance->copyValues($params);
+    $instance->save();
+    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
+
+    return $instance;
+  }
+
+  /**
+   * Creates and Records the credit note allocation as payment.
    *
-   * public static function create($params) {
-   * $className = 'CRM_Financeextras_DAO_CreditNoteAllocation';
-   * $entityName = 'CreditNoteAllocation';
-   * $hook = empty($params['id']) ? 'create' : 'edit';
+   * @param array $data
+   *  Credit note allocation data.
    *
-   * CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-   * $instance = new $className();
-   * $instance->copyValues($params);
-   * $instance->save();
-   * CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
+   * @return array
+   *   New credit note created object as array
    *
-   * return $instance;
-   * } */
+   */
+  public static function createWithAccountingEntries($data) {
+    $creditNoteAllocation = self::create($data)->toArray();
+
+    self::createAccountingEntries($data['credit_note_id'], $data['contribution_id'], $data['amount']);
+
+    return $creditNoteAllocation;
+  }
+
+  /**
+   * Creates the neccessary accounting entries using Payment API.
+   *
+   * @param int $creditNoteId
+   *  The credit note credit is to be allocated from.
+   *
+   * @param int $contributionId
+   *  Unique identifier of the contribtuion to allocated credit to.
+   *
+   * @param float $amount
+   *  The amount to be allocated.
+   */
+  private static function createAccountingEntries($creditNoteId, $contributionId, $amount) {
+    $date = date("Y-m-d");
+    $params = [
+      'contribution_id' => $contributionId,
+      'total_amount' => $amount,
+      'trxn_date' => $date,
+      'is_send_contribution_notification' => FALSE,
+      'payment_processor_id' => NULL,
+      'payment_instrument_id' => 1,
+    ];
+
+    $creditNoteLine = \Civi\Api4\CreditNoteLine::get()
+      ->addWhere('credit_note_id.id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $account = FinancialAccountUtils::getFinancialTypeAccount(
+      $creditNoteLine['financial_type_id'],
+      'Accounts Receivable Account is'
+    );
+    $transaction = \CRM_Financial_BAO_Payment::create($params);
+    \CRM_Core_BAO_FinancialTrxn::create([
+      'id' => $transaction->id,
+      'from_financial_account_id' => $account,
+      'to_financial_account_id' => $account,
+    ]);
+  }
 
 }

--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -36,15 +36,26 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
    *
    */
   public static function createWithAccountingEntries($data) {
-    $creditNoteAllocation = self::create($data)->toArray();
+    $transaction = CRM_Core_Transaction::create();
+    try {
+      $allocation = self::create($data)->toArray();
 
-    self::createAccountingEntries($data['credit_note_id'], $data['contribution_id'], $data['amount']);
+      self::createAccountingEntries($allocation['id'], $data['credit_note_id'], $data['contribution_id'], $data['amount']);
+    }
+    catch (\Throwable $th) {
+      $transaction->rollback();
 
-    return $creditNoteAllocation;
+      throw $th;
+    }
+
+    return $allocation;
   }
 
   /**
    * Creates the neccessary accounting entries using Payment API.
+   *
+   * @param int $allocationId
+   *  The credit note allocation ID
    *
    * @param int $creditNoteId
    *  The credit note credit is to be allocated from.
@@ -55,7 +66,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
    * @param float $amount
    *  The amount to be allocated.
    */
-  private static function createAccountingEntries($creditNoteId, $contributionId, $amount) {
+  private static function createAccountingEntries($allocationId, $creditNoteId, $contributionId, $amount) {
     $date = date("Y-m-d");
     $params = [
       'contribution_id' => $contributionId,
@@ -63,6 +74,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       'trxn_date' => $date,
       'is_send_contribution_notification' => FALSE,
       'payment_processor_id' => NULL,
+    // Defaulting to 1 as payment instrument value doesn't matter for credit allocation
       'payment_instrument_id' => 1,
     ];
 
@@ -76,11 +88,68 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       'Accounts Receivable Account is'
     );
     $transaction = \CRM_Financial_BAO_Payment::create($params);
+
+    // The Payment API typically uses the "Accounts Receivable" as the "from" account
+    // and the financial account linked to the payment processor or the default
+    // asset account as the "to" account. Here, we manually set both accounts
+    // to the specified account ID, to ensure they are attached to epxected accounts.
     \CRM_Core_BAO_FinancialTrxn::create([
       'id' => $transaction->id,
       'from_financial_account_id' => $account,
       'to_financial_account_id' => $account,
     ]);
+
+    self::createAllocationEntityTransactions($allocationId, $transaction->id, $amount);
+  }
+
+  /**
+   * Creates entity transactions for an allocation.
+   *
+   * Two types ofentity financial trnsactions are created
+   *  - Entity financial trnsaction to directly link line item to the finacial transanction
+   *  By default CiviCRM links the the trnsaction to a finacial item and then links
+   *  the financial item to the line item
+   *
+   * - Enity financial transaction to directly link the allocation entity to financial trnsction
+   *
+   * @param int $allocationId
+   *   The allocation ID.
+   * @param int $transactionId
+   *   The transaction ID.
+   * @param float $amount
+   *   The amount of the allocation.
+   */
+  private static function createAllocationEntityTransactions($allocationId, $transactionId, $amount) {
+    $finacialItemEntityTrxns = \Civi\Api4\EntityFinancialTrxn::get()
+      ->addSelect('amount', 'financial_trxn_id', 'financial_item.entity_id', 'financial_item.entity_table')
+      ->addJoin('FinancialItem AS financial_item', 'INNER', ['financial_item.id', '=', 'entity_id'])
+      ->addWhere('entity_table', '=', 'civicrm_financial_item')
+      ->addWhere('financial_trxn_id', '=', $transactionId)
+      ->execute();
+
+    foreach ($finacialItemEntityTrxns as $entityTrxn) {
+      $lineItemEntityTrxn = [
+        'entity_table' => $entityTrxn['financial_item.entity_table'],
+        'entity_id' => $entityTrxn['financial_item.entity_id'],
+        'financial_trxn_id' => $transactionId,
+        'amount' => $entityTrxn['amount'],
+      ];
+
+      $entityTrxn = new CRM_Financial_DAO_EntityFinancialTrxn();
+      $entityTrxn->copyValues($lineItemEntityTrxn);
+      $entityTrxn->save();
+    }
+
+    $allocationEntityTrxn = [
+      'entity_table' => CRM_Financeextras_BAO_CreditNoteAllocation::$_tableName,
+      'financial_trxn_id' => $transactionId,
+      'entity_id' => $allocationId,
+      'amount' => $amount,
+    ];
+
+    $entityTrxn = new CRM_Financial_DAO_EntityFinancialTrxn();
+    $entityTrxn->copyValues($allocationEntityTrxn);
+    $entityTrxn->save();
   }
 
 }

--- a/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
@@ -1,0 +1,187 @@
+<?php
+
+use Civi\Api4\Contribution;
+use Civi\Api4\CreditNote;
+use Civi\Api4\CreditNoteAllocation;
+use Civi\Financeextras\Utils\CurrencyUtils;
+use CRM_Financeextras_ExtensionUtil as E;
+
+/**
+ * Credit Note allocation Form controller class.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+class CRM_Financeextras_Form_Contribute_CreditNoteAllocate extends CRM_Core_Form {
+
+  /**
+   * ID of the credit Note to allocate credit to.
+   *
+   * @var int
+   */
+  public $crid;
+
+  /**
+   * Credit Note to allocate credit to.
+   *
+   * @var array
+   */
+  public $creditNote;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    CRM_Utils_System::setTitle(ts('Allocate Credit Balance To Invoices'));
+
+    $this->crid = CRM_Utils_Request::retrieve('crid', 'Positive', $this);
+    $this->creditNote = $this->getCreditNote();
+
+    $url = CRM_Utils_System::url('civicrm/contact/view',
+      ['reset' => 1, 'cid' => $this->creditNote['contact_id'], 'selectedChild' => 'contribute']
+    );
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($url);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+    $currencies = array_column(CurrencyUtils::getCurrencies(), 'symbol', 'name');
+    $contributions = $this->getContributions();
+
+    $this->assign('creditNote', $this->creditNote);
+    $this->assign('contributions', $contributions);
+    $this->assign('currencySymbol', $currencies[$this->creditNote['currency']]);
+
+    foreach ($contributions as $contribution) {
+      $this->add('text', 'item_ref[' . $contribution["id"] . ']', NULL, []);
+      $this->add('number', 'item_amount[' . $contribution["id"] . ']', NULL, []);
+    }
+
+    $this->addButtons([
+      [
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'submit',
+        'name' => E::ts('Allocate credit'),
+      ],
+    ]);
+
+    parent::buildQuickForm();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function postProcess() {
+    $values = $this->getSubmitValues();
+    $amounts = array_filter($values['item_amount']);
+    $references = array_filter($values['item_ref']);
+
+    if (!$this->validateAllocation($amounts)) {
+      return FALSE;
+    }
+
+    if (empty($amounts)) {
+      CRM_Core_Session::setStatus('No amount was allocated.', '', 'info');
+      return;
+    }
+
+    $contributionIds = array_keys($amounts);
+    foreach ($contributionIds as $contributionId) {
+      CreditNoteAllocation::allocate()
+        ->setContributionId($contributionId)
+        ->setCreditNoteId($this->crid)
+        ->setReference($references[$contributionId])
+        ->setTypeId($this->getAllocationTypeValueByName('invoice'))
+        ->setAmount($amounts[$contributionId])
+        ->setCurrency($this->creditNote['currency'])
+        ->execute();
+    }
+
+    CRM_Core_Session::setStatus('Credits allocated successfully.', '', 'success');
+    $url = CRM_Utils_System::url('civicrm/contact/view',
+    ['cid' => $this->creditNote['contact_id'], 'selectedChild' => 'contribute']
+    );
+    CRM_Utils_System::redirect($url);
+
+    return;
+  }
+
+  /**
+   * This enforces the rule to ensure
+   * the allocation is valid
+   *
+   * @param array $amounts
+   *  Array of submitted amounts from user.
+   *
+   * @return array|bool
+   */
+  public function validateAllocation($amounts) {
+    $creditsToAllocate = array_sum($amounts);
+
+    if ($creditsToAllocate > $this->creditNote['remaining_credit']) {
+      CRM_Core_Session::setStatus('Amount to be refunded cannot exceed the remaining credit.', 'Error', 'error');
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  private function getContributions() {
+    $contributions = Contribution::get()
+      ->addWhere('contact_id', '=', $this->creditNote['contact_id'])
+      ->addWhere('contribution_status_id:name', 'IN', ['Pending', 'Partially paid'])
+      ->addWhere('currency', '=', $this->creditNote['currency'])
+      ->execute()
+      ->getArrayCopy();
+
+    array_walk($contributions, function(&$contribution) {
+      $contribution['due_amount'] = CRM_Utils_Money::subtractCurrencies(
+        $contribution['total_amount'],
+        $contribution['paid_amount'],
+        $this->creditNote['currency']
+      );
+    });
+
+    return $contributions;
+  }
+
+  /**
+   * Returns the currrent credit note
+   *
+   * @return array
+   *   Array of credit note fields and values.
+   */
+  private function getCreditNote() {
+    return CreditNote::get()
+      ->addWhere('id', '=', $this->crid)
+      ->execute()
+      ->first();
+  }
+
+  /**
+   * Gets allocation type option value by name
+   *
+   * @param string $name
+   *  The allocation type name.
+   *
+   * @return string|int
+   *   The allocation type value.
+   */
+  private function getAllocationTypeValueByName($name) {
+    $optionValues = \Civi\Api4\OptionValue::get()
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_allocation_type')
+      ->addWhere('name', '=', $name)
+      ->execute()
+      ->first();
+
+    return $optionValues['value'];
+  }
+
+}

--- a/CRM/Financeextras/Form/Contribute/CreditNoteDelete.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteDelete.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Api4\CreditNote;
-use CRM_Certificate_ExtensionUtil as E;
+use CRM_Financeextras_ExtensionUtil as E;
 
 /**
  * Credit Note delete Form controller class.

--- a/Civi/Api4/Action/CreditNoteAllocation/AllocateAction.php
+++ b/Civi/Api4/Action/CreditNoteAllocation/AllocateAction.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNoteAllocation;
+
+use CRM_Core_Transaction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use CRM_Financeextras_BAO_CreditNoteAllocation;
+
+/**
+ * Allocate credit to contributions.
+ */
+class AllocateAction extends AbstractAction {
+  use DAOActionTrait;
+
+  /**
+   * @var int
+   */
+  protected $contributionId;
+
+  /**
+   * @var int
+   */
+  protected $creditNoteId;
+
+  /**
+   * Allocation reference
+   *
+   * @var string
+   */
+  protected $reference;
+
+  /**
+   * Allocateion type
+   *
+   * @var int
+   */
+  protected $typeId;
+
+  /**
+   * Amount to allocate
+   *
+   * @var int
+   */
+  protected $amount;
+
+  /**
+   * Credit note currecny
+   *
+   * @var string
+   */
+  protected $currency;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    $resultArray = [];
+    try {
+      $transaction = CRM_Core_Transaction::create();
+      $resultArray = $this->allocateCredit();
+    }
+    catch (\Throwable $th) {
+      \Civi::log()->error('unable to create allocation ' . $th->getMessage(), ['error' => $th]);
+      $transaction->rollback();
+
+      throw $th;
+    }
+
+    $transaction->commit();
+    return $result->exchangeArray($resultArray);
+  }
+
+  /**
+   * Allocate credit to contribution.
+   *
+   * @return array
+   *
+   */
+  private function allocateCredit() {
+    $data = [
+      'credit_note_id' => $this->creditNoteId,
+      'contribution_id' => $this->contributionId,
+      'type_id' => $this->typeId,
+      'currency' => $this->currency,
+      'reference' => $this->reference,
+      'amount' => $this->amount,
+    ];
+
+    return CRM_Financeextras_BAO_CreditNoteAllocation::createWithAccountingEntries($data);
+  }
+
+}

--- a/Civi/Api4/CreditNoteAllocation.php
+++ b/Civi/Api4/CreditNoteAllocation.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Api4;
 
+use Civi\Api4\Action\CreditNoteAllocation\AllocateAction;
+
 /**
  * CreditNoteAllocation entity.
  *
@@ -10,5 +12,19 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class CreditNoteAllocation extends Generic\DAOEntity {
+
+  /**
+   * Allocate credit to contributions.
+   *
+   * @param bool $checkPermissions
+   *   Should permission be checked for the user.
+   *
+   * @return Civi\Api4\Action\CreditNoteAllocation\Allocate
+   *   returns compute total action
+   */
+  public static function allocate($checkPermissions = TRUE) {
+    return (new AllocateAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
 }

--- a/financeextras.php
+++ b/financeextras.php
@@ -133,3 +133,9 @@ function financeextras_civicrm_tabset($tabsetName, &$tabs, $context) {
     $loader->addModules(['crmApp', 'fe-creditnote']);
   }
 }
+
+function financeextras_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef) {
+  if ($objectName === 'CreditNoteAllocation' && $op === 'create') {
+    \CRM_Financeextras_BAO_CreditNote::updateCreditNoteStatusPostAllocation($objectRef->credit_note_id);
+  }
+}

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.tpl
@@ -1,0 +1,51 @@
+<div id="bootstrap-theme">
+
+  <div class="panel panel-default creditnote__allocate-form-panel">
+    <div class="panel-body">
+      <div class="row" style="margin: 2em 0em;">
+        <div class="col-md-10">
+          <table class="table">
+            <tbody>
+              <tr>
+                <th><p>{ts}Remaining credit available to allocate{/ts}</p></th><td><p>{$creditNote.remaining_credit|crmMoney:$creditNote.currency}</p></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+
+      <div class="row">
+        <div class="col-md-10">
+          <table class="table">
+            <thead>
+              <th>Contribution ID</th>
+              <th>Invoice No</th>
+              <th>Total Amount</th>
+              <th>Amount Due</th>
+              <th>Amount to Allocate</th>
+              <th>Ref.</th>
+            </thead>
+            <tbody>
+            {foreach from=$contributions item=contribution}
+              <tr>
+                <td>{$contribution.id}</td>
+                <td>{$contribution.invoice_number}</td>
+                <td>{$contribution.total_amount|crmMoney:$creditNote.currency}</td>
+                <td>{$contribution.due_amount|crmMoney:$creditNote.currency}</td>
+                <td>{$currencySymbol} {$form.item_amount[$contribution.id].html}</td>
+                <td>{$form.item_ref[$contribution.id].html}</td>
+              </tr>
+            {/foreach}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="crm-submit-buttons panel-footer" style="display: flex; justify-content: space-between;">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+  </div>
+</div>

--- a/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/AllocateActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/AllocateActionTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Api4\CreditNoteAllocation;
+use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+use Civi\Financeextras\Utils\FinancialAccountUtils;
+
+/**
+ * CreditNote.AllocateAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CreditNoteAllocation_AllocateActionTest extends BaseHeadlessTest {
+
+  use CreditNoteTrait;
+
+  /**
+   * Test credit note compute action returns expected fields.
+   */
+  public function testCanAllocateCreditNoteToContribution() {
+    $amountAllocated = 100;
+    $contributionAmount = 200;
+    $creditNote = $this->createCreditNote();
+    $contribution = $this->createContribution($creditNote['contact_id'], $contributionAmount);
+    $allocation = $this->createAllocation($creditNote['id'], $contribution['id'], $amountAllocated, $creditNote['currency']);
+
+    $this->assertNotEmpty($allocation);
+    $this->assertEquals(CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id'], TRUE), $contributionAmount - $amountAllocated);
+  }
+
+  /**
+   * Tests that the expected accounting entries are created for the credit note allocation.
+   */
+  public function testExpectedAccountingEntriesAreCreatedForCrediNoteAllocation() {
+    $amountAllocated = 100;
+    $creditNote = $this->createCreditNote();
+    $contribution = $this->createContribution($creditNote['contact_id'], 200);
+    $this->createAllocation($creditNote['id'], $contribution['id'], $amountAllocated, $creditNote['currency']);
+
+    $expectedAccount = FinancialAccountUtils::getFinancialTypeAccount(
+        $creditNote['items'][0]['financial_type_id'],
+        'Accounts Receivable Account is'
+      );
+
+    $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_id', '=', $contribution['id'])
+      ->addWhere('entity_table', '=', 'civicrm_contribution')
+      ->addWhere('amount', '=', $amountAllocated)
+      ->execute()
+      ->first();
+
+    $this->assertNotEmpty($entityFinancialTrxn);
+
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('from_financial_account_id', '=', $expectedAccount)
+      ->addWhere('to_financial_account_id', '=', $expectedAccount)
+      ->addWhere('total_amount', '=', $amountAllocated)
+      ->addWhere('id', '=', $entityFinancialTrxn['financial_trxn_id'])
+      ->addWhere('status_id', '=', 1)
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('check_number', 'IS NULL')
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($financialTrxn);
+  }
+
+  /**
+   * Tests that the contribution status is updated to partially paid
+   *
+   * When only part of the contribution amount is allocated.
+   */
+  public function testContributionStatusIsPartiallyPaidAfterPartCreditAllocation() {
+    $contributionAmount = 200;
+    $creditNote = $this->createCreditNote();
+    $contribution = $this->createContribution($creditNote['contact_id'], $contributionAmount);
+    $this->createAllocation($creditNote['id'], $contribution['id'], $contributionAmount / 2, $creditNote['currency']);
+
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addSelect('contribution_status_id:name')
+      ->addWhere('id', '=', $contribution['id'])
+      ->execute()
+      ->first();
+
+    $this->assertEquals('Partially paid', $contribution['contribution_status_id:name']);
+  }
+
+  /**
+   * Tests that the contribution status is updated to completed
+   *
+   * When the amount allocated to a contribution is the full due amount.
+   */
+  public function testContributionStatusIsCompletedAfterFullCreditAllocation() {
+    $contributionAmount = 200;
+    $creditNote = $this->createCreditNote();
+    $contribution = $this->createContribution($creditNote['contact_id'], $contributionAmount);
+    $this->createAllocation($creditNote['id'], $contribution['id'], $contributionAmount / 2, $creditNote['currency']);
+    $this->createAllocation($creditNote['id'], $contribution['id'], $contributionAmount / 2, $creditNote['currency']);
+
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addSelect('contribution_status_id:name')
+      ->addWhere('id', '=', $contribution['id'])
+      ->execute()
+      ->first();
+
+    $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
+  }
+
+  private function createCreditNote($creditAmount = 400) {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData(['quantity' => 1, 'unit_price' => $creditAmount]);
+
+    return CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first();
+  }
+
+  private function createContribution($contactId, $contributionAmount) {
+    return \Civi\Api4\Contribution::create()
+      ->addValue('contact_id', $contactId)
+      ->addValue('total_amount', $contributionAmount)
+      ->addValue('contribution_status_id', 2)
+      ->addValue('financial_type_id', 1)
+      ->execute()
+      ->first();
+  }
+
+  private function createAllocation($creditNoteId, $contributionId, $amount, $currency) {
+    $allocationType = \Civi\Api4\OptionValue::get()
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_allocation_type')
+      ->addWhere('name', '=', 'invoice')
+      ->execute()
+      ->first()['value'];
+
+    return CreditNoteAllocation::allocate()
+      ->setContributionId($contributionId)
+      ->setCreditNoteId($creditNoteId)
+      ->setReference('localhost')
+      ->setTypeId($allocationType)
+      ->setAmount($amount)
+      ->setCurrency($currency)
+      ->execute();
+  }
+
+}

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -35,4 +35,9 @@
     <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteVoid</page_callback>
     <access_arguments>access CiviCRM, access CiviContribute, edit contributions</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contribution/creditnote/allocate</path>
+    <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteAllocate</page_callback>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR allows users to allocate credit from a credit note to an invoice.

## Before
There was no credit allocation function.

## After
Users can now allocate credit to an invoice.
![pololll](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/c9c3bca0-d583-4095-ba4d-c156551c4621)


## Technical Details

This PR introduced a new API endpoint `CreditNoteAllocation.Allocate`, which facilitates the allocation of credit to contributions. When credit is applied to a contribution, it requires the creation of accounting entries to accurately allocate the payment within CiviCRM. The newly introduced API endpoint takes care of this also.

To streamline the process of creating these accounting entries and avoid redundant work within the system, we have adopted the recommended approach by CiviCRM, as outlined in the documentation (https://docs.civicrm.org/dev/en/latest/financial/paymentAPI/). So, instead of manually generating accounting entries, we leverage the existing `Payment.Create` API, which not only creates the required entries but also implements the following functionalities:
1. Appropriately updates the contribution status to reflect either `Partially Paid` or `Completed`.
2. Proportionally distributes the allocated amount among the contribution line items.

Since the `Payment.Create` API uses the financial account related to the contribution, we manually update the `from_financial_account_id` and `to_financial_account_id` to the Accounts Receivable account associated with the financial type of the first line item in the credit note.
