### PR TITLE
CIWEMB-316:  Update Contribution Status Based on Payment

### DIFF
--- a/Civi/Financeextras/Event/ContributionPaymentUpdatedEvent.php
+++ b/Civi/Financeextras/Event/ContributionPaymentUpdatedEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Civi\Financeextras\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * The fe.contribution.received_payment event will be dispatched
+ * when payment is added/refunded/cacncelled from a contribution
+ * and the contribution status needs to be re caluclated.
+ */
+class ContributionPaymentUpdatedEvent extends Event {
+  public const NAME = 'fe.contribution.received_payment';
+
+  public function __construct(protected int $contributionId) {
+  }
+
+  public function getContributionId() {
+    return $this->contributionId;
+  }
+
+}

--- a/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
+++ b/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Civi\Financeextras\Event\Listener;
+
+use CRM_Contribute_DAO_Contribution;
+use Civi\Financeextras\Utils\OptionValueUtils;
+use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
+
+class ContributionPaymentUpdatedListener {
+
+  public static function handle(ContributionPaymentUpdatedEvent $event) {
+    self::updateContributionStatus($event->getContributionId());
+  }
+
+  private static function updateContributionStatus($contributionId) {
+    $status = 'Pending';
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addWhere('id', '=', $contributionId)
+      ->execute()
+      ->first();
+
+    if (empty($contribution)) {
+      return;
+    }
+
+    $status = match (TRUE) {
+      empty($contribution['paid_amount']) => 'Pending',
+      $contribution['total_amount'] == $contribution['paid_amount'] => 'Completed',
+      $contribution['total_amount'] > $contribution['paid_amount'] => 'Partially paid',
+      $contribution['total_amount'] < $contribution['paid_amount'] => 'Pending refund',
+    };
+
+    $newStatusId = OptionValueUtils::getValueForOptionValue('contribution_status', $status);
+    $contribution = new CRM_Contribute_DAO_Contribution();
+    $contribution->id = $contributionId;
+    $contribution->find(TRUE);
+    $contribution->contribution_status_id = $newStatusId;
+    $contribution->save(FALSE);
+  }
+
+}

--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Civi\Financeextras\Hook\BuildForm;
+
+use CRM_Financeextras_ExtensionUtil as E;
+use Civi\Financeextras\Utils\OptionValueUtils;
+
+class ContributionCreate {
+
+  /**
+   * @param \CRM_Contribute_Form_Contribution $form
+   */
+  public function __construct(private \CRM_Contribute_Form_Contribution $form) {
+  }
+
+  public function handle() {
+    $this->configureRecordPaymentField();
+    $this->preventUserFromSettingContributionStatus();
+  }
+
+  /**
+   * We are changing the CiviCRM core behavior that allow users
+   * to set contibution status manually during create/edit, instead
+   * this status will be set based on the payment allocated to the
+   * contribution.
+   */
+  private function preventUserFromSettingContributionStatus() {
+    try {
+      $statusElement = $this->form->getElement('contribution_status_id');
+      if (!$this->isEdit()) {
+        // By default new contribution will have a pending status
+        // and will be updated to the right status post payment(if any)
+        $statusElement->setValue(OptionValueUtils::getValueForOptionValue('contribution_status', 'Pending'));
+      }
+      $statusElement->freeze();
+    }
+    catch (\Throwable $th) {
+    }
+  }
+
+  /**
+   * CiviCRM by default always shows the payment fields for new contribution,
+   * This method configures the display of these payment related fields by
+   * grouping them together as a block and adds a 'Record Payment' checkbox
+   * that determines visibility of this block.
+   *
+   * Also, adds a payment amount field, that allows users to specify the amount
+   * they would like to record for the contribution.
+   */
+  private function configureRecordPaymentField() {
+    if (!$this->isEdit()) {
+      $this->form->add('checkbox', 'fe_record_payment_check', ts('Record Payment'), NULL);
+      $this->form->add('text', 'fe_record_payment_amount', ts('Amount'), NULL);
+      \Civi::resources()->add([
+        'scriptFile' => [E::LONG_NAME, 'js/modifyContributionForm.js'],
+        'region' => 'page-header',
+      ]);
+      \Civi::resources()->add([
+        'template' => 'CRM/Financeextras/Form/Contribute/AddPayment.tpl',
+        'region' => 'page-body',
+      ]);
+      \Civi::resources()->addVars('financeextras', ['currencies' => \CRM_Core_OptionGroup::values('currencies_enabled')]);
+    }
+  }
+
+  private function isEdit() {
+    return !empty($this->form->_id);
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param \CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Contribute_Form_Contribution";
+  }
+
+}

--- a/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Civi\Financeextras\Hook\PostProcess;
+
+use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
+
+class ContributionPostProcess {
+
+  /**
+   * @param \CRM_Contribute_Form_Contribution $form
+   */
+  public function __construct(private \CRM_Contribute_Form_Contribution $form) {
+  }
+
+  public function handle() {
+    $this->recordPayment();
+  }
+
+  public function recordPayment() {
+    $values = $this->form->getSubmitValues();
+
+    try {
+      $transaction = \CRM_Core_transaction::create();
+
+      if (!empty($values['fe_record_payment_check']) && !empty($values['fe_record_payment_amount'])) {
+        $params = [
+          'is_payment' => 1,
+          'trxn_id' => $values['trxn_id'],
+          'contribution_id' => $this->form->_id,
+          'check_number' => $values['check_number'] ?? NULL,
+          'card_type_id' => $values['card_type_id'] ?? NULL,
+          'pan_truncation' => $values['pan_truncation'] ?? NULL,
+          'total_amount' => $values['fe_record_payment_amount'],
+          'trxn_date' => $values['receive_date'] ?? date('YmdHis'),
+          'payment_instrument_id' => $values['payment_instrument_id'],
+        ];
+
+        \CRM_Financial_BAO_Payment::create($params);
+      }
+    }
+    catch (\Throwable $th) {
+      $transaction->rollback();
+      \CRM_Core_Session::setStatus('Error creating contribution payment', ts('Contribution Payemnt Error'), 'error');
+      \Civi::log()->error('Error creating contribution payment: ' . $th->getMessage());
+    }
+
+    \Civi::dispatcher()->dispatch(ContributionPaymentUpdatedEvent::NAME, new ContributionPaymentUpdatedEvent($this->form->_id));
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Contribute_Form_Contribution";
+  }
+
+}

--- a/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Civi\Financeextras\Hook\ValidateForm;
+
+class ContributionCreate {
+
+  /**
+   * @param \CRM_Contribute_Form_Contribution $form
+   * @param array $fields
+   * @param array $errors
+   */
+  public function __construct(private \CRM_Contribute_Form_Contribution $form, private array &$fields, private array &$errors) {
+  }
+
+  public function handle() {
+    $this->validatePaymentForm();
+  }
+
+  public function validatePaymentForm() {
+    if (!empty($this->fields['fe_record_payment_check']) && empty($this->fields['fe_record_payment_amount'])) {
+      $this->errors['fe_record_payment_amount'] = ts('Payment amount is required');
+    }
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Contribute_Form_Contribution";
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -15,6 +15,7 @@ function financeextras_civicrm_config(&$config) {
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\SearchDisplayRun', 'respond'], -100);
   Civi::dispatcher()->addSubscriber(new Civi\Financeextras\Event\Subscriber\CreditNoteInvoiceSubscriber());
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\Contribution', 'respond'], -101);
+  Civi::dispatcher()->addListener('fe.contribution.received_payment', ['\Civi\Financeextras\Event\Listener\ContributionPaymentUpdatedListener', 'handle']);
 }
 
 /**

--- a/financeextras.php
+++ b/financeextras.php
@@ -140,3 +140,48 @@ function financeextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
     \CRM_Financeextras_BAO_CreditNote::updateCreditNoteStatusPostAllocation($objectRef->credit_note_id);
   }
 }
+
+/**
+ * Implements hook_civicrm_validateForm().
+ */
+function financeextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+  $hooks = [
+    \Civi\Financeextras\Hook\ValidateForm\ContributionCreate::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($form, $formName)) {
+      (new $hook($form, $fields, $errors))->handle();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_postProcess().
+ */
+function financeextras_civicrm_postProcess($formName, $form) {
+  $hooks = [
+    \Civi\Financeextras\Hook\PostProcess\ContributionPostProcess::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($form, $formName)) {
+      (new $hook($form))->handle();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_buildForm().
+ */
+function financeextras_civicrm_buildForm($formName, &$form) {
+  $hooks = [
+    \Civi\Financeextras\Hook\BuildForm\ContributionCreate::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($form, $formName)) {
+      (new $hook($form))->handle();
+    }
+  }
+}

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -1,0 +1,83 @@
+CRM.$(function ($) {
+
+  (function() {
+    setTotalAmount();
+    hideStatusField();
+    setAmountCurencySymbol();
+    toggleRecordPaymentBlock();
+    placePaymentFieldsTogether();
+  })();
+
+  function setTotalAmount() {
+    const recordPaymentAmount = document.querySelector("input[name=fe_record_payment_amount]");
+    $('#total_amount').on("change", function() {
+      recordPaymentAmount.value = $('#total_amount').val();
+    });
+  
+    $('#price_set_id').on('change', function() {
+      if (($(this).val() !== '')) {
+        $('#pricevalue').on('change', function() {
+          recordPaymentAmount.value = $('#pricevalue').data('raw-total');
+        });
+      }
+    })
+  }
+
+  function hideStatusField() {
+    CRM.$('.crm-contribution-form-block-contribution_status_id').hide();
+  }
+
+  function setAmountCurencySymbol() {
+    const setSymbol = () => {
+      const currencySelect = $('#currency').val();
+      const currencySymbol = CRM.vars.financeextras.currencies[currencySelect];
+
+      $('.record_payment-block #currency-symbol').text(currencySymbol)
+    };
+  
+    setSymbol();
+    $('select[name=currency]').on('change', function() {
+      setSymbol();
+    });
+  }
+
+  function toggleRecordPaymentBlock() {
+    const recordPaymentCheck = document.querySelector("input[name=fe_record_payment_check]");
+    const toggle = (checked)  => {
+      if (checked) {
+        $('.record_payment-block').show();
+      } else {
+        $('.record_payment-block').hide();
+      }
+    }
+
+    toggle(recordPaymentCheck.checked)
+    recordPaymentCheck.addEventListener('change', function() {
+      toggle(this.checked)
+    });
+  }
+
+  function placePaymentFieldsTogether() {
+    $('tr.crm-contribution-form-block-receive_date').after(
+      $('<tr>').addClass('record_payment-block_row').append($('<td>').attr('colspan', 2).append(
+        $('.record_payment-block')
+      ))
+    )
+    $('tr.record_payment-block_row').before(
+      $('<tr>').append($('<td>').attr('colspan', 2).append(
+        $('.record_payment-block_check')
+      ))
+    )
+    $('tr.crm-contribution-form-block-financeextras_record_payment_amount').after(
+      $('tr.crm-contribution-form-block-payment_instrument_id')
+    )
+    $('tr.crm-contribution-form-block-payment_instrument_id').after($('tr.crm-contribution-form-block-trxn_id'))
+    $('tr.crm-contribution-form-block-trxn_id').after(
+      $('<tr>').addClass('crm-contribution-fe-billing_row').append($('<td>').attr('colspan', 2).append(
+        $('div#billing-payment-block')
+      ))
+    );
+    $('tr.crm-contribution-fe-billing_row').after($('tr.crm-contribution-form-block-receipt_date'));
+    $('#payment_information > fieldset > legend').hide();
+  }
+});

--- a/templates/CRM/Financeextras/Form/Contribute/AddPayment.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/AddPayment.tpl
@@ -1,0 +1,33 @@
+<div class="record_payment-block_check">
+  <table>
+    <tbody>
+      <tr class="crm-contribution-form-block-financeextras_record_payment_check">
+        <td class="label">{$form.fe_record_payment_check.html}</td>
+        <td>{$form.fe_record_payment_check.label}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="record_payment-block">
+  <table>
+    <tbody>
+      <tr class="crm-contribution-form-block-financeextras_record_payment_amount">
+        <td class="label" id="amount-label">{$form.fe_record_payment_amount.label} <span class="crm-marker" title="This field is required."> *</span></td>
+        <td><span id="currency-symbol"></span> {$form.fe_record_payment_amount.html}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{literal}
+  <style>
+    #payment_information > fieldset > legend {
+      display: none;
+    }
+    .payment-details_group {
+      display: none;
+    }
+    .crm-contribution-form-block-financeextras_record_payment_amount > #amount-label {
+      vertical-align: baseline;
+    }
+  </style>
+{/literal}


### PR DESCRIPTION
## Overview
This PR introduces changes to the contribution status handling and payment recording process. It removes the ability for users to manually set the status of a new contribution from the UI. Instead, the contribution status will be automatically updated based on the payment made to the contribution. Additionally, users have the option to record a payment for the new contribution.

## Before
Previously, users could set the contribution status from the UI.

<img width="1264" alt="Screenshot 2023-07-18 at 08 18 51" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/72282e9c-d589-45c1-9c6d-f8db3e097b18">


## After
With this update, users can no longer set the contribution status from the UI. However, they can record a payment for the new contribution if needed.

##### Create Contribution Screen <hr>
![Screenshot](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/f62fce78-359f-466e-80d9-825f5b3587a7)

##### Edit Contribution Screen <hr>
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d183bb10-a0aa-4f66-bfe8-44c7ed2aba61)


## Technical Details
To handle the contribution status updates, a new event `fe.contribution.received_payment` is introduced. The contribution status will be updated based on the following conditions:

| Status           | Conditions                                                                                   |
|------------------|----------------------------------------------------------------------------------------------|
| Pending          | - No payments exist                                                                           |
|                  |                                                                                              |
| Partially paid   | - The sum of all line items and tax amounts is greater than the sum of all payments.                                                                       |
|                  |                                                                                              |
| Pending refund   | - The sum of all line items and tax amounts is less than the sum of all allocated credit amounts and payments                                               |
|                  |                                                                                              |
| Completed        | - Sum of all line items and tax amounts equals the sum of all payments, and there is no allocated credit                                                 |

Instead of utilizing the DB post-contribution create hook, a custom event is used to ensure payment is recorded before recalculating the status. This approach enables selective recalculation for specific forms where the `status_id` has been deliberately removed. hence, avoiding unexpected side effects and easing bug tracing.

Presently after a user saves a Contribution form, either on edit or new, this event is emitted:
https://github.com/compucorp/io.compuco.financeextras/blob/90575c2f31a5241e986856726425f41168e5c404/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php#L46-L48

In subsequent PRs, this event will also need to be emitted in other payment situations such as when creating a New Membership (Non-payment plan), and when Registering Participant (Paid Ticket). 

Once all these tasks are completed in a new pull request, the next step will be to identify a centralized location where we can trigger this event when a payment is recorded for a contribution.