### PR TITLE
CIWEMB-419: Set allocation amount to 2DP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/Civi/Api4/Action/CreditNoteAllocation/AllocateAction.php
+++ b/Civi/Api4/Action/CreditNoteAllocation/AllocateAction.php
@@ -41,7 +41,7 @@ class AllocateAction extends AbstractAction {
   /**
    * Amount to allocate
    *
-   * @var int
+   * @var mixed
    */
   protected $amount;
 

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -121,9 +121,10 @@
         const duePercent = (100 * dueAmount) /contribution.total_amount
         for (let i = 0; i < lineItems.length; i++) {
           const qty = (duePercent == 100) ? lineItems[i].qty : 1
-          const unitPrice = (duePercent == 100) ? 
+          let unitPrice = (duePercent == 100) ? 
             lineItems[i].unit_price : 
             (duePercent/100) * (lineItems[i].unit_price * lineItems[i].qty);
+          unitPrice = Number(unitPrice.toFixed(2))
           $scope.creditnotes.items[i] = {
             quantity: qty,
             unit_price: unitPrice,


### PR DESCRIPTION
## Overview
This PR ensures the allocation amount is always positive and doesn't exceed 2 decimal places.

## Before
The allocation amount field was not validated against negative and multiple DPs.
<img width="1282" alt="Screenshot 2023-07-27 at 09 48 22" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/389ebed5-c3a9-4aa2-8751-2a1f2c54c6ac">

## After
The allocation amount must be positive can not exceed 2 DPs.
<img width="1279" alt="Screenshot 2023-07-27 at 09 49 55" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/ec2543b7-90bf-4287-9cb8-5145a9f1da59">
