### PR TITLE
CIWEMB-370: UI update to credit note view screen

### DIFF
--- a/ang/fe-creditnote.ang.php
+++ b/ang/fe-creditnote.ang.php
@@ -7,6 +7,7 @@ use Civi\Api4\OptionValue;
 use Civi\Financeextras\Utils\CurrencyUtils;
 
 $options = [
+  'shortDateFormat' => Civi::Settings()->get('dateformatshortdate'),
   'canEditContribution' => CRM_Core_Permission::check('edit contributions'),
 ];
 
@@ -34,6 +35,7 @@ financeextras_set_credit_note_status($options);
 
 return [
   'js' => [
+    'js/strftime.js',
     'ang/fe-creditnote.module.js',
     'ang/fe-creditnote/*.js',
     'ang/fe-creditnote/*/*.js',

--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
@@ -29,7 +29,8 @@
     $scope.allocated_credit = 0;
     $scope.remaining_credit = 0;
     $scope.isView = $scope.context == 'view'
-    $scope.formatDate = CRM.utils.formatDate;
+    /*eslint-disable no-undef*/
+    $scope.formatDate = (date) => strftime(CRM['fe-creditnote'].shortDateFormat, date)
     $scope.formatMoney = MoneyFormat.formatMoney;
     $scope.isUpdate = $scope.context == 'update';
     $scope.hasAllocatePermission = CRM['fe-creditnote'].canEditContribution;

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -35,7 +35,7 @@
         </tr>
         <tr>
           <td>{{ts('Currency')}}</td>
-          <td>{{currencySymbol}}</td>
+          <td>{{currency}}</td>
         </tr>
         <tr>
           <td colspan="2">

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -5,7 +5,7 @@
     <div class="panel-body">
       <div class="row" ng-if="hasEditPermission">
         <div class="col-md-12">
-          <a ng-href="{{ crmUrl('civicrm/contribution/creditnote/update', {reset: 1, id: creditnotes.id, action: 'update'}) }}" class="btn btn-primary-outline pull-right">Edit Credit Note</a>
+          <a ng-href="{{ crmUrl('civicrm/contribution/creditnote/update', {reset: 1, id: creditnotes.id, action: 'update'}) }}" class="btn btn-primary pull-right">Edit Credit Note</a>
         </div>
       </div>
       <table class="table" id="creditnote__detail">

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -47,7 +47,7 @@
                 <table class="table table-striped">
                   <tr><th>Subtotal</th><td>{{ currencySymbol }} {{ formatMoney(creditnotes.total, creditnotes.currency) }}</td></tr>
                     <tr ng-repeat="i in taxRates">
-                      <th>*{{ i.tax_name }} @ {{ i.rate }}%</th>
+                      <th>*{{ taxTerm }} @ {{ i.rate }}%</th>
                       <td>{{ currencySymbol }} {{ formatMoney(i.value, creditnotes.currency) }}</td>
                     </tr>
                   <tr><th>Total</th><td>{{ currencySymbol }} {{formatMoney(creditnotes.grandTotal, creditnotes.currency)}}</td></tr>

--- a/ang/fe-creditnote/directives/creditnote-view.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.js
@@ -70,8 +70,8 @@
         $scope.creditnotes = creditnotes
         $scope.currency = creditnotes.currency
         $scope.currencySymbol = CurrencyCodes.getSymbol(creditnotes.currency);
-        $scope.creditnotes.date = $.datepicker.formatDate('dd/mm/yy', new Date(creditnotes.date))
-
+        /*eslint-disable no-undef*/
+        $scope.creditnotes.date = strftime(CRM['fe-creditnote'].shortDateFormat, creditnotes.date)
         creditnotes.items.forEach((element, i) => {
           element.financial_type = element['financial_type_id.name']
           handleFinancialTypeChange(i);

--- a/ang/fe-creditnote/directives/creditnote-view.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.js
@@ -37,6 +37,7 @@
     const defaultCurrency = 'GBP';
     const financialTypesCache = new Map();
 
+    $scope.taxTerm = '';
     $scope.ts = CRM.ts();
     $scope.crmUrl = CRM.url;
     $scope.roundTo = roundTo;
@@ -48,6 +49,7 @@
     (function init () {
       prepopulateCreditnotes();
 
+      getTaxTerm().then((taxTerm) => $scope.taxTerm = taxTerm)
       $scope.$on('totalChange', _.debounce(handleTotalChange, 250));
     }());
 
@@ -67,7 +69,7 @@
         const creditnotes = result[0] ?? null;
         $scope.creditnotes = creditnotes
         $scope.currencySymbol = CurrencyCodes.getSymbol(creditnotes.currency);
-        $scope.creditnotes.date = $.datepicker.formatDate('dd/mmyy', new Date(creditnotes.date))
+        $scope.creditnotes.date = $.datepicker.formatDate('dd/mm/yy', new Date(creditnotes.date))
 
         creditnotes.items.forEach((element, i) => {
           element.financial_type = element['financial_type_id.name']
@@ -149,6 +151,19 @@
      */
     function roundTo (n, place) {
       return +(Math.round(n + 'e+' + place) + 'e-' + place);
+    }
+
+    /**
+     * Retrieves the contribution tax term from settings
+     * 
+     * @returns {string} tax term
+     */
+    async function getTaxTerm() {
+      const setting = await crmApi4('Setting', 'get', {
+        select: ["contribution_invoice_settings"]
+      });
+
+      return setting[0]['value']['tax_term'] ?? '';
     }
 
   }

--- a/ang/fe-creditnote/directives/creditnote-view.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.js
@@ -68,6 +68,7 @@
       }).then(function (result) {
         const creditnotes = result[0] ?? null;
         $scope.creditnotes = creditnotes
+        $scope.currency = creditnotes.currency
         $scope.currencySymbol = CurrencyCodes.getSymbol(creditnotes.currency);
         $scope.creditnotes.date = $.datepicker.formatDate('dd/mm/yy', new Date(creditnotes.date))
 

--- a/css/fe-creditnote.css
+++ b/css/fe-creditnote.css
@@ -36,3 +36,6 @@
 #bootstrap-theme .table .table {
   background-color: unset;
 }
+#creditnote__view #creditnote__detail>tbody> tr > td {
+  border-top: none;
+}

--- a/js/strftime.js
+++ b/js/strftime.js
@@ -1,0 +1,107 @@
+/* Port of strftime() by T. H. Doan (https://thdoan.github.io/strftime/)
+ *
+ * Day of year (%j) code based on Joe Orost's answer:
+ * http://stackoverflow.com/questions/8619879/javascript-calculate-the-day-of-the-year-1-366
+ *
+ * Week number (%V) code based on Taco van den Broek's prototype:
+ * http://techblog.procurios.nl/k/news/view/33796/14863/calculate-iso-8601-week-and-year-in-javascript.html
+ */
+/*eslint-disable no-unused-vars*/
+function strftime(sFormat, date) {
+  if (typeof sFormat !== 'string') {
+    return '';
+  }
+
+  if (!(date instanceof Date)) {
+    date = new Date();
+  }
+
+  const nDay = date.getDay();
+  const nDate = date.getDate();
+  const nMonth = date.getMonth();
+  const nYear = date.getFullYear();
+  const nHour = date.getHours();
+  const nTime = date.getTime();
+  const aDays = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday'
+  ];
+  const aMonths = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+  ];
+  const aDayCount = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+  const isLeapYear = () => (nYear % 4 === 0 && nYear % 100 !== 0) || nYear % 400 === 0;
+  const getThursday = () => {
+    const target = new Date(date);
+    target.setDate(nDate - ((nDay + 6) % 7) + 3);
+    return target;
+  };
+  const zeroPad = (nNum, nPad) => ((Math.pow(10, nPad) + nNum) + '').slice(1);
+
+  return sFormat.replace(/%[a-z]+\b/gi, (sMatch) => {
+    return (({
+      '%a': aDays[nDay].slice(0, 3),
+      '%A': aDays[nDay],
+      '%b': aMonths[nMonth].slice(0, 3),
+      '%B': aMonths[nMonth],
+      '%c': date.toUTCString().replace(',', ''),
+      '%C': Math.floor(nYear / 100),
+      '%d': zeroPad(nDate, 2),
+      '%e': nDate,
+      '%F': (new Date(nTime - (date.getTimezoneOffset() * 60000))).toISOString().slice(0, 10),
+      '%G': getThursday().getFullYear(),
+      '%g': (getThursday().getFullYear() + '').slice(2),
+      '%H': zeroPad(nHour, 2),
+      '%I': zeroPad((nHour + 11) % 12 + 1, 2),
+      '%j': zeroPad(aDayCount[nMonth] + nDate + ((nMonth > 1 && isLeapYear()) ? 1 : 0), 3),
+      '%k': nHour,
+      '%l': (nHour + 11) % 12 + 1,
+      '%m': zeroPad(nMonth + 1, 2),
+      '%n': nMonth + 1,
+      '%M': zeroPad(date.getMinutes(), 2),
+      '%p': (nHour < 12) ? 'AM' : 'PM',
+      '%P': (nHour < 12) ? 'am' : 'pm',
+      '%s': Math.round(nTime / 1000),
+      '%S': zeroPad(date.getSeconds(), 2),
+      '%u': nDay || 7,
+      '%V': (() => {
+        const target = getThursday();
+        const n1stThu = target.valueOf();
+        target.setMonth(0, 1);
+        const nJan1 = target.getDay();
+
+        if (nJan1 !== 4) {
+          target.setMonth(0, 1 + ((4 - nJan1) + 7) % 7);
+        }
+
+        return zeroPad(1 + Math.ceil((n1stThu - target) / 604800000), 2);
+      })(),
+      '%w': nDay,
+      '%x': date.toLocaleDateString(),
+      '%X': date.toLocaleTimeString(),
+      '%y': (nYear + '').slice(2),
+      '%Y': nYear,
+      '%z': date.toTimeString().replace(/.+GMT([+-]\d+).+/, '$1'),
+      '%Z': date.toTimeString().replace(/.+\((.+?)\)$/, '$1'),
+      '%Zs': new Intl.DateTimeFormat('default', {
+        timeZoneName: 'short',
+      }).formatToParts(date).find((oPart) => oPart.type === 'timeZoneName')?.value,
+    }[sMatch] || '') + '') || sMatch;
+  });
+}


### PR DESCRIPTION
## Overview
This pull request aims to improve the credit note view screen by implementing the following changes:
- Displaying the tax term instead of the account tax name.
- Displaying the currency name instead of the currency symbol.
- Formatting the date using the short date format specified by the user in the Date localization settings (`admin/setting/date?action=reset=1`).

## Before
The previous version of the credit note view screen displayed the tax name instead of the tax term, and it showed the currency symbol instead of the currency name. Additionally, the date format was not customized according to the user's preferences.

![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/17e1c655-cbc8-469c-80da-3df645252806)

## After
The updated credit note view screen now reflects the following improvements:
- The tax term is displayed instead of the account tax name.
- The currency name is shown in place of the currency symbol.
- The date is formatted using the short date format specified in the user's Date localization settings.

<img width="1344" alt="Screenshot 2023-07-13 at 17 52 24" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/eeedeeb5-7d75-4f2d-8c66-cb4423a50391">

## Technical Details
To achieve the desired date formatting using the POSIX specifiers specified in [Administer > Localization > Date Formats], an external JavaScript library called [strftime](https://github.com/thdoan/strftime) has been included. This library provides the functionality to format dates according to the POSIX specifiers.

It is worth noting that this library serves as the JavaScript equivalent of the PHP function [CiviCRM CRM_Utils_Date::customFormat](https://github.com/civicrm/civicrm-core/blob/fc0a25d1aa8a5c44bb30121f9b5bdb14c4f38247/CRM/Utils/Date.php#L326-L461).