### PR TITLE
CIWEMB-365: Display Debit account Credit note allocation is linked to

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -152,4 +152,33 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
     $entityTrxn->save();
   }
 
+  /**
+   * Returns Debit account of the financial transaction the credit allocation record is linked to.
+   *
+   * @param int $id
+   *  Credit note allocation ID
+   * @return string
+   *   Debit Account name
+   */
+  public static function getPaidFrom($id) {
+    $entityTrxn = new \CRM_Financial_DAO_EntityFinancialTrxn();
+    $entityTrxn->entity_table = \CRM_Financeextras_DAO_CreditNoteAllocation::$_tableName;
+    $entityTrxn->entity_id = $id;
+    $entityTrxn->find(TRUE);
+    if (empty($entityTrxn->financial_trxn_id)) {
+      return NULL;
+    }
+
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get()
+      ->addWhere('id', '=', $entityTrxn->financial_trxn_id)
+      ->addSelect('to_financial_account_id:label')
+      ->execute()
+      ->first();
+
+    if (empty($financialTrxn)) {
+      return NULL;
+    }
+    return $financialTrxn['to_financial_account_id:label'];
+  }
+
 }

--- a/Civi/Api4/Action/CreditNoteAllocation/GetAction.php
+++ b/Civi/Api4/Action/CreditNoteAllocation/GetAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNoteAllocation;
+
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\DAOGetAction;
+use CRM_Financeextras_BAO_CreditNoteAllocation;
+
+/**
+ * {@inheritDoc}
+ */
+class GetAction extends DAOGetAction {
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  protected function getObjects(Result $result) {
+    parent::getObjects($result);
+
+    if ($result->count() > 0) {
+      $items = $result->getArrayCopy();
+
+      foreach ($items as &$item) {
+        $item['paid_from'] = $this->getPaidfrom($item['id']);
+      }
+
+      $result->exchangeArray($items);
+    }
+  }
+
+  private function getPaidFrom($id) {
+    return CRM_Financeextras_BAO_CreditNoteAllocation::getPaidFrom($id);
+  }
+
+}

--- a/Civi/Api4/CreditNoteAllocation.php
+++ b/Civi/Api4/CreditNoteAllocation.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4;
 
+use Civi\Api4\Action\CreditNoteAllocation\GetAction;
 use Civi\Api4\Action\CreditNoteAllocation\AllocateAction;
 
 /**
@@ -12,6 +13,17 @@ use Civi\Api4\Action\CreditNoteAllocation\AllocateAction;
  * @package Civi\Api4
  */
 class CreditNoteAllocation extends Generic\DAOEntity {
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param bool $checkPermissions
+   * @return DAOGetAction
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new GetAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
   /**
    * Allocate credit to contributions.

--- a/financeextras.php
+++ b/financeextras.php
@@ -134,7 +134,7 @@ function financeextras_civicrm_tabset($tabsetName, &$tabs, $context) {
   }
 }
 
-function financeextras_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef) {
+function financeextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'CreditNoteAllocation' && $op === 'create') {
     \CRM_Financeextras_BAO_CreditNote::updateCreditNoteStatusPostAllocation($objectRef->credit_note_id);
   }


### PR DESCRIPTION
## Overview
This PR enhances the GET API for credit note allocation by including the `Debit account` of the associated financial transaction in the response.

## Before
The `CreditNoteAllocation.get` API response does not include the `paid_from` field.

```
[
  {
    "id": 1,
    "credit_note_id": 1,
    "contribution_id": 5598,
    "type_id": 1,
    "currency": "GBP",
    "reference": "Predoli",
    "amount": 10,
    "date": "2023-07-13",
    "is_reversed": false
  }
]
```

## After
The `CreditNoteAllocation.get` API response now includes the `paid_from` field.

```
[
  {
    "id": 1,
    "credit_note_id": 1,
    "contribution_id": 5598,
    "type_id": 1,
    "currency": "GBP",
    "reference": "Predoli",
    "amount": 10,
    "date": "2023-07-13",
    "is_reversed": false,
     "paid_from": "Accounts Receivable"
  }
]
```

## Technical Details
When a credit note is allocated to an invoice, a new record is created in the `entity_financial_trxn` table to link the credit note allocation to a financial transaction (i.e., payment).

```
"entity_table": "credit allocation table name",
"entity_id": "credit allocation item id",
"financial_trxn_id": "Id of the financial transaction above",
"Amount": Total amount allocated
```