### PR TITLE
CIWEMB-304: User can email credit note invoice to contact

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteDownload.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteDownload.php
@@ -1,10 +1,11 @@
 <?php
 
+use Civi\Financeextras\Event\CreditNoteDownloadedEvent;
 
 /**
- * Handles Credit Note Invoice Task.
+ * Handles Credit Note Download Task.
  */
-class CRM_Financeextras_Form_Contribute_CreditNoteInvoice extends CRM_Core_Form {
+class CRM_Financeextras_Form_Contribute_CreditNoteDownload extends CRM_Core_Form {
 
   /**
    * Renders and return the generated PDF to the browser.
@@ -16,6 +17,12 @@ class CRM_Financeextras_Form_Contribute_CreditNoteInvoice extends CRM_Core_Form 
     $rendered = $creditNoteInvoiceService->render($creditNoteId);
     ob_end_clean();
     CRM_Utils_PDF_Utils::html2pdf($rendered['html'], 'credit_note_invoice.pdf', FALSE, $rendered['format']);
+
+    Civi::dispatcher()->dispatch(CreditNoteDownloadedEvent::NAME, new CreditNoteDownloadedEvent(
+      $creditNoteId,
+      $rendered
+    ));
+
     CRM_Utils_System::civiExit();
   }
 

--- a/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
@@ -1,0 +1,168 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Token\TokenProcessor;
+
+/**
+ * Handles Credit Note Email Invoice Task.
+ */
+class CRM_Financeextras_Form_Contribute_CreditNoteEmail extends CRM_Core_Form {
+  use CRM_Contact_Form_Task_EmailTrait;
+
+  /**
+   * The array that holds all the contact ids.
+   *
+   * @var array
+   */
+  private $_contactIds; // phpcs:ignore
+
+  /**
+   * Current form context.
+   *
+   * @var string
+   */
+  private $_context; // phpcs:ignore
+
+  /**
+   * Credit Note ID.
+   *
+   * @var int
+   */
+  private $creditNoteId;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    $this->setTitle('Email Credit Note');
+    $this->creditNoteId = CRM_Utils_Request::retrieveValue('id', 'Positive');
+
+    $this->setContactIDs();
+    $this->setIsSearchContext(FALSE);
+    $this->traitPreProcess();
+  }
+
+  /**
+   * Lists available tokens for this form.
+   *
+   * Presently all tokens are returned.
+   *
+   * @return array
+   *   List of Available tokens
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function listTokens() {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contactId']]);
+    $tokens = $tokenProcessor->listTokens();
+
+    return $tokens;
+  }
+
+  /**
+   * Submits the form values.
+   *
+   * This is also accessible for testing.
+   *
+   * @param array $formValues
+   *   Submitted values.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   * @throws \API_Exception
+   */
+  public function submit(array $formValues): void {
+    $sents = 0;
+    $from = $formValues['from_email_address'];
+    $text = $this->getSubmittedValue('text_message');
+    $html = $this->getSubmittedValue('html_message');
+    $from = CRM_Utils_Mail::formatFromAddress($from);
+
+    $cc = $this->getCc();
+    $additionalDetails = empty($cc) ? '' : "\ncc : " . $this->getEmailUrlString($this->getCcArray());
+
+    $bcc = $this->getBcc();
+    $additionalDetails .= empty($bcc) ? '' : "\nbcc : " . $this->getEmailUrlString($this->getBccArray());
+
+    /** @var \Civi\Financeextras\Service\CreditNoteInvoiceService */
+    $creditNoteInvoiceService = \Civi::service('service.credit_note_invoice');
+    $creditNoteInvoice = $creditNoteInvoiceService->render($this->creditNoteId);
+
+    foreach ($this->getRowsForEmails() as $values) {
+      $mailParams = [];
+      $mailParams['messageTemplate'] = [
+        'msg_text' => $text,
+        'msg_html' => $html,
+        'msg_subject' => $this->getSubject(),
+      ];
+      $mailParams['tokenContext'] = [
+        'contactId' => $values['contact_id'],
+        'creditNoteId' => $this->creditNoteId,
+      ];
+      $mailParams['tplParams'] = [];
+      $mailParams['from'] = $from;
+      $mailParams['toEmail'] = $values['email'];
+      $mailParams['cc'] = $cc ?? NULL;
+      $mailParams['bcc'] = $bcc ?? NULL;
+      $mailParams['attachments'][] = CRM_Utils_Mail::appendPDF('creditnote_invoice.pdf', $creditNoteInvoice['html'], $creditNoteInvoice['format']);
+      // Send the mail.
+      [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($mailParams);
+      $sents += ($sent ? 1 : 0);
+    }
+
+    CRM_Core_Session::setStatus(ts('One email has been sent successfully. ', [
+      'plural' => '%count emails were sent successfully. ',
+      'count' => $sents,
+    ]), ts('Message Sent', ['plural' => 'Messages Sent', 'count' => $sents]), 'success');
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setContactIDs() { // phpcs:ignore
+    $this->_contactIds = $this->getContactIds();
+  }
+
+  /**
+   * Returns Credit Note Contact ID.
+   *
+   * @return array
+   *   Contact ID as an array
+   */
+  protected function getContactIds(): array {
+    if (isset($this->_contactIds)) {
+      return $this->_contactIds;
+    }
+
+    $creditNoteId = CRM_Utils_Request::retrieveValue('id', 'Positive');
+
+    $creditNote = CreditNote::get()
+      ->addWhere('id', '=', $creditNoteId)
+      ->execute()
+      ->first();
+
+    $this->_contactIds = [$creditNote['contact_id']];
+
+    return $this->_contactIds;
+  }
+
+  /**
+   * Get the rows for each contactID.
+   *
+   * @return array
+   *   Array if contact IDs.
+   */
+  protected function getRows(): array {
+    $rows = [];
+    foreach ($this->_contactIds as $index => $contactID) {
+      $rows[] = [
+        'contact_id' => $contactID,
+        'schema' => ['contactId' => $contactID],
+      ];
+    }
+    return $rows;
+  }
+
+}

--- a/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
@@ -2,6 +2,7 @@
 
 use Civi\Api4\CreditNote;
 use Civi\Token\TokenProcessor;
+use Civi\Financeextras\Event\CreditNoteMailedEvent;
 
 /**
  * Handles Credit Note Email Invoice Task.
@@ -116,6 +117,12 @@ class CRM_Financeextras_Form_Contribute_CreditNoteEmail extends CRM_Core_Form {
       'count' => $sents,
     ]), ts('Message Sent', ['plural' => 'Messages Sent', 'count' => $sents]), 'success');
 
+    Civi::dispatcher()->dispatch(CreditNoteMailedEvent::NAME, new CreditNoteMailedEvent(
+      $this->creditNoteId,
+      $creditNoteInvoice,
+      $this->getSubject(),
+      array_column($this->getRowsForEmails(), 'contact_id')
+    ));
   }
 
   /**

--- a/Civi/Financeextras/Event/CreditNoteDownloadedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteDownloadedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Civi\Financeextras\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * The fe.creditnote.downloaded event is dispatched
+ * when a credit note invoice is successfully downloaded
+ * within the system.
+ */
+class CreditNoteDownloadedEvent extends Event {
+  public const NAME = 'fe.creditnote.downloaded';
+
+  public function __construct(
+        protected int $creditNoteId,
+        protected array $creditNoteInvoice
+    ) {
+  }
+
+  public function getCreditNoteId() {
+    return $this->creditNoteId;
+  }
+
+  public function getCreditNoteInvoice() {
+    return $this->creditNoteInvoice;
+  }
+
+}

--- a/Civi/Financeextras/Event/CreditNoteMailedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteMailedEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Civi\Financeextras\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * The fe.creditnote.mailed event is dispatched
+ * when a credit note invoice is successfully mailed
+ * within the system.
+ */
+class CreditNoteMailedEvent extends Event {
+  public const NAME = 'fe.creditnote.mailed';
+
+  public function __construct(
+        protected int $creditNoteId,
+        protected array $creditNoteInvoice,
+        protected string $mailSubject,
+        protected array $contactIds,
+    ) {
+  }
+
+  public function getCreditNoteId() {
+    return $this->creditNoteId;
+  }
+
+  public function getCreditNoteInvoice() {
+    return $this->creditNoteInvoice;
+  }
+
+  public function getSubject() {
+    return $this->mailSubject;
+  }
+
+  public function getMailedContacts() {
+    return $this->contactIds;
+  }
+
+}

--- a/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
+++ b/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Civi\Financeextras\Event\Subscriber;
+
+use DateTime;
+use Civi\Financeextras\Event\CreditNoteMailedEvent;
+use Civi\Financeextras\Event\CreditNoteDownloadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      CreditNoteMailedEvent::NAME => 'createMailActivity',
+    ];
+  }
+
+  /**
+   * Creates activity for the creditnote invoice mail.
+   *
+   * @param \Civi\Financeextras\Event\CreditNoteMailedEvent $e
+   *   The registration event. Add new tokens using register().
+   */
+  public function createMailActivity(CreditNoteMailedEvent $e) {
+    $activityType = 'Emailed Invoice';
+    $attachment = $this->storeFile($e->getCreditNoteInvoice()['html'], $e->getCreditNoteInvoice()['format']);
+    $this->createActivity($e->getMailedContacts(), $activityType, $e->getSubject(), $attachment);
+  }
+
+  /**
+   * Creates Credit note invoice activity
+   *
+   * @param array $targetContactIds
+   * @param string $type
+   * @param string $subject
+   * @param array $attachment
+   */
+  private function createActivity($targetContactIds, $type, $subject, $attachment) {
+    $now = (new DateTime())->format('YmdHis');
+    $currentUser = \CRM_Core_Session::singleton()->get('userID');
+    \Civi\Api4\Activity::create()
+      ->addValue('subject', $subject)
+      ->addValue('target_contact_id', $targetContactIds)
+      ->addValue('source_contact_id', $currentUser)
+      ->addValue('activity_type_id:name', $type)
+      ->addValue('activity_date_time', $now)
+      ->addValue('attachFile_1', [
+        'uri' => $attachment,
+        'type' => 'application/pdf',
+        'location' => $attachment,
+        'upload_date' => date('YmdHis'),
+      ])
+      ->execute();
+  }
+
+  /**
+   * Persists the file to local disk
+   *
+   * @param string $content
+   *  The file content
+   * @param array $format
+   *  The file PDF format
+   *
+   * @return string
+   *   File path
+   */
+  private function storeFile($content, $format) {
+    return \CRM_Utils_Mail::appendPDF('credit_note_invoice.pdf', $content, $format)['fullPath'] ?? '';
+  }
+
+  /**
+   * Returns a credit note contact ID.
+   *
+   * @param int $id
+   *  Credit Note ID
+   *
+   * @return int
+   *   Credit Note contact ID
+   */
+  private function getCreditNoteContactId($id) {
+    return \Civi\Api4\CreditNote::get()
+      ->addSelect('contact_id')
+      ->addWhere('id', '=', $id)
+      ->execute()
+      ->first()['contact_id'];
+  }
+
+}

--- a/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
+++ b/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
@@ -15,7 +15,22 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents() {
     return [
       CreditNoteMailedEvent::NAME => 'createMailActivity',
+      CreditNoteDownloadedEvent::NAME => 'createDownloadActivity',
     ];
+  }
+
+  /**
+   * Creates activity for the creditnote invoice download.
+   *
+   * @param \Civi\Financeextras\Event\CreditNoteDownloadedEvent $e
+   *   The registration event. Add new tokens using register().
+   */
+  public function createDownloadActivity(CreditNoteDownloadedEvent $e) {
+    $activityType = 'Downloaded Invoice';
+    $subject = 'Downloaded Credit Note PDF';
+    $targetContactId = $this->getCreditNoteContactId($e->getCreditNoteId());
+    $attachment = $this->storeFile($e->getCreditNoteInvoice()['html'], $e->getCreditNoteInvoice()['format']);
+    $this->createActivity([$targetContactId], $activityType, $subject, $attachment);
   }
 
   /**

--- a/financeextras.php
+++ b/financeextras.php
@@ -13,6 +13,7 @@ use CRM_Financeextras_ExtensionUtil as E;
 function financeextras_civicrm_config(&$config) {
   _financeextras_civix_civicrm_config($config);
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\SearchDisplayRun', 'respond'], -100);
+  Civi::dispatcher()->addSubscriber(new Civi\Financeextras\Event\Subscriber\CreditNoteInvoiceSubscriber());
 }
 
 /**

--- a/managed/SavedSearch_Credit_Notes.mgd.php
+++ b/managed/SavedSearch_Credit_Notes.mgd.php
@@ -162,7 +162,7 @@ $mgd = [
                   'target' => '',
                 ],
                 [
-                  'path' => 'civicrm/',
+                  'path' => 'civicrm/contribution/creditnote/email?id=[id]',
                   'icon' => 'fa-external-link',
                   'text' => 'Email Credit Note',
                   'style' => 'default',

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteEmail.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteEmail.tpl
@@ -1,0 +1,88 @@
+{* {include file="CRM/Contact/Form/Task/Email.tpl"} *}
+
+<div class="messages status no-popup">
+  {icon icon="fa-info-circle"}{/icon}
+  {ts}You can email a credit note from this screen. The credit note will be attached as a PDF to your email.{/ts}
+</div>
+<table class="form-layout-compressed">
+  <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
+    <td class="label">{$form.from_email_address.label}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+  </tr>
+  <tr class="crm-contactEmail-form-block-recipient">
+    <td class="label">{$form.to.label}</td>
+    <td>
+      {$form.to.html} {help id="id-to_email" file="CRM/Contact/Form/Task/Email.hlp"}
+    </td>
+  </tr>
+  <tr class="crm-email-element crm-contactEmail-form-block-cc_id">
+    <td class="label">{$form.cc_id.label}</td>
+    <td>
+        {$form.cc_id.html}
+    </td>
+  </tr>
+  <tr class="crm-contactEmail-form-block-template">
+    <td class="label">{$form.template.label}</td>
+    <td>{$form.template.html}</td>
+  </tr>
+  <tr class="crm-contactEmail-form-block-subject">
+    <td class="label">{$form.subject.label}</td>
+    <td>
+      {$form.subject.html|crmAddClass:huge}&nbsp;
+    </td>
+  </tr>
+  <tr class="crm-email-element">
+    <td class="label">{ts}Email body{/ts}</td>
+    <td><div class="html">{$form.html_message.html}</div></td>
+  </tr>
+</table>
+
+<div class="spacer"></div>
+<div class="crm-submit-buttons">
+  {$form.buttons.html}
+</div>
+
+{literal}
+<script>
+
+  CRM.$(function($) {
+    var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkemail' q='id=1' h=0 }{literal}";
+
+    var $form = $("form.{/literal}{$form.formClass}{literal}");
+    function emailSelect(el, prepopulate) {
+      $(el, $form).data('api-entity', 'contact').css({width: '40em', 'max-width': '90%'}).crmSelect2({
+        minimumInputLength: 1,
+        multiple: true,
+        ajax: {
+          url: sourceDataUrl,
+          data: function(term) {
+            return {
+              name: term
+            };
+          },
+          results: function(response) {
+            return {
+              results: response
+            };
+          }
+        }
+      }).select2('data', prepopulate);
+    }
+
+    {/literal}
+      var toContact = {if $toContact}{$toContact}{else}''{/if};
+    {literal}
+    emailSelect('#to', toContact);
+  })
+
+  function selectValue(val) {
+    console.log(val)
+    var dataUrl = {/literal}"{crmURL p='civicrm/ajax/template' h=0 }"{literal};
+
+    cj.post( dataUrl, {tid: val}, function( data ) {
+      CRM.wysiwyg.setVal('#html_message', data.msg_html || '');
+      cj("#subject").val( data.subject || '' );
+    });
+  }
+</script>
+{/literal}

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -5,9 +5,14 @@
     <page_callback>CRM_Financeextras_Page_Contribute_CreditNoteAngular</page_callback>
     <access_arguments>edit contributions</access_arguments>
   </item>
-    <item>
+  <item>
     <path>civicrm/contribution/creditnote/download-pdf</path>
     <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteInvoice::download</page_callback>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/contribution/creditnote/email</path>
+    <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteEmail</page_callback>
     <access_arguments>edit contributions</access_arguments>
   </item>
   <item>

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -7,7 +7,7 @@
   </item>
   <item>
     <path>civicrm/contribution/creditnote/download-pdf</path>
-    <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteInvoice::download</page_callback>
+    <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteDownload::download</page_callback>
     <access_arguments>edit contributions</access_arguments>
   </item>
   <item>


### PR DESCRIPTION
## Overview
This PR adds the functionality that allows the user to email a credit note invoice to contacts.

## Before
No functionality to send credit note invoice emails to contacts

## After
The user can now send credit note invoice emails to contacts, and an activity is created with the mail recipients as target contact.

![resttt222](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d22f11b0-db2f-4095-a10e-08379c43db02)


## Technical Details
Additionally, as part of this email functionality, Two new types of invoice-related activity types are now created: "Emailed Invoice" and "Downloaded Invoice." The former is created when an invoice is sent to a contact via email, while the latter is generated when the invoice is downloaded in PDF format.

<img width="519" alt="Screenshot 2023-06-27 at 14 53 52" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/a0f894e7-0925-40a8-8584-a9a83c0f5179">

For both types of activities, we ensure that the credit note invoice is attached to the corresponding activity record.

