### PR TITLE
CIWEMB-367: Update to Credit note create screen

### DIFF
--- a/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
+++ b/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
@@ -14,8 +14,10 @@ class CRM_Financeextras_Page_Contribute_CreditNoteAngular extends \CRM_Core_Page
     $route = $this->getRoute();
     $loader = Civi::service('angularjs.loader');
     $creditNoteId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 'null');
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 'null');
     $this->assign('id', $creditNoteId);
     $this->assign('context', $route['name']);
+    $this->assign('contact_id', $contactId);
     $loader->addModules(['crmApp', 'fe-creditnote']);
     CRM_Utils_System::setTitle(ts($route['title']));
 

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -175,7 +175,7 @@
                   <table class="table">
                     <tr><th>Subtotal</th><td>{{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
                       <tr ng-repeat="i in taxRates">
-                        <th>*{{ i.tax_name }} @ {{ i.rate }}%</th>
+                        <th>*{{ taxTerm }} @ {{ i.rate }}%</th>
                         <td>{{ formatMoney(i.value, creditnotes.currency) }}</td>
                       </tr>
                     <tr><th>Total</th><td>{{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -142,7 +142,6 @@
                 </td>
                 <td>
                   <div class="input-group" style="width: 10em">
-                    <span class="input-group-addon">{{ currencySymbol }}</span>
                     <input type="number" min="0" name="unit_price_{{$index}}" required placeholder="Unit Price" ng-model="creditnotes.items[$index].unit_price" ng-change="calculateSubtotal($index)" class="form-control" step="0.01" />
                   </div>
                   <br />
@@ -175,12 +174,12 @@
             <div class="row">
                 <div class="col-sm-4 pull-right">
                   <table class="table">
-                    <tr><th>Subtotal</th><td>{{ currencySymbol }} {{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
+                    <tr><th>Subtotal</th><td>{{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
                       <tr ng-repeat="i in taxRates">
                         <th>*{{ i.tax_name }} @ {{ i.rate }}%</th>
-                        <td>{{ currencySymbol }} {{ formatMoney(i.value, creditnotes.currency) }}</td>
+                        <td>{{ formatMoney(i.value, creditnotes.currency) }}</td>
                       </tr>
-                    <tr><th>Total</th><td>{{ currencySymbol }} {{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>
+                    <tr><th>Total</th><td>{{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>
                   </table>
                 </div>
             </div>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -53,17 +53,16 @@
           </div>
         </div>
         <div class="form-group">
-          <label class="col-sm-2 control-label required-mark">
+          <label class="col-sm-2 control-label">
             {{ ts('Description') }}
             <a crm-ui-help="hs({title:ts('Description'), id:'creditnotes_description'})"></a>
           </label>
           <div class="col-sm-5">
-            <textarea name="description" ng-model="creditnotes.description" class="crm-form-wysiwyg" id="creditnotes-description" ng-disabled="isView" required></textarea>
-            <span class="crm-inline-error" ng-show="creditnotesForm.description.$dirty && creditnotesForm.description.$invalid && creditnotesForm.description.$error.required">Description is required</span>
+            <textarea name="description" ng-model="creditnotes.description" class="crm-form-wysiwyg" id="creditnotes-description" ng-disabled="isView"></textarea>
           </div>
         </div>
         <div class="form-group">
-          <label class="col-sm-2 control-label required-mark">
+          <label class="col-sm-2 control-label">
             {{ ts('Reference') }}
           </label>
           <div class="col-sm-5 civicase__ui-range">

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -204,8 +204,8 @@
       <creditnote-allocation-table ng-if="creditnotes.id && isView" credit-note-id="{{creditnotes.id}}" />
     </div>
     <div class="panel-footer flex-between crm-submit-buttons">
-        <button type="button" class="btn btn-primary-outline cancel crm-form-submit crm-button crm-button-type-cancel" history-back>
-          <span class="btn-icon"></span> {{ts('Cancel')}}</button>
+        <a class="btn btn-primary-outline cancel crm-form-submit crm-button-type-cancel" ng-href="{{ crmUrl('civicrm/contact/view', {reset: 1, cid: contactId, selectedChild: 'contribute'}) }}">
+          <span class="btn-icon"></span> {{ts('Cancel')}}</a>
         <button ng-if="!isView" type="submit" class="btn btn-primary crm-form-submit crm-button crm-button-type-submit" ng-disabled="submitInProgress" ng-click="saveCreditnotes()">
           <span class="btn-icon"></span> {{ts('Create')}}</button>
     </div>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -41,6 +41,7 @@
     const financialTypesCache = new Map();
 
     $scope.ts = CRM.ts();
+    $scope.taxTerm = '';
     $scope.crmUrl = CRM.url;
     $scope.formValid = true;
     $scope.roundTo = roundTo;
@@ -87,6 +88,8 @@
       };
       $scope.total = 0;
       $scope.taxRates = [];
+
+      getTaxTerm().then((taxTerm) => $scope.taxTerm = taxTerm)
     }
 
     /**
@@ -107,7 +110,7 @@
      * Prepopulates credit notes using credit note ID
      */
     function prepopulateCreditnotes () {
-      if (!$scope.id) {
+      if (!parseInt($scope.id)) {
         return;
       }
 
@@ -289,6 +292,19 @@
 
       item.line_total = item.unit_price * item.quantity || 0;
       $scope.$emit('totalChange');
+    }
+
+    /**
+     * Retrieves the contribution tax term from settings
+     * 
+     * @returns {string} tax term
+     */
+    async function getTaxTerm() {
+      const setting = await crmApi4('Setting', 'get', {
+        select: ["contribution_invoice_settings"]
+      });
+
+      return setting[0]['value']['tax_term'] ?? '';
     }
 
 

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -21,6 +21,7 @@
       scope: {
         id: '@',
         context: '@',
+        contactId: '@',
       }
     };
   });
@@ -58,6 +59,7 @@
     (function init () {
       initializeCreditnotes();
       prepopulateCreditnotes();
+      setDefaultContactID();
       $scope.newCreditnotesItem = newCreditnotesItem;
       CRM.wysiwyg.create('#creditnotes-description');
       $scope.removeCreditnotesItem = removeCreditnotesItem;
@@ -307,6 +309,14 @@
       return setting[0]['value']['tax_term'] ?? '';
     }
 
+    /**
+     * Sets default contact ID.
+     */
+    function setDefaultContactID () {
+      if (!parseInt($scope.contributionId) && parseInt($scope.contactId)) {
+        $scope.creditnotes.contact_id = $scope.contactId
+      }
+    }
 
   }
 })(angular, CRM.$, CRM._);

--- a/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
+++ b/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
@@ -6,12 +6,13 @@
 <script type="text/javascript">
   const id = JSON.parse({ $id });
   const context = '{ $context }';
+  const contactId = JSON.parse({ $contact_id });
   {literal}
     (function(angular, $, _) {
       const app = angular.module('creditnoteTab', ['fe-creditnote']);
       app.directive('view', function () {
       return {
-        template: `<creditnote-create id=${id} context=${context}></creditnote-create>`,
+        template: `<creditnote-create id=${id} context=${context} contact-id=${contactId}></creditnote-create>`,
       }
     });
     })(angular, CRM.$, CRM._);


### PR DESCRIPTION
## Overview
This PR  makes the following updates to the credit note create screen.

### Remove the currency symbol from total fields
## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/e0fce773-1629-418b-b3d3-9ca5ba7d3db8)

## After
<img width="1261" alt="Screenshot 2023-06-23 at 10 22 11" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/c97aa50c-ba58-4c57-a55b-991c0fb702a6">


### Remove required mark from optional fields (description and reference field)
## Before
<img width="952" alt="Screenshot 2023-06-23 at 10 24 11" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/74902123-33a3-473b-ac75-87cbcc9eb1b7">

## After
<img width="1045" alt="Screenshot 2023-06-23 at 10 21 08" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/acf433df-c668-411f-a80f-a71fa71c8e91">


###  Use tax terms from contribution settings as tax label
## Before
The sales tax account name was used as tax label

## After
The tax terms from contribution settings is used as tax label
![tttrtr](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/9efaa217-d259-4700-b9cd-0b1be46fcf2d)

### Redirect back to the contribution tab on cancel
## After
Clicking on the cancel button attempts to take the user to the previous page but sometimes instead of the credit note tab loading, it displays the summary tab.

https://github.com/compucorp/io.compuco.financeextras/assets/85277674/7ecbd166-5833-4dca-8cf4-147c2f60251a


## After
![cancel](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1465cdda-6bb2-4290-a441-176c2e8c8aea)

### Prefill contact record
## Before
The contact field is not prefilled

## After
<img width="953" alt="Screenshot 2023-06-23 at 10 16 49" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/85fb2aa7-3c82-4aa3-afb3-bbd364882e9b">
