### PR TITLE
CIWEMB-365: User can reverse credit note allocation from UI

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
@@ -31,7 +31,7 @@
       <td>
         <a 
           ng-href="{{crmUrl('civicrm/contact/view/contribution', {reset:1, id:allocation.contribution_id, action:'view'})}}">
-            {{ allocation['contribution_id.invoice_number'] }}
+            {{ (allocation['contribution_id.invoice_number']) || allocation['contribution_id']  }}
         </a>
       </td>
       <td>{{ formatDate(allocation['date'], 'dd-M-yy') }}</td>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -97,7 +97,7 @@
     }
 
     /**
-     * Prepopulates credit notee line items from contrbution
+     * Prepopulates credit note line items from contrbution
      */
     function prepopulateFromContribution() {
       if (!parseInt($scope.contributionId)) {
@@ -176,6 +176,7 @@
         $scope.creditnotes.comment = creditnotes.comment
         $scope.creditnotes.status_id = creditnotes.status_id
         $scope.creditnotes.items = []
+        $scope.contactId = creditnotes.contact_id
 
         creditnotes.items.forEach((element, i) => {
           $scope.creditnotes.items.push({

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -67,7 +67,7 @@
         <tr>
           <td colspan="2">
             <div>
-              <creditnote-allocation-table ng-if="creditnotes.id" credit-note-id="{{creditnotes.id}}" />
+              <creditnote-allocation-table ng-if="creditnotes.id" credit-note-id="{{creditnotes.id}}" context="view" />
             </div>
           </td>
         </tr>

--- a/ang/fe-creditnote/directives/creditnote-view.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.js
@@ -31,15 +31,16 @@
    * @param {object} $scope the controller scope
    * @param {object} CurrencyCodes CurrencyCodes service
    * @param {object} crmApi4 crm api V4 service
+   * @param {object} MoneyFormat service
    */
-  function creditnoteViewController ($scope, CurrencyCodes, crmApi4) {
+  function creditnoteViewController ($scope, CurrencyCodes, crmApi4, MoneyFormat) {
     const defaultCurrency = 'GBP';
     const financialTypesCache = new Map();
 
     $scope.ts = CRM.ts();
     $scope.crmUrl = CRM.url;
     $scope.roundTo = roundTo;
-    $scope.formatMoney = formatMoney;
+    $scope.formatMoney = MoneyFormat.formatMoney;
     $scope.getContactLink = getContactLink;
     $scope.currencySymbol = CurrencyCodes.getSymbol(defaultCurrency);
     $scope.hasEditPermission = CRM['fe-creditnote'].canEditContribution;
@@ -149,18 +150,6 @@
     function roundTo (n, place) {
       return +(Math.round(n + 'e+' + place) + 'e-' + place);
     }
-
-    /**
-     * Formats a number into the number format of the currently selected currency
-     *
-     * @param {number} value the number to be formatted
-     * @param {string } currency the selected currency
-     * @returns {number} the formatted number
-     */
-    function formatMoney (value, currency) {
-      return CRM.formatMoney(value, true, CurrencyCodes.getFormat(currency));
-    }
-
 
   }
 })(angular, CRM.$, CRM._);

--- a/ang/fe-creditnote/services/money-format.service.js
+++ b/ang/fe-creditnote/services/money-format.service.js
@@ -19,6 +19,9 @@
      * @returns {number} the formatted number
      */
     this.formatMoney = (value, currency, symbol) => {
+      if (!currency) {
+        currency = 'GBP' // If data is still loading, currency could be undefined
+      }
       let money = CRM.formatMoney(value, true, CurrencyCodes.getFormat(currency));
 
       if (symbol) {


### PR DESCRIPTION
## Overview
This PR enables the user to delete credit note allocation using the endpoint added in this [PR](https://github.com/compucorp/io.compuco.financeextras/pull/52)

## Before
The delete allocation button does not work
<img width="1320" alt="Screenshot 2023-07-13 at 09 43 49" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/e136b2f4-f246-4581-b00f-76112f7f07ff">


## After
The allocation delete button now works
![qaqaqa](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d369ee7a-b6b1-4722-aad9-a360d1f3182e)
