### PR TITLE
CIWEMB-291: Update action menu items icon

### DIFF
--- a/managed/SavedSearch_Credit_Notes.mgd.php
+++ b/managed/SavedSearch_Credit_Notes.mgd.php
@@ -152,7 +152,7 @@ $mgd = [
                 ],
                 [
                   'path' => 'civicrm/contribution/creditnote/download-pdf?id=[id]',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-download',
                   'text' => 'Download PDF Document Credit Note',
                   'style' => 'default',
                   'condition' => [],
@@ -163,7 +163,7 @@ $mgd = [
                 ],
                 [
                   'path' => 'civicrm/contribution/creditnote/email?id=[id]',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-envelope-o',
                   'text' => 'Email Credit Note',
                   'style' => 'default',
                   'condition' => [],
@@ -174,7 +174,7 @@ $mgd = [
                 ],
                 [
                   'path' => 'civicrm/contribution/creditnote/void?id=[id]',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-ban',
                   'text' => 'Void',
                   'style' => 'default',
                   'condition' => [],
@@ -185,7 +185,7 @@ $mgd = [
                 ],
                 [
                   'path' => 'civicrm/contribution/creditnote/allocate?crid=[id]',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-money',
                   'text' => 'Allocate credit to invoice',
                   'style' => 'default',
                   'condition' => [],
@@ -196,7 +196,7 @@ $mgd = [
                 ],
                 [
                   'path' => 'civicrm/',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-retweet',
                   'text' => 'Record cash refund',
                   'style' => 'default',
                   'condition' => [],
@@ -207,7 +207,7 @@ $mgd = [
                 ],
                 [
                   'path' => 'civicrm/',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-credit-card',
                   'text' => 'Make credit card refund',
                   'style' => 'default',
                   'condition' => [],


### PR DESCRIPTION
## Overview
This PR updates the icon used for the credit note list action menu items.

## Before
<img width="281" alt="Screenshot 2023-07-10 at 15 46 17" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/30c623c1-4a99-4126-a24b-b1d938e7ac19">


## After
<img width="277" alt="Screenshot 2023-07-10 at 15 30 56" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/ca9f44ae-3c1c-468d-a99c-2bce746990ed">
