### PR TITLE
CIWEMB-414: Set contact Id from contribution

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -114,6 +114,7 @@
           return
         }
 
+        $scope.contactId = contribution.contact_id
         $scope.creditnotes.contact_id = contribution.contact_id
         const lineItems = contribution.items;
         // Ensure the due amount is not less than zero


### PR DESCRIPTION
## Overview
This pull request addresses an error that occurs when clicking the cancel button on the contribution credit note create page. The error is caused by the contact ID not being set. The solution is to set the page's contact ID state variable to the contribution contact.

## Before
https://github.com/compucorp/io.compuco.financeextras/assets/85277674/85435eb8-85b9-41bc-a9f6-dbe55e5e250f

## After
![After](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1399831f-b5ea-42d1-82ed-e4f721c52542)