### PR TITLE
CIWEMB-294:User can void credit note

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteVoid.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteVoid.php
@@ -1,0 +1,65 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use CRM_Financeextras_ExtensionUtil as E;
+
+/**
+ * Credit Note void Form controller class.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+class CRM_Financeextras_Form_Contribute_CreditNoteVoid extends CRM_Core_Form {
+
+  /**
+   * Credit Note to void.
+   *
+   * @var int
+   */
+  public $id;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    CRM_Utils_System::setTitle('Void Credit Note');
+
+    $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => E::ts('Yes'),
+      ],
+      [
+        'type' => 'cancel',
+        'name' => E::ts('No'),
+        'isDefault' => TRUE,
+      ],
+    ]);
+
+    parent::buildQuickForm();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function postProcess() {
+    if (!empty($this->id)) {
+      try {
+        CreditNote::void()
+          ->setId($this->id)
+          ->execute();
+        CRM_Core_Session::setStatus(E::ts('Credit Note voided successfully.'), ts('Credit Note voided'), 'success');
+      }
+      catch (\Throwable $th) {
+        CRM_Core_Session::setStatus(E::ts($th->getMessage()), ts('Error voiding credit note'), 'error');
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/Action/CreditNote/VoidAction.php
+++ b/Civi/Api4/Action/CreditNote/VoidAction.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNote;
+
+use Civi\Api4\CreditNote;
+use CRM_Core_Transaction;
+use Civi\Api4\CreditNoteLine;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\CreditNoteAllocation;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+
+/**
+ * Voids Credit notes.
+ */
+class VoidAction extends AbstractAction {
+  use DAOActionTrait;
+
+  /**
+   * credit note id.
+   *
+   * @var int
+   */
+  protected $id;
+
+  /**
+   * credit note.
+   *
+   * @var int
+   */
+  private $creditNote;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    $transaction = CRM_Core_Transaction::create();
+    try {
+      if (is_int($this->id)) {
+        $result[] = $this->voidCreditNote();
+      }
+
+      $transaction->commit();
+    }
+    catch (\Throwable $th) {
+      $transaction->rollback();
+      throw $th;
+    }
+  }
+
+  /**
+   * Voids credit notes and lines accounting entries.
+   *
+   * @throws \API_Exception
+   */
+  private function voidCreditNote(): void {
+    if (!$this->validateAction()) {
+      throw new \API_Exception("Allocation has been made from the credit note, or doesn't exist");
+    }
+
+    $finacialTypeId = $this->creditNote['items'][0]['financial_type_id'];
+    $financialTrxn = \CRM_Financeextras_BAO_CreditNote::voidCreditNote($this->id, $finacialTypeId);
+
+    \CRM_Financeextras_BAO_CreditNoteLine::voidAccountingEntries($this->creditNote, $financialTrxn);
+  }
+
+  /**
+   * Validates if a credit note can be void.
+   *
+   * Credit notes can be voided if
+   *  - status is open
+   *  - no amounts have been allocated
+   *  - no cash refund recorded
+   *  - no credit card refund recorded
+   *
+   * @return bool
+   *   TRUE if credit note can be void, otherwise FALSE.
+   */
+  private function validateAction() {
+    $this->creditNote = CreditNote::get()
+      ->addWhere('id', '=', $this->id)
+      ->addWhere('status_id:name', '=', 'open')
+      ->addChain('items', CreditNoteLine::get()
+        ->addWhere('credit_note_id', '=', '$id')
+      )
+      ->execute()
+      ->first();
+
+    if (empty($this->creditNote)) {
+      return FALSE;
+    }
+
+    $creditNoteAllocations = CreditNoteAllocation::get()
+      ->addWhere('credit_note_id', '=', $this->id)
+      ->execute()
+      ->first();
+
+    return empty($creditNoteAllocations);
+  }
+
+}

--- a/Civi/Api4/CreditNote.php
+++ b/Civi/Api4/CreditNote.php
@@ -2,10 +2,11 @@
 
 namespace Civi\Api4;
 
+use Civi\Api4\Action\CreditNote\GetAction;
+use Civi\Api4\Action\CreditNote\VoidAction;
 use Civi\Api4\Action\CreditNote\ComputeTotalAction;
 use Civi\Api4\Action\CreditNote\CreditNoteSaveAction;
 use Civi\Api4\Action\CreditNote\DeleteWithItemsAction;
-use Civi\Api4\Action\CreditNote\GetAction;
 
 /**
  * CreditNote entity.
@@ -71,11 +72,26 @@ class CreditNote extends Generic\DAOEntity {
   }
 
   /**
+   * Voids a credit note.
+   *
+   * @param bool $checkPermissions
+   *  Should permission be checked for the user.
+   *
+   * @return \Civi\Api4\Action\CreditNote\VoidAction
+   *   returns the credit note void action
+   */
+  public static function void($checkPermissions = TRUE) {
+    return (new VoidAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * {@inheritDoc}
    */
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
+      'void' => ['access CiviContribute', 'edit contributions'],
       'computeTotal' => ['access CiviCRM', 'access CiviContribute'],
       'get' => ['access CiviCRM', 'access CiviContribute'],
       'default' => ['access CiviCRM', 'access CiviContribute', 'edit contributions'],

--- a/Civi/Financeextras/Utils/OptionValueUtils.php
+++ b/Civi/Financeextras/Utils/OptionValueUtils.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Civi\Financeextras\Utils;
+
+use Civi\Api4\OptionValue;
+
+/**
+ * Class provide utility methods for 'OptionValue'
+ */
+class OptionValueUtils {
+
+  /**
+   * Gets the option value ID (value)
+   * for the specified option group.
+   *
+   * @param string $optionGroupName
+   * @param string $optionValueName
+   *
+   * @return string
+   */
+  public static function getValueForOptionValue($optionGroupName, $optionValueName) {
+    return OptionValue::get()
+      ->addWhere('option_group_id:name', '=', $optionGroupName)
+      ->addWhere('name', '=', $optionValueName)
+      ->addSelect('value')
+      ->setLimit(1)
+      ->execute()
+      ->first()['value'] ?? NULL;
+  }
+
+}

--- a/js/creditnote.js
+++ b/js/creditnote.js
@@ -1,7 +1,5 @@
 CRM.$(function () {
-  CRM.$(function () {
-    moveCreditNoteTabNextToContributionTab();
-  });
+  moveCreditNoteTabNextToContributionTab();
 
   /**
    * Moves the credit note tab to the appropratie position

--- a/managed/SavedSearch_Credit_Notes.mgd.php
+++ b/managed/SavedSearch_Credit_Notes.mgd.php
@@ -173,7 +173,7 @@ $mgd = [
                   'target' => 'crm-popup',
                 ],
                 [
-                  'path' => 'civicrm/',
+                  'path' => 'civicrm/contribution/creditnote/void?id=[id]',
                   'icon' => 'fa-external-link',
                   'text' => 'Void',
                   'style' => 'default',
@@ -181,7 +181,7 @@ $mgd = [
                   'entity' => '',
                   'action' => '',
                   'join' => '',
-                  'target' => '',
+                  'target' => 'crm-popup',
                 ],
                 [
                   'path' => 'civicrm/contribution/creditnote/allocate?crid=[id]',

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteVoid.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteVoid.tpl
@@ -1,0 +1,21 @@
+<div id="bootstrap-theme">
+  <div class="alert alert-warning text-center">
+    <h1><i class="fa fa-question-circle"></i></h1>
+    <h3>{ts}Are you sure you would like to Void this credit note?{/ts} </h3>
+    
+    <h4>{ts}This cannot be undone.{/ts}</h4>
+  </div>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>
+
+<script type="text/javascript">
+  {literal}
+    CRM.$(function($) {
+      $("a[target='crm-popup']").on('crmPopupFormSuccess', function (e) {
+        CRM.refreshParent(e);
+      });
+    });
+  {/literal}
+</script>

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Financeextras\Utils\OptionValueUtils;
+use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
+use Civi\Financeextras\Utils\FinancialAccountUtils;
+
+/**
+ * CreditNote.VoidAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CreditNote_VoidActionTest extends BaseHeadlessTest {
+
+  use CreditNoteTrait;
+
+  /**
+   * Test case to verify that a credit note with manual refund allocation cannot be voided.
+   */
+  public function testCreditNoteWithManualRefundAllocationCannotBeVoided() {
+    $creditNote = $this->createCreditNote();
+
+    $this->allocateCredit($creditNote['id'], 'manual_refund_payment', $creditNote['total_credit'] / 2);
+
+    $this->expectException(\API_Exception::class);
+    $this->expectExceptionMessage('Allocation has been made from the credit note, or doesn\'t exist');
+
+    CreditNote::void()->setId($creditNote['id'])->execute();
+  }
+
+  /**
+   * Test case to verify that a credit note with online refund allocation cannot be voided.
+   */
+  public function testCreditNoteWithOnlineRefundAllocationCannotBeVoided() {
+    $creditNote = $this->createCreditNote();
+
+    $this->allocateCredit($creditNote['id'], 'online_refund_payment', $creditNote['total_credit'] / 2);
+
+    $this->expectException(\API_Exception::class);
+    $this->expectExceptionMessage('Allocation has been made from the credit note, or doesn\'t exist');
+
+    CreditNote::void()->setId($creditNote['id'])->execute();
+  }
+
+  /**
+   * Test case to verify that a credit note with invoice allocation cannot be voided.
+   */
+  public function testCreditNoteWithInvoiceAllocationCannotBeVoided() {
+    $creditNote = $this->createCreditNote();
+
+    $this->allocateCredit($creditNote['id'], 'invoice', $creditNote['total_credit'] / 2);
+
+    $this->expectException(\API_Exception::class);
+    $this->expectExceptionMessage('Allocation has been made from the credit note, or doesn\'t exist');
+
+    CreditNote::void()->setId($creditNote['id'])->execute();
+  }
+
+  /**
+   * Test case to verify that the credit note status updates as expected when voided.
+   */
+  public function testCreditNoteStatusUpdatesAsExpected() {
+    $creditNote = $this->createCreditNote();
+
+    CreditNote::void()->setId($creditNote['id'])->execute();
+
+    $creditNote = CreditNote::get()
+      ->addWhere('id', '=', $creditNote['id'])
+      ->execute()
+      ->first();
+
+    $voidStatus = OptionValueUtils::getValueForOptionValue(CreditNoteStatusManager::NAME, 'void');
+    $this->assertEquals($voidStatus, $creditNote['status_id']);
+  }
+
+  /**
+   * Test case to verify that the expected accounting entries are created for a voided credit note.
+   *
+   * Asserts that the credit note is associated with a valid entity financial transaction
+   * and that the financial transaction meets the expected criteria.
+   */
+  public function testExpectedCreditNoteAccountingEntriesAreCreated() {
+    $creditNote = $this->createCreditNote();
+    CreditNote::void()->setId($creditNote['id'])->execute();
+    $expectedToAccount = \CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $creditNote['items'][0]['financial_type_id'],
+      'Accounts Receivable Account is'
+    );
+
+    $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNote::$_tableName)
+      ->addWhere('entity_id', '=', $creditNote['id'])
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+
+    $this->assertNotEmpty($entityFinancialTrxn);
+
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('id', '=', $entityFinancialTrxn['financial_trxn_id'])
+      ->addWhere('total_amount', '=', $creditNote['total_credit'])
+      ->addWhere('status_id:name', '=', 'Cancelled')
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('check_number', 'IS NULL')
+      ->addWhere('currency', '=', $creditNote['currency'])
+      ->addWhere('to_financial_account_id', '=', $expectedToAccount)
+      ->addWhere('from_financial_account_id', 'IS NULL')
+      ->addWhere('is_payment', '=', FALSE)
+      ->execute()
+      ->getArrayCopy();
+
+    $this->assertNotEmpty($financialTrxn);
+    $this->assertCount(1, $financialTrxn);
+  }
+
+  /**
+   * Tests that the expected accounting entries are created for the voided credit note line items with tax.
+   *
+   * For each credit note line entity with tax:
+   *  A Financial Item should be created for the amount - tax.
+   *  An Entity Financial transaction linking to financial item of the amount - tax should be created.
+   *
+   *  A Financial Item should be created for the tax amount.
+   *  An Entity Financial transaction linking to financial item of the tax amount should be created.
+   */
+  public function testExpectedCreditNoteLineAccountingEntriesAreCreated() {
+    $creditNoteData = $this->getCreditNoteData();
+    $creditNoteData['items'][] = $this->getCreditNoteLineData(['tax_rate' => 10]);
+
+    $creditNote = CreditNote::save()
+      ->addRecord($creditNoteData)
+      ->execute()
+      ->first();
+    CreditNote::void()->setId($creditNote['id'])->execute();
+
+    foreach ($creditNote['items'] as $lineItem) {
+      $expectedFinancialAccount = FinancialAccountUtils::getFinancialTypeAccount($lineItem['financial_type_id'], 'Income Account is');
+
+      $financialItemAPI = \Civi\Api4\FinancialItem::get(FALSE)
+        ->addWhere('entity_id', '=', $lineItem['id'])
+        ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNoteLine::$_tableName)
+        ->addWhere('currency', '=', $creditNote['currency'])
+        ->addWhere('contact_id', '=', $creditNote['contact_id']);
+
+      // Financial item should be created for Voided credit note line item.
+      $financialItemForMainAmount = (clone $financialItemAPI)->addWhere('amount', '=', ($lineItem['quantity'] * $lineItem['unit_price']))
+        ->execute()
+        ->first();
+      $this->assertNotEmpty($financialItemForMainAmount);
+      $this->assertEquals($expectedFinancialAccount, $financialItemForMainAmount['financial_account_id']);
+
+      // Financial item should be created for Voided credit note line item tax.
+      $expectedTaxFinancialAccount = FinancialAccountUtils::getFinancialTypeAccount($lineItem['financial_type_id'], 'Sales Tax Account is');
+      $financialItemForTax = (clone $financialItemAPI)->addWhere('amount', '=', $lineItem['tax_amount'])
+        ->execute()
+        ->first();
+      $this->assertNotEmpty($financialItemForTax);
+      $this->assertEquals($expectedTaxFinancialAccount, $financialItemForTax['financial_account_id']);
+
+      // Entity financial transaction should be created for both the main and tax financial item.
+      foreach ([$financialItemForMainAmount, $financialItemForTax] as $financialItem) {
+        $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+          ->addWhere('entity_id', '=', $financialItem['id'])
+          ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+          ->execute()
+          ->first();
+
+        $this->assertNotEmpty($entityFinancialTrxn);
+      }
+    }
+  }
+
+}

--- a/tests/phpunit/Civi/Financeextras/Test/Helper/CreditNoteTrait.php
+++ b/tests/phpunit/Civi/Financeextras/Test/Helper/CreditNoteTrait.php
@@ -4,6 +4,7 @@ namespace Civi\Financeextras\Test\Helper;
 
 use Civi\Api4\CreditNote;
 use Civi\Api4\OptionValue;
+use Civi\Financeextras\Utils\OptionValueUtils;
 use Civi\Financeextras\Test\Fabricator\ContactFabricator;
 
 /**
@@ -95,12 +96,28 @@ trait CreditNoteTrait {
       $creditNote['items'][0]['tax_rate'] = $params['items']['tax_rate'];
     }
 
-    $creditNote['id'] = CreditNote::save()
+    return CreditNote::save()
       ->addRecord($creditNote)
       ->execute()
-      ->jsonSerialize()[0]['id'];
+      ->first();
+  }
 
-    return $creditNote;
+  /**
+   * Creates credit note allocation record
+   *
+   * @param int $creditNoteId
+   * @param string $allocationType
+   * @param int $amount
+   */
+  public function allocateCredit($creditNoteId, $allocationType, $amount) {
+    $type = OptionValueUtils::getValueForOptionValue('financeextras_credit_note_allocation_type', $allocationType);
+
+    \Civi\Api4\CreditNoteAllocation::create()
+      ->addValue('credit_note_id', $creditNoteId)
+      ->addValue('type_id', $type)
+      ->addValue('currency', 'GBP')
+      ->addValue('amount', $amount)
+      ->execute();
   }
 
 }

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -30,4 +30,9 @@
     <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteDelete</page_callback>
     <access_arguments>access CiviCRM, access CiviContribute, delete in CiviContribute</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contribution/creditnote/void</path>
+    <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteVoid</page_callback>
+    <access_arguments>access CiviCRM, access CiviContribute, edit contributions</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR allows users to void a credit note

## Before
The functionality wasn't available

## After
Users can void a credit note

[screencast-compu.test_8888-2023.07.05-13_32_50.webm](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1a619a39-9fd4-45bd-91b6-9ad381b198fb)


## Technical Details
To void a credit note, its status is changed to `void`, and additional accounting entries are generated to reverse the effects of the credit note.

In a previous [PR](https://github.com/compucorp/io.compuco.financeextras/pull/30), when a credit note is generated, a set of financial accounting entries is created. In this PR, we replicate the same account accounting entries but with positive amounts instead of negative amounts, which is the case for new credit notes.

Furthermore, a credit note can only be voided if it does not have any associated allocations, such as an invoice, manual refund, or online refund. In [PR](https://github.com/compucorp/io.compuco.financeextras/pull/32), we have included a validation that disables the void action in the context menu if this condition is not met. This PR introduces an additional check at the API layer to enforce this requirement.
https://github.com/compucorp/io.compuco.financeextras/blob/125a56fcd03c1998533625dbcd7b86d98d301b5d/Civi/Api4/Action/CreditNote/VoidAction.php#L79

