### PR TITLE
CIWEMB-293: User can edit credit note

### DIFF
--- a/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
+++ b/CRM/Financeextras/Page/Contribute/CreditNoteAngular.php
@@ -32,6 +32,7 @@ class CRM_Financeextras_Page_Contribute_CreditNoteAngular extends \CRM_Core_Page
     $routes = [
       CRM_Core_Action::ADD => ['name' => 'new', 'title' => 'New Credit Note'],
       CRM_Core_Action::VIEW => ['name' => 'view', 'title' => 'View Credit Note'],
+      CRM_Core_Action::UPDATE => ['name' => 'update', 'title' => 'Update Credit Note'],
     ];
     return $routes[$action] ?? $routes[CRM_Core_Action::ADD];
   }

--- a/Civi/Api4/Action/CreditNote/CreditNoteSaveAction.php
+++ b/Civi/Api4/Action/CreditNote/CreditNoteSaveAction.php
@@ -43,7 +43,12 @@ class CreditNoteSaveAction extends AbstractSaveAction {
     try {
       $output = [];
       foreach ($items as $creditNote) {
-        $output[] = $this->createCreditNoteWithAccountingEntries($creditNote);
+        if (empty($creditNote['id'])) {
+          $output[] = $this->createCreditNoteWithAccountingEntries($creditNote);
+          continue;
+        }
+
+        $output[] = $this->updateCreditNote($creditNote);
       }
 
       return $output;
@@ -101,6 +106,28 @@ class CreditNoteSaveAction extends AbstractSaveAction {
     $finacialTypeId = $data['items'][0]['financial_type_id'];
 
     return CreditNoteBAO::createWithAccountingEntries($data, $finacialTypeId);
+  }
+
+  /**
+   * Updates credit note entity
+   *
+   * @param array $data
+   *  The credit note params
+   *
+   * @return array
+   *   updated credit note entity
+   */
+  public function updateCreditNote(array $data) {
+    $params = [
+      'id' => $data['id'],
+      'date' => $data['date'],
+      'comment' => $data['comment'],
+      'cn_number' => $data['cn_number'],
+      'reference' => $data['reference'],
+      'description' => $data['description'],
+    ];
+
+    return CreditNoteBAO::create($params);
   }
 
 }

--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
@@ -5,7 +5,7 @@
       <label class="col-sm-6 control-label">
         {{ts('Allocated')}}
       </label>
-      <div class="col-sm-6" ng-if="hasAllocatePermission">
+      <div class="col-sm-6" ng-if="hasAllocatePermission && isView">
         <a ng-href="{{ crmUrl('civicrm/contribution/creditnote/allocate', {crid: creditNoteId}) }}" class="btn btn-primary-outline pull-right">Allocate Credit</a>
       </div>
     </div>
@@ -15,14 +15,16 @@
   <br />
 </div>
 <div class="form-group">
-  <div class="col-sm-12" style="overflow: scroll;">
+  <div class="col-sm-12">
     <table class="table table-bordered table-striped">
      <tr>
        <th>Allocation Type</th>
        <th>Allocated To</th>
        <th>Date</th>
        <th>Reference</th>
+       <th>Paid From</th>
        <th>Amount</th>
+       <th ng-if="isUpdate"></th>
      </tr>
      <tr ng-repeat="allocation in allocations track by $index">
       <td>{{ allocation['type_id:label'] }}</td>
@@ -34,7 +36,27 @@
       </td>
       <td>{{ formatDate(allocation['date'], 'dd-M-yy') }}</td>
       <td>{{ allocation['reference'] }}</td>
+      <td>{{ allocation['paid_from'] }}</td>
       <td>{{ formatMoney(allocation['amount'], currency, true) }}</td>
+      <td ng-if="isUpdate">
+        <div class="btn-group btn-group-sm">
+          <button
+            type="button"
+            class="btn btn-default dropdown-toggle crm-hover-button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
+            ng-disabled="item['case_type_id.is_active'] === '0'"
+          >
+            <i class="fa fa-ellipsis-v"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-right">
+            <li ng-if="allocation['type_id:label'] == 'Invoice'">
+              <a title="{{:: ts('Delete') }}" ng-click="deleteAllocation(allocation['id'])" href="#">Delete</a>
+            </li>
+          </ul>
+        </div>
+      </td>
      </tr>
      </table>
   </div>

--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
@@ -8,6 +8,7 @@
       templateUrl: '~/fe-creditnote/directives/creditnote-allocation-table.directive.html',
       scope: {
         creditNoteId: '@',
+        context: '@'
       }
     };
   });
@@ -27,8 +28,10 @@
     $scope.total_credit = 0;
     $scope.allocated_credit = 0;
     $scope.remaining_credit = 0;
+    $scope.isView = $scope.context == 'view'
     $scope.formatDate = CRM.utils.formatDate;
     $scope.formatMoney = MoneyFormat.formatMoney;
+    $scope.isUpdate = $scope.context == 'update';
     $scope.hasAllocatePermission = CRM['fe-creditnote'].canEditContribution;
 
     crmApi4('CreditNote', 'get', {
@@ -37,12 +40,18 @@
       chain: {"allocations":["CreditNoteAllocation", "get", {"where":[["credit_note_id", "=", "$id"]], "select":["*", "type_id:label", "contribution_id.invoice_number"]}]}
     }).then(function(result) {
       const creditnotes = result[0] ?? null;
+
       $scope.currency = creditnotes.currency
-      $scope.allocations = creditnotes.allocations
+      $scope.allocations = creditnotes.allocations ?? []
       $scope.total_credit = creditnotes.total_credit
       $scope.remaining_credit = creditnotes.remaining_credit
       $scope.allocated_credit = creditnotes.total_credit - creditnotes.remaining_credit
     });
+
+    $scope.deleteAllocation = () => {
+      //not yet implemented.
+      CRM.alert('', 'No implementation', '', 'success');
+    }
 
   }
 

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -25,11 +25,35 @@
               }"
               required
               ng-minlength="1"
-              ng-disabled="isView"
+              ng-disabled="isView || isUpdate"
             />
             <span class="crm-inline-error" ng-show="creditnotesForm.contact.$dirty && creditnotesForm.contact.$invalid && creditnotesForm.contact.$error.required">Contact is required</span>
           </div>
         </div>
+        <div class="form-group" ng-if="isView || isUpdate">
+          <label class="col-sm-2 control-label required-mark">
+            {{ ts('Status') }}
+          </label>
+          <div class="col-sm-5">
+            <input class="form-control"
+              name="status_id"
+              ng-model="creditnotes.status_id"
+              crm-entityref="{
+                create: true,
+                entity: 'OptionValue',
+                api: {
+                  description_field: null,
+                  params: {active: true, option_group_id: 'financeextras_credit_note_status'}
+                },
+                select: { multiple: false, allowClear: false }
+              }"
+              required
+              ng-minlength="1"
+              ng-disabled="isView || isUpdate"
+            />
+          </div>
+        </div>
+
         <div class="form-group">
           <label class="col-sm-2 control-label required-mark">
             {{ ts('Number') }}
@@ -37,7 +61,7 @@
           <div class="col-sm-5">
               <input
                 class="form-control"" id="creditnotes_number"
-                ng-model="creditnotes.cn_number" placeholder="Number" name="number" type="text" disabled/>
+                ng-model="creditnotes.cn_number" placeholder="Number" name="number" type="text" ng-disabled="!isUpdate"/>
           </div>
         </div>
         <div class="form-group">
@@ -81,7 +105,7 @@
               ng-change="handleCurrencyChange()"
               placeholder="Currency"
               name="currency"
-              ng-disabled="isView"
+              ng-disabled="isView || isUpdate"
               required
             >
             <option value="">{{ ts('Currency') }}</option>
@@ -91,7 +115,7 @@
           </div>
         </div>
 
-        <div ng-if="!isView">
+        <div ng-if="!(isView || isUpdate)">
           <div class="row">
             <label class="col-sm-2 control-label required-mark">
               {{ts('Line Items:')}}
@@ -164,7 +188,7 @@
             <label class="col-sm-2"></label>
           </div>
         </div>
-        <div ng-if="isView">
+        <div ng-if="isView || isUpdate">
           <creditnote-line-table credit-note="{{ creditnotes }}" />
         </div>
 
@@ -201,13 +225,13 @@
         </div>
 
       </form>
-      <creditnote-allocation-table ng-if="creditnotes.id && isView" credit-note-id="{{creditnotes.id}}" />
+      <creditnote-allocation-table ng-if="creditnotes.id && (isView || isUpdate)" context="{{context}}" credit-note-id="{{creditnotes.id}}" />
     </div>
     <div class="panel-footer flex-between crm-submit-buttons">
         <a class="btn btn-primary-outline cancel crm-form-submit crm-button-type-cancel" ng-href="{{ crmUrl('civicrm/contact/view', {reset: 1, cid: contactId, selectedChild: 'contribute'}) }}">
           <span class="btn-icon"></span> {{ts('Cancel')}}</a>
         <button ng-if="!isView" type="submit" class="btn btn-primary crm-form-submit crm-button crm-button-type-submit" ng-disabled="submitInProgress" ng-click="saveCreditnotes()">
-          <span class="btn-icon"></span> {{ts('Create')}}</button>
+          <span class="btn-icon"></span> <span ng-if="!isUpdate">{{ts('Create')}}</span> <span ng-if="isUpdate">{{ts('Save')}}</span></button>
     </div>
   </div>
 </div>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -174,7 +174,8 @@
         $scope.creditnotes.description = creditnotes.description
         $scope.creditnotes.reference = creditnotes.reference
         $scope.creditnotes.comment = creditnotes.comment
-        $scope.creditnotes.items = [];
+        $scope.creditnotes.status_id = creditnotes.status_id
+        $scope.creditnotes.items = []
 
         creditnotes.items.forEach((element, i) => {
           $scope.creditnotes.items.push({
@@ -232,7 +233,7 @@
           redirectToAppropraitePage(result[0].id);
         }, function () {
           $scope.submitInProgress = false;
-          CRM.alert('Unable to create credit note', ts('Error'), 'error');
+          CRM.alert(`Unable to ${$scope.isUpdate? 'update': 'create'} credit note`, ts('Error'), 'error');
         });
     }
 
@@ -256,6 +257,11 @@
      * @param {boolean} the credit note ID
      */
     function redirectToAppropraitePage (creditNoteId) {
+      if ($scope.isUpdate) {
+        $window.location.href = $window.document.referrer;
+        return;
+      }
+
       $window.location.href = CRM.url(`/contribution/creditnote/allocate?crid=${creditNoteId}`);
     }
 

--- a/ang/fe-creditnote/directives/creditnote-line-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-line-table.directive.html
@@ -21,7 +21,7 @@
       <td>{{item.financial_type}}</td>
       <td>{{item.quantity}}</td>
       <td>{{ formatMoney(item['unit_price'], currency, true) }}</td>
-      <td>{{item.tax_rate}}</td>
+      <td>{{item.tax_rate}}%</td>
       <td>{{ formatMoney(item['line_total'], currency, true) }}</td>
      </tr>
     </table>

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -87,8 +87,4 @@
   #creditnote__view .table tr:first-child > td {
     border-top: none;
   }
-  #creditnote__view .table tr> td:first-child:not(.no-bold) {
-    color: #000;
-    font-weight: 600;
-  }
 </style>

--- a/css/fe-creditnote.css
+++ b/css/fe-creditnote.css
@@ -33,3 +33,6 @@
   right: 0;
   left: auto;
 }
+#bootstrap-theme .table .table {
+  background-color: unset;
+}


### PR DESCRIPTION
## Overview
With this PR user can edit a credit note.

## Before
The user couldn't edit a credit note

## After
The user can edit a credit note
![llexsaaaa](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/3d3bcbb2-7e8c-4837-97af-9e2ffc780fbc)


Also, we've added a delete button to the credit note allocation list (Type invlice). The delete functionality will be added in a different PR
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/cb031cf0-ade2-4316-849c-9b87026ccaec)


## Technical Details
Presently because of the accounting complexities and implications only the following fields can be updated by a user
- date
- comment
- cn_number
- reference
- description

While other fields are displayed as read-only.