### PR TITLE
CIWEMB-404: Format money columns with the creditnote currency

### DIFF
--- a/Civi/Api4/Action/CreditNote/GetAction.php
+++ b/Civi/Api4/Action/CreditNote/GetAction.php
@@ -20,6 +20,10 @@ class GetAction extends DAOGetAction {
       $items = $result->getArrayCopy();
 
       foreach ($items as &$item) {
+        if (empty($item['id'])) {
+          continue;
+        }
+
         $allocatedCredits = $this->getAllocations($item['id']);
         $item = array_merge($item, $allocatedCredits);
 

--- a/Civi/Api4/CreditNoteAllocation.php
+++ b/Civi/Api4/CreditNoteAllocation.php
@@ -54,4 +54,15 @@ class CreditNoteAllocation extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  public static function permissions() {
+    return [
+      'meta' => ['access CiviCRM'],
+      'get' => ['access CiviCRM', 'access CiviContribute'],
+      'default' => ['access CiviCRM', 'access CiviContribute', 'edit contributions'],
+    ];
+  }
+
 }


### PR DESCRIPTION
## Overview
This PR fixes the issue with the credit notes table using the system's default currency, instead of the credit note specified currency.

## Before
<img width="1128" alt="Screenshot 2023-07-27 at 10 21 45" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/f0ba6b80-3625-4481-8b1e-752f8e30b47e">


## After
The Credit Note table now respects the credit note specified currency.
<img width="1123" alt="Screenshot 2023-07-27 at 10 15 23" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/61b793f3-fb14-450e-b996-fafd03797e7f">

