### PR TITLE
CIWEMB-319: User can create contribution for event without payment

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Civi\Financeextras\Hook\BuildForm;
+
+use CRM_Core_Action;
+use CRM_Financeextras_ExtensionUtil as E;
+
+class ParticipantCreate {
+
+  /**
+   * @param \CRM_Event_Form_Participant $form
+   */
+  public function __construct(private \CRM_Event_Form_Participant $form) {
+  }
+
+  public function handle() {
+    $this->addContributionBlock();
+  }
+
+  /**
+   * Adds support for recording contribution without payment
+   *
+   * By default, the Participant registration form enables users to optionally record
+   * payment for a paid event. However, in cases where no payment is made for a paid event,
+   * no contribution is currently being created.
+   *
+   * This methods adds new contribution amount field and rearranges the payment block, such that
+   * when the user chooses free ticket, the contribution/payment fields will be hidden
+   * On the other hand, if the user chooses a paid ticket, a contribution will be
+   * created, and the user will have the option to record a payment for that contribution.
+   */
+  private function addContributionBlock() {
+    $this->form->addElement('radio', 'fe_ticket_type', NULL, ts('Paid Ticket'), 'paid_ticket');
+    $this->form->addElement('radio', 'fe_ticket_type', NULL, ts('Free Ticket'), 'free_ticket');
+    $this->form->add('text', 'fe_contribution_amount', ts('Contribution Total Amount'), ['readonly' => TRUE]);
+
+    $defaults = [
+      'fe_ticket_type' => $this->getDefaultTicketType(),
+      'fe_contribution_amount' => 0,
+    ];
+    $this->form->setDefaults(array_merge($this->form->_defaultValues, $defaults));
+
+    \Civi::resources()->add([
+      'scriptFile' => [E::LONG_NAME, 'js/modifyParticipantForm.js'],
+      'region' => 'page-header',
+    ]);
+    \Civi::resources()->add([
+      'template' => 'CRM/Financeextras/Form/Event/AddContribution.tpl',
+      'region' => 'page-body',
+    ]);
+  }
+
+  /**
+   * Returns the default ticket type
+   *
+   * Paid Ticket, If:
+   *  It's new and the event is a paid event
+   *  It's edit and the event as a contribution,
+   * Else, Free Ticket
+   */
+  private function getDefaultTicketType() {
+    // Check if the form is being updated and has a participant ID
+    if ($this->form->_id && $this->form->_action & CRM_Core_Action::UPDATE) {
+      $participantPayment = new \CRM_Event_BAO_ParticipantPayment();
+      $participantPayment->participant_id = $this->form->_id;
+      $participantPayment->find(TRUE);
+
+      // If a contribution ID is associated with the participant payment, set ticket type as 'paid_ticket'
+      return !empty($participantPayment->contribution_id) ? 'paid_ticket' : 'free_ticket';
+    }
+
+    // Check if the event is a paid event based on its configuration
+    $event = \Civi\Api4\Event::get()
+      ->addSelect('is_monetary')
+      ->addWhere('id', '=', $this->form->_eID)
+      ->execute()
+      ->first();
+
+    return ($event['is_monetary']) ? 'paid_ticket' : 'free_ticket';
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param \CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Event_Form_Participant";
+  }
+
+}

--- a/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Civi\Financeextras\Hook\PostProcess;
+
+use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
+use Civi\Financeextras\Utils\OptionValueUtils;
+
+class ParticipantPostProcess {
+
+  /**
+   * @param \CRM_Event_Form_Participant $form
+   */
+  public function __construct(private \CRM_Event_Form_Participant $form) {
+  }
+
+  public function handle() {
+    $this->recordContribution();
+  }
+
+  /**
+   * Creates a contribution record for the participant registeration
+   *
+   * Case 1: user selects free ticket, nothing to do, as a contribution shouldn't be created
+   * Case 2: user select paid ticket and doesn't record payment,
+   *    Create a new contribution here,
+   *    Link the contribution to the participant record using ParticipantPayment entity
+   * Case 3: user selects paid ticket and also records payment,
+   *    It means a payment has already been created, here we need to ensure
+   *      The contribution has the expected status as per the payment that was made
+   */
+  public function recordContribution() {
+    $values = $this->form->getSubmitValues();
+    $ticketType = $values['fe_ticket_type'] ?? NULL;
+
+    if (empty($ticketType) || $ticketType == 'free_ticket') {
+      return;
+    }
+
+    try {
+      $transaction = \CRM_Core_transaction::create();
+      if (!$values['record_contribution']) {
+        $contributionId = $this->createNewContribution();
+      }
+      else {
+        $contributionId = $this->getParticipantContribution();
+      }
+    }
+    catch (\Throwable $th) {
+      $transaction->rollback();
+      \CRM_Core_Session::setStatus('Error creating contribution', ts('Contribution Error'), 'error');
+      \Civi::log()->error('Error creating contribution: ' . $th->getMessage());
+    }
+
+    if (empty($contributionId)) {
+      return;
+    }
+
+    \Civi::dispatcher()->dispatch(ContributionPaymentUpdatedEvent::NAME, new ContributionPaymentUpdatedEvent($contributionId));
+  }
+
+  private function createNewContribution() {
+    $values = $this->form->getSubmitValues();
+    $params = [
+      'is_pay_later' => 1,
+      'skipLineItem' => TRUE,
+      'total_amount' => $values['fe_contribution_amount'],
+      'financial_type_id' => $values['financial_type_id'],
+      'currency' => \CRM_Core_Config::singleton()->defaultCurrency,
+      'contact_id' => $this->form->_contactID,
+      'receive_date' => $values['receive_date'] ?? date('Y-m-d'),
+      'contribution_mode' => 'participant',
+      'participant_id' => $this->form->_id,
+      'source' => $this->getSource(),
+      'contribution_status_id' => OptionValueUtils::getValueForOptionValue('contribution_status', 'Pending'),
+    ];
+
+    if (!empty($values['tax_amount'])) {
+      $params['tax_amount'] = $values['tax_amount'];
+    }
+
+    $contribution = \CRM_Contribute_BAO_Contribution::create($params);
+    $this->syncLineItem($contribution->id, $this->form->_id);
+
+    $participantPaymentParams = [
+      'participant_id' => $this->form->_id,
+      'contribution_id' => $contribution->id,
+    ];
+    \CRM_Event_BAO_ParticipantPayment::create($participantPaymentParams);
+
+    return $contribution->id;
+  }
+
+  private function getParticipantContribution() {
+    $participantPayment = new \CRM_Event_BAO_ParticipantPayment();
+    $participantPayment->participant_id = $this->form->_id;
+    $participantPayment->find(TRUE);
+
+    return $participantPayment->contribution_id;
+  }
+
+  private function getSource() {
+    if ($this->form->getSubmitValues()['source']) {
+      return $this->form->getSubmitValues()['source'];
+    }
+
+    $event = \Civi\Api4\Event::get()
+      ->addSelect('title')
+      ->addWhere('id', '=', $this->form->_eventId)
+      ->execute()->first();
+
+    return ts('%1 : Offline registration (by %2)', [
+      1 => $event['title'],
+      2 => \CRM_Core_Session::singleton()->getLoggedInContactDisplayName(),
+    ]);
+  }
+
+  private function syncLineItem($contributionId, $participantId) {
+    $lineItems = \Civi\Api4\LineItem::get()
+      ->addWhere('entity_table', '=', 'civicrm_participant')
+      ->addWhere('entity_id', '=', $participantId)
+      ->execute();
+
+    foreach ($lineItems as $item) {
+      $lineItem = new \CRM_Price_DAO_LineItem();
+      $lineItem->id = $item['id'];
+      $lineItem->entity_id = $participantId;
+      $lineItem->contribution_id = $contributionId;
+      $lineItem->save(FALSE);
+    }
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Event_Form_Participant";
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -162,6 +162,7 @@ function financeextras_civicrm_validateForm($formName, &$fields, &$files, &$form
  */
 function financeextras_civicrm_postProcess($formName, $form) {
   $hooks = [
+    \Civi\Financeextras\Hook\PostProcess\ParticipantPostProcess::class,
     \Civi\Financeextras\Hook\PostProcess\ContributionPostProcess::class,
   ];
 
@@ -178,6 +179,7 @@ function financeextras_civicrm_postProcess($formName, $form) {
 function financeextras_civicrm_buildForm($formName, &$form) {
   $hooks = [
     \Civi\Financeextras\Hook\BuildForm\MembershipCreate::class,
+    \Civi\Financeextras\Hook\BuildForm\ParticipantCreate::class,
     \Civi\Financeextras\Hook\BuildForm\ContributionCreate::class,
   ];
 

--- a/js/modifyParticipantForm.js
+++ b/js/modifyParticipantForm.js
@@ -1,0 +1,102 @@
+CRM.$(function ($) {
+
+  (function() {
+    $('.fe-record_contribution-block').hide();
+
+    observeEventFeeIsDisplayed();
+  })();
+
+  /**
+   * The event fees block for paid event is fetched via AJAX after the page has loaded.
+   * 
+   * Therefore, we need to ensure that the AJAX fetch is completed 
+   * before consolidating the payment fields and setting up event listeners.
+   */
+  function observeEventFeeIsDisplayed() {
+    const observer = new window.MutationObserver(function () {
+      if ($('.crm-event-eventfees-form-block-record_contribution').length && !$('tr.fe_record_contribution-block_row').length) {
+        observer.disconnect();
+
+        placePaymentFieldsTogether();
+        toggleContributionBlock();
+        togglePaymentBlock();
+        setTotalAmount();
+
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true
+        });
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  function placePaymentFieldsTogether() {
+    $('.fe-record_contribution-block').show();
+    $('tr.crm-event-eventfees-form-block-price_set_amount').after(
+      $('<tr>').addClass('fe_record_contribution-block_row').append($('<td>').attr('colspan', 2).append(
+        $('.fe-record_contribution-block')
+      ))
+    )
+    $('tr.crm-event-eventfees-form-block-financeextras_contribution-amount').after(
+      $('tr.crm-event-eventfees-form-block-financial_type_id')
+    )
+    $('tr.crm-event-eventfees-form-block-trxn_id').before(
+      $('tr.crm-event-eventfees-form-block-payment_instrument_id')
+    )
+    $('.crm-event-eventfees-form-block-financial_type_id label').prepend('Contribution ')
+    $('#receive_date').parent().parent().parent().hide()
+    $('.fe-contribution-date').html($('#receive_date').parent())
+    $('.crm-event-eventfees-form-block-financial_type_id .description').hide()
+    $('.fe-record_contribution-block #currency-symbol').text(window.symbol)
+    $('.crm-event-eventfees-form-block-contribution_status_id').hide();
+  }
+
+  function togglePaymentBlock() {
+    if ($('input#record_contribution').is(':checked')) {
+      $('input:radio[name=fe_ticket_type][value=paid_ticket]').click();
+    }else {
+      $('#payment_information').hide();
+    }
+  
+    $('input#record_contribution').on('input', () => {
+      if ($('input#record_contribution').is(':checked')) {
+        $('#billing-payment-block').show();
+      }else {
+        $('#billing-payment-block').hide();
+      }
+    })
+  }
+
+  function toggleContributionBlock() {
+    const toggleBlock = () => {
+      const isPaid = $('input:radio[name=fe_ticket_type][value=paid_ticket]').is(':checked')
+      $('input#record_contribution').prop("checked", !isPaid).trigger('click')
+      $('tr.crm-event-eventfees-form-block-record_contribution').toggle(isPaid)
+
+      $('.fe-record_contribution-fields').toggle(isPaid)
+    }
+
+    //if no free ticket is selected, uncheck record payment and hide the record payment field
+    toggleBlock();
+    $('input:radio[name=fe_ticket_type][value=paid_ticket]:checked').on('change', 
+      () => $('input#record_contribution').prop("checked", true).trigger('click')
+    );
+
+    $('input:radio[name=fe_ticket_type]').on('change', () => {
+        toggleBlock()
+      }
+    );
+  }
+
+  function setTotalAmount() {
+    $('input[name=fe_contribution_amount]').val($('#pricevalue').data('raw-total'));
+    $('#pricevalue').on('change', function() {
+      $('input[name=fe_contribution_amount]').val($('#pricevalue').data('raw-total'));
+    });
+  }
+});

--- a/templates/CRM/Financeextras/Form/Event/AddContribution.tpl
+++ b/templates/CRM/Financeextras/Form/Event/AddContribution.tpl
@@ -1,0 +1,34 @@
+<div class="fe-record_contribution-block">
+  <table>
+    <tbody>
+      <tr>
+        <td class="label">{$form.fe_ticket_type.paid_ticket.label}</td>
+        <td>{$form.fe_ticket_type.paid_ticket.html}</td>
+      </tr>
+      <tr>
+        <td class="label">{$form.fe_ticket_type.free_ticket.label}</td>
+        <td>{$form.fe_ticket_type.free_ticket.html}</td>
+      </tr>
+    </tbody>
+  </table>
+  <fieldset class="fe-record_contribution-fields">
+    <legend>Contribution Information</legend>
+    <table>
+    <tbody>
+      <tr class="crm-event-eventfees-form-block-financeextras_contribution-amount">
+        <td class="label" id="amount-label"> {$form.fe_contribution_amount.label}</td>
+        <td><span id="currency-symbol"></span> {$form.fe_contribution_amount.html}</td>
+      </tr>
+      <tr>
+        <td class="label"><label>{ts}Contribution Date{/ts}</label></td>
+        <td class="fe-contribution-date"></td>
+      </tr>
+    </tbody>
+  </table>
+  </fieldset>
+</div>
+<style>
+  .fe-record_contribution-fields > tbody > tr > td#amount-label {
+    vertical-align: baseline;
+  }
+</style>


### PR DESCRIPTION
## Overview
This Pull Request (PR) introduces a change that grants users the flexibility to optionally record a contribution for new Event registrations. With this update, users can now register participants for paid events without requiring a contribution (Free Ticket). Alternatively, they can create a contribution and choose to record a payment for it (Paid Ticket).

## Before
Previously, the user interface did not visually differentiate between contributions and payments during event registration. As a result, users lacked the option to record a contribution without creating a payment for it.
![Before](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/360941db-0b49-4ef2-bb6f-dcb2718a9469)

## After
With this update, users can now make the choice to record a contribution and optionally record a payment. The UI has been restructured to clearly separate contribution-related fields from payment-related fields, offering a more user-friendly experience.

![After](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/80680683-1237-4b01-8a8b-d5bfe4db7fd2)

## Technical Details
The changes made in this PR involve creating a visual separation between contribution and payment when registering for a new paid event. previously, users could only choose between recording a payment or not.
<img width="815" alt="Screenshot 2023-07-25 at 10 43 31" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/89f48ce7-e722-40e1-9be2-7e79e08d26ee">
When the user chooses to record payment, the system in the backend will create a contribution record and create a payment for that contribution. and when the user chooses not to record a payment no contribution will be created. Now, there are three possible scenarios:
1. If the user selects the free ticket option, no contribution will be created.
2. If the user selects the paid ticket option and chooses to record payment, both a contribution and payment will be created.
3. If the user selects the paid ticket option but decides not to record payment, a contribution will be created without any associated payment.

The first two scenarios are synonymous with unchecking or checking `record payment`, and the third scenario has been implemented using the logic in the `PostProcess` hook. 
https://github.com/compucorp/io.compuco.financeextras/blob/84f2dd30e026c96c8c091b16f968d3838e2a833e/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php#L31-L59