### PR TITLE
CIWEMB-355: Alter Menu for a credit note in Fully Allocated status

### DIFF
--- a/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
+++ b/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
@@ -95,6 +95,10 @@ class SearchDisplayRun {
       if (!empty($allocatedTotal) && $creditNote['status_id:name'] == 'open' && $link['text'] == 'Void') {
         $link['style'] = 'disabled';
       }
+
+      if ($creditNote['status_id:name'] == 'fully_allocated' && !in_array($link['text'], ['View', 'Edit', 'Delete', 'Download PDF Document Credit Note', 'Email Credit Note'])) {
+        $link['style'] = 'disabled';
+      }
     }
   }
 


### PR DESCRIPTION
## Overview
This PR ensures only the `View`, `Edit`, `Delete`, `Download PDF Document Credit Note`, and `Email Credit Note` menu items are enabled for credit notes with fully allocated status.

This is a follow-up PR to https://github.com/compucorp/io.compuco.financeextras/pull/32

## Before
All menu items are enabled for credit notes with fully allocated status.
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/21a7e16f-55ca-4892-bf35-5dfaf292adf9)


## After
`only View`, `Edit`, `Delete`, `Download PDF Document Credit Note`, and `Email Credit Note`are enabled for credit notes with fully allocated status.
<img width="1014" alt="Screenshot 2023-06-07 at 10 13 26" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/7da9784b-5c6e-4ded-b1bc-9426e894cd83">


