### PR TITLE
CIWEMB-422: Update CreditNote email functionality

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
@@ -120,8 +120,9 @@ class CRM_Financeextras_Form_Contribute_CreditNoteEmail extends CRM_Core_Form {
     Civi::dispatcher()->dispatch(CreditNoteMailedEvent::NAME, new CreditNoteMailedEvent(
       $this->creditNoteId,
       $creditNoteInvoice,
-      $this->getSubject(),
-      array_column($this->getRowsForEmails(), 'contact_id')
+      $subject,
+      array_column($this->getRowsForEmails(), 'contact_id'),
+      $html . $additionalDetails
     ));
   }
 

--- a/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
@@ -112,10 +112,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteEmail extends CRM_Core_Form {
       $sents += ($sent ? 1 : 0);
     }
 
-    CRM_Core_Session::setStatus(ts('One email has been sent successfully. ', [
-      'plural' => '%count emails were sent successfully. ',
-      'count' => $sents,
-    ]), ts('Message Sent', ['plural' => 'Messages Sent', 'count' => $sents]), 'success');
+    CRM_Core_Session::setStatus(ts('Credit Note Sent by Email Successfully.'), ts('Message Sent'), 'success');
 
     Civi::dispatcher()->dispatch(CreditNoteMailedEvent::NAME, new CreditNoteMailedEvent(
       $this->creditNoteId,

--- a/Civi/Financeextras/Event/CreditNoteMailedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteMailedEvent.php
@@ -17,6 +17,7 @@ class CreditNoteMailedEvent extends Event {
         protected array $creditNoteInvoice,
         protected string $mailSubject,
         protected array $contactIds,
+        protected string $details,
     ) {
   }
 
@@ -34,6 +35,10 @@ class CreditNoteMailedEvent extends Event {
 
   public function getMailedContacts() {
     return $this->contactIds;
+  }
+
+  public function getDetails() {
+    return $this->details;
   }
 
 }

--- a/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
+++ b/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
@@ -30,7 +30,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
     $subject = 'Downloaded Credit Note PDF';
     $targetContactId = $this->getCreditNoteContactId($e->getCreditNoteId());
     $attachment = $this->storeFile($e->getCreditNoteInvoice()['html'], $e->getCreditNoteInvoice()['format']);
-    $this->createActivity([$targetContactId], $activityType, $subject, $attachment);
+    $this->createActivity([$targetContactId], $activityType, $subject, $attachment, '');
   }
 
   /**
@@ -42,7 +42,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
   public function createMailActivity(CreditNoteMailedEvent $e) {
     $activityType = 'Emailed Invoice';
     $attachment = $this->storeFile($e->getCreditNoteInvoice()['html'], $e->getCreditNoteInvoice()['format']);
-    $this->createActivity($e->getMailedContacts(), $activityType, $e->getSubject(), $attachment);
+    $this->createActivity($e->getMailedContacts(), $activityType, $e->getSubject(), $attachment, $e->getDetails());
   }
 
   /**
@@ -52,8 +52,9 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
    * @param string $type
    * @param string $subject
    * @param array $attachment
+   * @param string $details
    */
-  private function createActivity($targetContactIds, $type, $subject, $attachment) {
+  private function createActivity($targetContactIds, $type, $subject, $attachment, $details) {
     $now = (new DateTime())->format('YmdHis');
     $currentUser = \CRM_Core_Session::singleton()->get('userID');
     \Civi\Api4\Activity::create()
@@ -62,6 +63,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
       ->addValue('source_contact_id', $currentUser)
       ->addValue('activity_type_id:name', $type)
       ->addValue('activity_date_time', $now)
+      ->addValue('details', $details)
       ->addValue('attachFile_1', [
         'uri' => $attachment,
         'type' => 'application/pdf',

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteEmail.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteEmail.tpl
@@ -26,16 +26,16 @@
     <td>{$form.template.html}</td>
   </tr>
   <tr class="crm-contactEmail-form-block-subject">
-    <td class="label">{$form.subject.label}</td>
-    <td>
-      {$form.subject.html|crmAddClass:huge}&nbsp;
-    </td>
-  </tr>
-  <tr class="crm-email-element">
-    <td class="label">{ts}Email body{/ts}</td>
-    <td><div class="html">{$form.html_message.html}</div></td>
-  </tr>
+       <td class="label">{$form.subject.label}</td>
+       <td>
+         {$form.subject.html|crmAddClass:huge}&nbsp;
+         <input class="crm-token-selector big" data-field="subject" />
+         {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+       </td>
+    </tr>
 </table>
+
+{include file="CRM/Contact/Form/Task/EmailCommon.tpl" noAttach=0}
 
 <div class="spacer"></div>
 <div class="crm-submit-buttons">
@@ -46,6 +46,9 @@
 <script>
 
   CRM.$(function($) {
+    $('.crm-plaint_text_email-accordion').hide();
+    $('#attachments').parent().parent().hide()
+    $('#saveTemplate').parent().hide();
     var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkemail' q='id=1' h=0 }{literal}";
 
     var $form = $("form.{/literal}{$form.formClass}{literal}");


### PR DESCRIPTION
## Overview
This PR makes the following updates to the credit note email functionality
- Add token selector for subject and message body
- Updates the mail sent alert message to `Credit Note Sent by Email Successfully.`
- Include the mail body in the activity log.

## Before
![shot](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/4eaf8b02-6139-4861-b1c2-40c26be9f14b)


## After
Subject and token selectors can be seen
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/39145b13-d314-4095-913d-f97a8ba74e89)

The activity log now includes the email body in its details.
<img width="440" alt="Screenshot 2023-07-27 at 08 56 00" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/8d08e48a-cfa8-44a6-b1fd-535291c90b59">



