### PR TITLE
CIWEMB-306: User can open credit note screen with line items from contribution

### DIFF
--- a/CRM/Financeextras/Hook/Links/Contribution.php
+++ b/CRM/Financeextras/Hook/Links/Contribution.php
@@ -79,6 +79,7 @@ class CRM_Financeextras_Hook_Links_Contribution {
         'url' => 'civicrm/contribution/creditnote',
         'qs' => 'reset=1&action=add&contribution_id=' . $this->contributionId,
         'title' => 'Add Credit Note',
+        'class' => 'no-popup',
       ];
     }
   }

--- a/CRM/Financeextras/Hook/Links/Contribution.php
+++ b/CRM/Financeextras/Hook/Links/Contribution.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Alters action links for contributions.
+ */
+class CRM_Financeextras_Hook_Links_Contribution {
+
+  /**
+   * ID for the current contribution.
+   *
+   * @var int
+   */
+  private $contributionId;
+
+  /**
+   * List of links for the current contribution.
+   *
+   * @var array
+   */
+  private $links;
+
+  /**
+   * CRM_Financeextras_Hook_Links_Contribution constructor.
+   *
+   * @param int $contributionId
+   *  ID for the current contribution
+   * @param array $links
+   *  List of links for the current contribution
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct($contributionId, &$links) {
+    $this->contributionId = $contributionId;
+    $this->links = &$links;
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param string $op
+   *  Link context
+   * @param string $objectName
+   *  Link entity
+   *
+   * @return bool
+   */
+  public static function shouldHandle($op, $objectName) {
+    return $op == 'contribution.selector.row' &&
+      $objectName == 'Contribution' &&
+      CRM_Core_Permission::check('edit contributions');
+  }
+
+  /**
+   * Checks contribution has been cancelled.
+   *
+   * @return bool
+   *   Array with recurring contribution's data.
+   *
+   * @throws \Civi\API\Exception
+   */
+  private function isContributionCancelled() {
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addWhere('id', '=', $this->contributionId)
+      ->addWhere('contribution_status_id:name', '=', 'Cancelled')
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    return !empty($contribution);
+  }
+
+  /**
+   * Adds credit note action to contribution links.
+   */
+  public function alterLinks() {
+    if (!$this->isContributionCancelled()) {
+      $this->links[] = [
+        'name' => 'Add Credit Note',
+        'url' => 'civicrm/contribution/creditnote',
+        'qs' => 'reset=1&action=add&contribution_id=' . $this->contributionId,
+        'title' => 'Add Credit Note',
+      ];
+    }
+  }
+
+}

--- a/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
+++ b/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
@@ -15,9 +15,12 @@ class CRM_Financeextras_Page_Contribute_CreditNoteAngular extends \CRM_Core_Page
     $loader = Civi::service('angularjs.loader');
     $creditNoteId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 'null');
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 'null');
+    $contributionId = CRM_Utils_Request::retrieve('contribution_id', 'Positive', $this, FALSE, 'null');
+
     $this->assign('id', $creditNoteId);
     $this->assign('context', $route['name']);
     $this->assign('contact_id', $contactId);
+    $this->assign('contribution_id', $contributionId);
     $loader->addModules(['crmApp', 'fe-creditnote']);
     CRM_Utils_System::setTitle(ts($route['title']));
 

--- a/Civi/Financeextras/APIWrapper/Contribution.php
+++ b/Civi/Financeextras/APIWrapper/Contribution.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Civi\Financeextras\APIWrapper;
+
+class Contribution {
+
+  /**
+   * Callback to wrap Contribution API calls.
+   */
+  public static function Respond($event) {
+    $request = $event->getApiRequestSig();
+    $result = $event->getResponse();
+
+    switch ($request) {
+      case '4.contribution.get':
+        self::addPaidAmountColumn($result);
+        break;
+    }
+  }
+
+  /**
+   * Adds amount paid column to Contribution result.
+   *
+   * @param &$result
+   *    The API result object.
+   */
+  private static function addPaidAmountColumn(&$result) {
+    foreach ($result as &$contribution) {
+      $contribution['paid_amount'] = \CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id'], TRUE);
+    }
+  }
+
+}

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -147,7 +147,7 @@
                   <span class="crm-inline-error" ng-show="creditnotesForm.unit_price_{{$index}}.$dirty && (creditnotesForm.unit_price_{{$index}}.$invalid || creditnotesForm.unit_price_{{$index}}.$error.required)">Unit price is invalid</span>
                 </td>
                 <td style="width: 10em">
-                  <input type="text" value="{{ creditnotes.items[$index].tax_rate > 0 ? roundTo(creditnotes.items[$index].tax_rate, 4) : '' }}" class="form-control" disabled>
+                  <input type="text" value="{{ creditnotes.items[$index].tax_rate > 0 ? roundTo(creditnotes.items[$index].tax_rate, 4)+'%' : '' }}" class="form-control" disabled>
                 </td>
                 <td style="width: 10em">
                   <input type="text" value="{{ formatMoney(creditnotes.items[$index].line_total, creditnotes.currency) }}" class="form-control" disabled>

--- a/financeextras.php
+++ b/financeextras.php
@@ -14,6 +14,7 @@ function financeextras_civicrm_config(&$config) {
   _financeextras_civix_civicrm_config($config);
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\SearchDisplayRun', 'respond'], -100);
   Civi::dispatcher()->addSubscriber(new Civi\Financeextras\Event\Subscriber\CreditNoteInvoiceSubscriber());
+  Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\Contribution', 'respond'], -101);
 }
 
 /**

--- a/financeextras.php
+++ b/financeextras.php
@@ -115,15 +115,9 @@ function financeextras_civicrm_pageRun($page) {
  * Implements hook_civicrm_links().
  */
 function financeextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
-  if ($op == 'contribution.selector.row' && $objectName == 'Contribution') {
-    if (CRM_Core_Permission::check('edit contributions')) {
-      $links[] = [
-        'name' => 'Add Credit Note',
-        'url' => 'civicrm/contribution/creditnote',
-        'qs' => 'reset=1&action=add',
-        'title' => 'Add Credit Note',
-      ];
-    }
+  if (CRM_Financeextras_Hook_Links_Contribution::shouldHandle($op, $objectName)) {
+    $contributionHook = new CRM_Financeextras_Hook_Links_Contribution($objectId, $links);
+    $contributionHook->alterLinks();
   }
 }
 

--- a/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
+++ b/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
@@ -7,13 +7,14 @@
   const id = JSON.parse({ $id });
   const context = '{ $context }';
   const contactId = JSON.parse({ $contact_id });
+  const contributionId = JSON.parse({ $contribution_id });
   {literal}
     (function(angular, $, _) {
       const app = angular.module('creditnoteTab', ['fe-creditnote']);
       app.directive('view', function () {
       const template = context == 'view' ? 'view' : 'create'
       return {
-        template: `<creditnote-${template} id=${id} context=${context} contact-id=${contactId}></creditnote-create>`,
+        template: `<creditnote-${template} id=${id} context=${context} contact-id=${contactId} contribution-id=${contributionId}></creditnote-create>`,
       }
     });
     })(angular, CRM.$, CRM._);
@@ -21,5 +22,5 @@
     CRM.$(document).one('crmLoad', function() {
       angular.bootstrap(document.getElementById('creditnote-tab'), ['creditnoteTab']);
     });
-  {/literal}
+{/literal}
 </script>


### PR DESCRIPTION
## Overview
This PR allows users to create a credit note for a contribution and populate the credit note line items from the contribution line item. 

## Before
Users can not open a new credit notes screen for a contribution with the line items populated.

## After
Users can open a new credit notes screen for a contribution with the line items populated.

![qwerere](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1465f13f-7903-4772-ae2f-bff0089e1679)



## Technical Details
To populate the line items, we take the remaining amount to be paid on the invoice, which is the due amount(i.e. total - paid). Then, we distribute this amount proportionally among the line items based on their total amount.

The following rule is followed:
In cases where no payments or allocations have been made against the invoice (i.e. percentage due is equal to 100), a credit note line is created for each line item on the invoice, with the full amount allocated to each line.

However, suppose previous payments or allocations have been made against the invoice (i.e. percentage due is less than 100). In that case, The due/unpaid amount is distributed proportionally among the line items based on their respective total amounts (i.e. unit_price * quantity), and the credit note line item quantity is set at 1.

Also, we have implemented a check within the `financeextras_civicrm_links` hook to display the "add credit note" link only for contributions that have not been cancelled.

Furthermore, we utilize the [API Wrappers event listener](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/) to incorporate the contribution's "Paid Amount" in its APIv4 GET response.