### PR TITLE
CIWEMB-333: Redirect to allocation screen on credit note creation

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -177,10 +177,9 @@
 
       $scope.submitInProgress = true;
       crmApi4('CreditNote', 'save', { records: [$scope.creditnotes] })
-        .then(function () {
-          $scope.submitInProgress = false;
+        .then(function (result) {
           showSucessNotification();
-          redirectToAppropraitePage();
+          redirectToAppropraitePage(result[0].id);
         }, function () {
           $scope.submitInProgress = false;
           CRM.alert('Unable to create credit note', ts('Error'), 'error');
@@ -203,14 +202,11 @@
 
     /**
      * Handles page rediection after successfully creating creditnotes.
+     * 
+     * @param {boolean} the credit note ID
      */
-    function redirectToAppropraitePage () {
-      if ($scope.isUpdate) {
-        $window.location.href = $window.document.referrer;
-        return;
-      }
-
-      $window.location.href = 'a#/';
+    function redirectToAppropraitePage (creditNoteId) {
+      $window.location.href = CRM.url(`/contribution/creditnote/allocate?crid=${creditNoteId}`);
     }
 
     /**

--- a/ang/fe-creditnote/directives/history-back.directive.js
+++ b/ang/fe-creditnote/directives/history-back.directive.js
@@ -1,0 +1,20 @@
+(function (angular, $window) {
+  var module = angular.module('fe-creditnote');
+
+  module.directive('historyBack', function () {
+    return {
+      restrict: 'A',
+      link: function (elem) {
+        elem.bind('click', function () {
+          $window.history.back();
+          const currPage = window.location.href;
+          setTimeout(function () {
+            if ($window.location.href === currPage) {
+              $window.close();
+            }
+          }, 500);
+        });
+      }
+    };
+  });
+})(angular, window);

--- a/templates/CRM/Financeextras/Page/Contribute/CreditNoteTab.tpl
+++ b/templates/CRM/Financeextras/Page/Contribute/CreditNoteTab.tpl
@@ -10,7 +10,7 @@
   {if $action eq 16 and $permission EQ 'edit'}
   {capture assign=newCreditnotesURL}{crmURL p="civicrm/contribution/creditnote" q="reset=1&action=add&cid=`$contactId`&context=contribution"}{/capture}
     <div class="action-link">
-      <a accesskey="N" href="{$newCreditnotesURL|smarty:nodefaults}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Create New Credit Note{/ts}</span></a>
+      <a accesskey="N" href="{$newCreditnotesURL|smarty:nodefaults}" class="button no-popup"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Create New Credit Note{/ts}</span></a>
       <br /><br />
     </div>
   {/if}


### PR DESCRIPTION
## Overview
This PR redirects the user to the credit note allocation screen post-credit note creation.

## Before
The user was redirected to CiviCRM's main page after creating a credit note.

## After
The user is redirected to the credit note allocation screen after creating a credit note.

## Comment

The allocation screen will be created in this PR https://github.com/compucorp/io.compuco.financeextras/pull/37
