### PR TITLE
CIWEMB-370: Revamp the credit note view screen

### DIFF
--- a/Civi/Api4/CreditNote.php
+++ b/Civi/Api4/CreditNote.php
@@ -76,6 +76,7 @@ class CreditNote extends Generic\DAOEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
+      'computeTotal' => ['access CiviCRM', 'access CiviContribute'],
       'get' => ['access CiviCRM', 'access CiviContribute'],
       'default' => ['access CiviCRM', 'access CiviContribute', 'edit contributions'],
       'delete' => ['access CiviCRM', 'access CiviContribute', 'delete in CiviContribute'],

--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
@@ -16,7 +16,7 @@
 </div>
 <div class="form-group">
   <div class="col-sm-12" style="overflow: scroll;">
-    <table class="table table-bordered">
+    <table class="table table-bordered table-striped">
      <tr>
        <th>Allocation Type</th>
        <th>Allocated To</th>
@@ -43,10 +43,9 @@
 <div class="form-group">
   <div class="col-sm-12">
     <br />
-    <br />
     <div class="row">
         <div class="col-sm-4 pull-right">
-          <table class="table">
+          <table class="table table-striped">
             <tr><th>Total Credit</th><td>{{ formatMoney(total_credit, currency, true) }}</td></tr>
             <tr><th>Allocated Credit</th><td>{{formatMoney(allocated_credit, currency, true)}}</td></tr>
             <tr><th>Remaining Credit</th><td>{{formatMoney(remaining_credit, currency, true)}}</td></tr>

--- a/ang/fe-creditnote/directives/creditnote-line-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-line-table.directive.html
@@ -5,16 +5,16 @@
   <br />
   <br />
 </div>
-<div class="form-group">
+<div class="form-group row">
   <div class="col-sm-12" style="overflow: scroll;">
-    <table class="table table-bordered">
+    <table class="table table-bordered table-striped text-center">
       <tr>
-        <th>Item</th>
-        <th>Financial Type</th>
-        <th>Quantity</th>
-        <th>Unit Price</th>
-        <th>Tax</th>
-        <th>Subtotal</th>
+        <th class="text-center">Item</th>
+        <th class="text-center">Financial Type</th>
+        <th class="text-center">Quantity</th>
+        <th class="text-center">Unit Price</th>
+        <th class="text-center">Tax</th>
+        <th class="text-center">Subtotal</th>
       </tr>
      <tr ng-repeat="item in items track by $index">
       <td>{{item.description}}</td>

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -1,0 +1,94 @@
+<div id="bootstrap-theme" class="creditnote__container">
+  <h1 class="hidden" crm-page-title>{{ ts('View Credit Note') }}</h1>
+
+  <div class="panel panel-default" id="creditnote__view">
+    <div class="panel-body">
+      <div class="row" ng-if="hasEditPermission">
+        <div class="col-md-12">
+          <a ng-href="{{ crmUrl('civicrm/contribution/creditnote/update', {reset: 1, id: creditnotes.id, action: 'update'}) }}" class="btn btn-primary-outline pull-right">Edit Credit Note</a>
+        </div>
+      </div>
+      <table class="table" id="creditnote__detail">
+        <tr>
+          <td style="width: 200px">{{ ts('Contact') }}</td>
+          <td><span><a href="{{getContactLink(creditnotes.contact_id)}}" target="_blank">{{creditnotes['contact_id.display_name']}}</a></span></td>
+        </tr>
+        <tr>
+          <td>{{ ts('Status') }}</td>
+          <td>{{creditnotes['status_id:label']}}</td>
+        </tr>
+        <tr>
+          <td>{{ ts('Number') }}</td>
+          <td>{{ creditnotes.cn_number }}</td>
+        </tr>
+        <tr>
+          <td>{{ ts('Description') }}</td>
+          <td><span ng-bind-html="creditnotes.description "></span></td>
+        </tr>
+        <tr>
+          <td>{{ ts('Date') }}</td>
+          <td>{{ creditnotes.date }}</td>
+        </tr>
+        <tr>
+          <td>{{ ts('Reference') }}</td>
+          <td>{{ creditnotes.reference }}</td>
+        </tr>
+        <tr>
+          <td>{{ts('Currency')}}</td>
+          <td>{{currencySymbol}}</td>
+        </tr>
+        <tr>
+          <td colspan="2">
+            <div class="">
+              <creditnote-line-table credit-note="{{ creditnotes }}" />
+            </div>
+            <div class="row">
+              <div class="col-sm-4 pull-right">
+                <table class="table table-striped">
+                  <tr><th>Subtotal</th><td>{{ currencySymbol }} {{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
+                    <tr ng-repeat="i in taxRates">
+                      <th>*{{ i.tax_name }} @ {{ i.rate }}%</th>
+                      <td>{{ currencySymbol }} {{ formatMoney(i.value, creditnotes.currency) }}</td>
+                    </tr>
+                  <tr><th>Total</th><td>{{ currencySymbol }} {{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>
+                </table>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" class="no-bold">
+            <b>{{ts('Comment')}}</b>
+            <br>
+            <br>
+            <p>{{ creditnotes.comment }}</p>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2">
+            <div>
+              <creditnote-allocation-table ng-if="creditnotes.id" credit-note-id="{{creditnotes.id}}" />
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
+    <div class="panel-footer flex-between crm-submit-buttons">
+        <button type="button" class="btn btn-primary-outline cancel crm-form-submit crm-button crm-button-type-cancel" history-back>
+          <span class="btn-icon"></span> {{ts('Cancel')}}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  #creditnote__view .table>tbody>tr>td {
+    padding: 10px 10px;
+  }
+  #creditnote__view .table tr:first-child > td {
+    border-top: none;
+  }
+  #creditnote__view .table tr> td:first-child:not(.no-bold) {
+    color: #000;
+    font-weight: 600;
+  }
+</style>

--- a/ang/fe-creditnote/directives/creditnote-view.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.js
@@ -1,0 +1,166 @@
+(function (angular, $, _) {
+  var module = angular.module('fe-creditnote');
+
+  module.directive('creditnoteView', function ($timeout) {
+    return {
+      restrict: 'E',
+      controller: 'creditnoteViewController',
+      templateUrl: '~/fe-creditnote/directives/creditnote-view.directive.html',
+      link: function() {
+        $timeout(function() {
+          if (CRM.$("div.ui-dialog").length) {
+            const buttonPane = CRM.$("<div>").addClass("ui-dialog-buttonpane ui-widget-content ui-helper-clearfix");
+            const buttonSet = CRM.$("<div>").addClass("ui-dialog-buttonset flex-between");
+            buttonSet.append(CRM.$('.crm-submit-buttons > button'))
+            buttonPane.append(buttonSet);
+
+            CRM.$("div.ui-dialog").append(buttonPane);
+          }
+        }, 20);
+      },
+      scope: {
+        id: '@',
+        context: '@',
+      }
+    };
+  });
+
+  module.controller('creditnoteViewController', creditnoteViewController);
+
+  /**
+   * @param {object} $scope the controller scope
+   * @param {object} CurrencyCodes CurrencyCodes service
+   * @param {object} crmApi4 crm api V4 service
+   */
+  function creditnoteViewController ($scope, CurrencyCodes, crmApi4) {
+    const defaultCurrency = 'GBP';
+    const financialTypesCache = new Map();
+
+    $scope.ts = CRM.ts();
+    $scope.crmUrl = CRM.url;
+    $scope.roundTo = roundTo;
+    $scope.formatMoney = formatMoney;
+    $scope.getContactLink = getContactLink;
+    $scope.currencySymbol = CurrencyCodes.getSymbol(defaultCurrency);
+    $scope.hasEditPermission = CRM['fe-creditnote'].canEditContribution;
+
+    (function init () {
+      prepopulateCreditnotes();
+
+      $scope.$on('totalChange', _.debounce(handleTotalChange, 250));
+    }());
+
+    /**
+     * Prepopulates credit notes using credit note ID
+     */
+    function prepopulateCreditnotes () {
+      if (!$scope.id) {
+        return;
+      }
+
+      crmApi4('CreditNote', 'get', {
+        where: [["id", "=", $scope.id]],
+        select: ['*', 'contact_id.display_name', 'status_id:label'],
+        chain: {"items":["CreditNoteLine", "get", {"where":[["credit_note_id", "=", "$id"]], "select": ['*', 'financial_type_id.name']}]}
+      }).then(function (result) {
+        const creditnotes = result[0] ?? null;
+        $scope.creditnotes = creditnotes
+        $scope.currencySymbol = CurrencyCodes.getSymbol(creditnotes.currency);
+        $scope.creditnotes.date = $.datepicker.formatDate('dd/mmyy', new Date(creditnotes.date))
+
+        creditnotes.items.forEach((element, i) => {
+          element.financial_type = element['financial_type_id.name']
+          handleFinancialTypeChange(i);
+        });
+        CRM.wysiwyg.setVal('#creditnotes-description', $scope.creditnotes.description);
+      });
+    }
+
+    /**
+     * Computes total and tax rates from API
+     */
+    function handleTotalChange () {
+      crmApi4('CreditNote', 'computeTotal', {
+        lineItems: $scope.creditnotes.items
+      }).then(function (results) {
+        $scope.taxRates = results[0].taxRates;
+        $scope.creditnotes.total = results[0].totalBeforeTax;
+        $scope.creditnotes.grandTotal = results[0].totalAfterTax;
+      }, function () {
+        // handle failure
+      });
+    }
+
+    /**
+     * Returns link to the contact dashboard
+     *
+     * @param {number} id the contact ID
+     *
+     * @returns {string} dashboard link
+     */
+    function getContactLink (id) {
+      return CRM.url(`/contact/view?reset=1&cid=${id}`);
+    }
+
+    /**
+     * Update tax filed and regenrate line item tax rates for line itme financial types
+     *
+     * @param {number} index of the credit note line item
+     */
+    function handleFinancialTypeChange (index) {
+      $scope.creditnotes.items[index].tax_rate = 0;
+      $scope.$emit('totalChange');
+
+      if ($scope.creditnotes.items[index]['financial_type_id.name']) {
+        $scope.creditnotes.items[index]['financial_type_id.name'] = '';
+      }
+
+      const updateFinancialTypeDependentFields = (financialTypeId) => {
+        $scope.creditnotes.items[index].tax_rate = financialTypesCache.get(financialTypeId).tax_rate;
+        $scope.creditnotes.items[index].tax_name = financialTypesCache.get(financialTypeId).name;
+        $scope.$emit('totalChange');
+      };
+
+      const financialTypeId = $scope.creditnotes.items[index].financial_type_id;
+      if (financialTypeId && financialTypesCache.has(financialTypeId)) {
+        updateFinancialTypeDependentFields(financialTypeId);
+        return;
+      }
+
+      if (financialTypeId) {
+        crmApi4('EntityFinancialAccount', 'get', {
+          where: [["account_relationship:name", "=", "Sales Tax Account is"], ["entity_table", "=", "civicrm_financial_type"], ["entity_id", "=", financialTypeId]],
+          limit: 1,
+          chain: {"financialAccount":["FinancialAccount", "get", {"where":[["id", "=", "$financial_account_id"]]}, 0]}
+        }).then(function(entityFinancialAccounts) {
+          financialTypesCache.set(financialTypeId, entityFinancialAccounts[0]['financialAccount']);
+          updateFinancialTypeDependentFields(financialTypeId);
+        });
+      }
+    }
+
+    /**
+     * Rounds floating ponumber n to specified number of places
+     *
+     * @param {*} n number to round
+     * @param {*} place decimal places to round to
+     * @returns {number} the rounded off number
+     */
+    function roundTo (n, place) {
+      return +(Math.round(n + 'e+' + place) + 'e-' + place);
+    }
+
+    /**
+     * Formats a number into the number format of the currently selected currency
+     *
+     * @param {number} value the number to be formatted
+     * @param {string } currency the selected currency
+     * @returns {number} the formatted number
+     */
+    function formatMoney (value, currency) {
+      return CRM.formatMoney(value, true, CurrencyCodes.getFormat(currency));
+    }
+
+
+  }
+})(angular, CRM.$, CRM._);

--- a/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
+++ b/templates/CRM/Financeextras/Page/Contribute/CreditNoteAngular.tpl
@@ -11,8 +11,9 @@
     (function(angular, $, _) {
       const app = angular.module('creditnoteTab', ['fe-creditnote']);
       app.directive('view', function () {
+      const template = context == 'view' ? 'view' : 'create'
       return {
-        template: `<creditnote-create id=${id} context=${context} contact-id=${contactId}></creditnote-create>`,
+        template: `<creditnote-${template} id=${id} context=${context} contact-id=${contactId}></creditnote-create>`,
       }
     });
     })(angular, CRM.$, CRM._);

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -11,6 +11,11 @@
     <access_arguments>edit contributions</access_arguments>
   </item>
   <item>
+    <path>civicrm/contribution/creditnote/view</path>
+    <page_callback>CRM_Financeextras_Page_Contribute_CreditNoteAngular</page_callback>
+    <access_arguments>access CiviContribute</access_arguments>
+  </item>
+  <item>
     <path>civicrm/contribution/creditnote</path>
     <page_callback>CRM_Financeextras_Page_Contribute_CreditNoteAngular</page_callback>
     <access_arguments>edit contributions</access_arguments>


### PR DESCRIPTION
## Overview
This PR updates the credit note view screen

## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/579922de-70a7-46c9-bea6-6d2f7782cf2d)


## After
![asview](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/12a51a0c-e302-490a-ab88-9eedac694422)

## Technical Details
Previously, credit notes were shown using the create directive, but with the fields disabled. However, in this pull request (PR), we have introduced a new directive and path specifically for displaying credit notes.