### PR TITLE
CIWEMB-289: Export CreditNotes saved search

### DIFF
--- a/ang/fe-creditnote/directives/history-back.directive.js
+++ b/ang/fe-creditnote/directives/history-back.directive.js
@@ -1,10 +1,11 @@
 (function (angular, $window) {
   var module = angular.module('fe-creditnote');
 
+  /* eslint-disable no-unused-vars*/
   module.directive('historyBack', function () {
     return {
       restrict: 'A',
-      link: function (elem) {
+      link: function (scope, elem, attrs) {
         elem.bind('click', function () {
           $window.history.back();
           const currPage = window.location.href;

--- a/info.xml
+++ b/info.xml
@@ -26,5 +26,6 @@
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>ang-php@1.0.0</mixin>
+    <mixin>mgd-php@1.0.0</mixin>
   </mixins>
 </extension>

--- a/managed/SavedSearch_Credit_Notes.mgd.php
+++ b/managed/SavedSearch_Credit_Notes.mgd.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * @file
+ * Exported creditnotes saved search.
+ */
+
+$mgd = [
+  [
+    'name' => 'SavedSearch_Credit_Notes_List',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Credit_Notes_List',
+        'label' => 'Credit Notes List',
+        'form_values' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'CreditNote',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'cn_number',
+            'status_id:label',
+            'reference',
+            'date',
+            'total_credit',
+            'SUM(CreditNote_CreditNoteAllocation_credit_note_id_01.amount) AS SUM_CreditNote_CreditNoteAllocation_credit_note_id_01_amount',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [
+            'id',
+          ],
+          'join' => [
+            [
+              'CreditNoteAllocation AS CreditNote_CreditNoteAllocation_credit_note_id_01',
+              'LEFT',
+              [
+                'id',
+                '=',
+                'CreditNote_CreditNoteAllocation_credit_note_id_01.credit_note_id',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+        'expires_date' => NULL,
+        'description' => NULL,
+        'mapping_id' => NULL,
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Credit_Notes_List_SearchDisplay_Credit_Notes_List_Table_1',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Credit_Notes_List_Table_1',
+        'label' => 'Credit Notes List Table 1',
+        'saved_search_id.name' => 'Credit_Notes_List',
+        'type' => 'table',
+        'settings' => [
+          'actions' => FALSE,
+          'limit' => 50,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'pager' => [
+            'expose_limit' => TRUE,
+          ],
+          'placeholder' => 5,
+          'sort' => [],
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'cn_number',
+              'dataType' => 'String',
+              'label' => 'Number',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'status_id:label',
+              'dataType' => 'Integer',
+              'label' => 'Status',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'reference',
+              'dataType' => 'String',
+              'label' => 'Reference',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'date',
+              'dataType' => 'Date',
+              'label' => 'Date',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'total_credit',
+              'dataType' => 'Money',
+              'label' => 'Total Value',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'SUM_CreditNote_CreditNoteAllocation_credit_note_id_01_amount',
+              'dataType' => 'Money',
+              'label' => 'Allocated',
+              'sortable' => TRUE,
+              'empty_value' => '0.00',
+            ],
+            [
+              'text' => '',
+              'style' => 'default',
+              'size' => 'btn-sm',
+              'icon' => 'fa-ellipsis-v',
+              'links' => [
+                [
+                  'entity' => 'CreditNote',
+                  'action' => 'view',
+                  'join' => '',
+                  'target' => '',
+                  'icon' => 'fa-external-link',
+                  'text' => 'View',
+                  'style' => 'default',
+                  'path' => '',
+                  'condition' => [],
+                ],
+                [
+                  'entity' => 'CreditNote',
+                  'action' => 'update',
+                  'join' => '',
+                  'target' => '',
+                  'icon' => 'fa-pencil',
+                  'text' => 'Edit',
+                  'style' => 'default',
+                  'path' => '',
+                  'condition' => [],
+                ],
+                [
+                  'path' => 'civicrm/',
+                  'icon' => 'fa-external-link',
+                  'text' => 'Download PDF Document Credit Note',
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
+                  'path' => 'civicrm/',
+                  'icon' => 'fa-external-link',
+                  'text' => 'Email Credit Note',
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                ],
+                [
+                  'path' => 'civicrm/',
+                  'icon' => 'fa-external-link',
+                  'text' => 'Void',
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
+                  'path' => 'civicrm/contribution/creditnote/allocate?crid=[id]',
+                  'icon' => 'fa-external-link',
+                  'text' => 'Allocate credit to invoice',
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
+                  'path' => 'civicrm/',
+                  'icon' => 'fa-external-link',
+                  'text' => 'Record cash refund',
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
+                  'path' => 'civicrm/',
+                  'icon' => 'fa-external-link',
+                  'text' => 'Make credit card refund',
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
+                  'entity' => 'CreditNote',
+                  'action' => 'delete',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-trash',
+                  'text' => 'Delete',
+                  'style' => 'default',
+                  'path' => '',
+                  'condition' => [
+                    'check user permission',
+                    '=',
+                    'delete in CiviContribute',
+                  ],
+                ],
+              ],
+              'type' => 'menu',
+              'alignment' => '',
+              'label' => 'Actions',
+            ],
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ],
+    ],
+  ],
+];
+
+$searchKitIsInstalled = 'installed' ===
+CRM_Extension_System::singleton()->getManager()->getStatus('org.civicrm.search_kit');
+if ($searchKitIsInstalled) {
+  return $mgd;
+}
+
+return [];


### PR DESCRIPTION
## Overview
In this PR we export the credit note saved search so it can be imported automatically on extension install/uninstall.

Kindly see this link for more information on managed entities:
https://docs.civicrm.org/dev/en/latest/api/v4/managed/