### PR TITLE
CIWEMB-295: Allow user to create credit note refund

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -161,7 +161,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
    * @param float $amount
    *   The amount of the allocation.
    */
-  private static function createAllocationEntityTransactions($allocationId, $transactionId, $amount) {
+  public static function createAllocationEntityTransactions($allocationId, $transactionId, $amount) {
     $allocationEntityTrxn = [
       'entity_table' => CRM_Financeextras_BAO_CreditNoteAllocation::$_tableName,
       'financial_trxn_id' => $transactionId,

--- a/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
@@ -1,0 +1,223 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Financeextras\Utils\CurrencyUtils;
+use CRM_Financeextras_ExtensionUtil as E;
+
+/**
+ * Credit Note refund Form controller class.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_Form_AbstractEditPayment {
+
+  /**
+   * Credit Note to refund.
+   *
+   * @var int
+   */
+  public $crid;
+
+  /**
+   * Credit Note to refund.
+   *
+   * @var array
+   */
+  public $creditNote;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    CRM_Utils_System::setTitle('Record a cash refund');
+
+    $this->crid = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->creditNote = $this->getCreditNote();
+
+    $url = CRM_Utils_System::url('civicrm/contribution/creditnote/refund', 'reset=1&id=' . $this->crid);
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($url);
+    parent::preProcess();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+
+    $this->addEntityRef('contact_id', ts('Contact'), [
+      'entity' => 'Contact',
+      'placeholder' => ts('- Contact -'),
+      'select' => ['minimumInputLength' => 0],
+      'api' => [
+        'params' => [
+          "is_active" => 1,
+        ],
+      ],
+      'readonly' => TRUE,
+      'class' => 'form-control',
+    ], TRUE);
+
+    $this->add(
+      'select',
+      'currency',
+      '',
+      array_combine(
+        array_column(CurrencyUtils::getCurrencies(), 'name'),
+        array_column(CurrencyUtils::getCurrencies(), 'symbol')
+      ),
+      FALSE,
+      ['disabled' => TRUE]
+    );
+
+    $this->add(
+      'text',
+      'amount',
+      ts('Refund Amount'),
+      [],
+      TRUE,
+      ['class' => 'form-control']
+    );
+
+    $this->add(
+      'datepicker',
+      'date',
+      ts('Date'),
+      NULL,
+      TRUE,
+      ['time' => FALSE]
+    );
+
+    $checkPaymentID = array_search('Check', CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'validate'));
+
+    $this->add(
+      'select',
+      'payment_instrument_id',
+      ts('Payment Method'),
+      ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'create'),
+      TRUE,
+      ['onChange' => "return showHideByValue('payment_instrument_id', '{$checkPaymentID}','checkNumber','table-row','select',false);"]
+    );
+
+    $this->add(
+      'text',
+      'trxn_id',
+      ts('Transaction ID')
+    );
+
+    $this->add(
+      'text',
+      'fee_amount',
+      ts('Fee Amount')
+    );
+
+    $this->add(
+      'text',
+      'reference',
+      ts('Reference')
+    );
+
+    parent::buildQuickForm();
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => E::ts('Create'),
+      ],
+      [
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+        'isDefault' => TRUE,
+      ],
+    ]);
+  }
+
+  public function setDefaultValues() {
+    if (empty($this->crid)) {
+      return [];
+    }
+
+    $creditNote = $this->creditNote;
+    $defaults = [
+      'amount' => $creditNote['remaining_credit'],
+      'contact_id' => $creditNote['contact_id'],
+      'currency' => $creditNote['currency'],
+      'date' => date('Y-m-d'),
+    ];
+
+    return $defaults;
+  }
+
+  public function addRules() {
+    $this->addFormRule([$this, 'refundRule']);
+  }
+
+  /**
+   *
+   * @param array $values
+   *
+   * @return array|bool
+   */
+  public function refundRule($values) {
+    $errors = [];
+    if ($values['amount'] > $this->creditNote['remaining_credit']) {
+      $errors['amount'] = ts('Amount to be refunded cannot exceed the remaining credit');
+    }
+
+    return $errors ?: TRUE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function postProcess() {
+    try {
+      $values = $this->getSubmitValues();
+
+      \Civi\Api4\CreditNote::refund()
+        ->setId($this->crid)
+        ->setAmount($values['amount'])
+        ->setReference($values['reference'])
+        ->setDate($values['date'])
+        ->setPaymentParam([
+          'payment_instrument_id' => $values['payment_instrument_id'],
+          'credit_card_type' => $values['credit_card_type'],
+          'pan_truncation' => $values['pan_truncation'],
+          'trxn_id' => $values['trxn_id'],
+          'fee_amount' => $values['fee_amount'],
+          'check_number' => $values['check_number'],
+        ])
+        ->execute()
+        ->first();
+
+      CRM_Core_Session::setStatus('Credit note refund created successfully.', '', 'success');
+      $url = CRM_Utils_System::url('civicrm/contact/view',
+        ['cid' => $this->creditNote['contact_id'], 'selectedChild' => 'contribute']
+      );
+      CRM_Utils_System::redirect($url);
+    }
+    catch (\Throwable $th) {
+      CRM_Core_Session::setStatus(E::ts($th->getMessage()), ts('Error Creating credit note refund'), 'error');
+    }
+  }
+
+  /**
+   * Returns the currrent credit note
+   *
+   * @return array
+   *   Array of credit note fields and values.
+   */
+  private function getCreditNote() {
+    $creditNote = CreditNote::get()
+      ->addWhere('id', '=', $this->crid)
+      ->execute()
+      ->first();
+
+    if (empty($creditNote)) {
+      throw new CRM_Core_Exception("Credit note with the given id doesn't exist");
+    }
+
+    return $creditNote;
+  }
+
+}

--- a/Civi/Api4/Action/CreditNote/RefundAction.php
+++ b/Civi/Api4/Action/CreditNote/RefundAction.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Civi\Api4\Action\CreditNote;
+
+use CRM_Core_Transaction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use CRM_Financeextras_BAO_CreditNote as CreditNoteBAO;
+
+/**
+ * Refund Credit notes.
+ */
+class RefundAction extends AbstractAction {
+  use DAOActionTrait;
+
+  /**
+   * credit note ID.
+   *
+   * @var int
+   */
+  protected $id;
+
+  /**
+   * Refund Amount
+   *
+   * @var int
+   */
+  protected $amount;
+
+  /**
+   * Refund reference
+   *
+   * @var string
+   */
+  protected $reference;
+
+  /**
+   * Refund Date
+   *
+   * @var string
+   */
+  protected $date;
+
+  /**
+   * Payment Information
+   *
+   * @var array
+   */
+  protected $paymentParam;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    $transaction = CRM_Core_Transaction::create();
+    try {
+      $allocationParam = [
+        'amount' => $this->amount,
+        'date' => $this->date,
+        'reference' => $this->reference,
+      ];
+      $result[] = CreditNoteBAO::refund($this->id, $allocationParam, $this->paymentParam);
+    }
+    catch (\Throwable $th) {
+      $transaction->rollback();
+
+      throw $th;
+    }
+  }
+
+}

--- a/Civi/Api4/CreditNote.php
+++ b/Civi/Api4/CreditNote.php
@@ -4,6 +4,7 @@ namespace Civi\Api4;
 
 use Civi\Api4\Action\CreditNote\GetAction;
 use Civi\Api4\Action\CreditNote\VoidAction;
+use Civi\Api4\Action\CreditNote\RefundAction;
 use Civi\Api4\Action\CreditNote\ComputeTotalAction;
 use Civi\Api4\Action\CreditNote\CreditNoteSaveAction;
 use Civi\Api4\Action\CreditNote\DeleteWithItemsAction;
@@ -61,6 +62,20 @@ class CreditNote extends Generic\DAOEntity {
   }
 
   /**
+   * Record a credit note refund.
+   *
+   * @param bool $checkPermissions
+   *  Should permission be checked for the user.
+   *
+   * @return \Civi\Api4\Action\CreditNote\RefundAction
+   *   returns the credit note refund action
+   */
+  public static function refund($checkPermissions = TRUE) {
+    return (new RefundAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * {@inheritDoc}
    *
    * @param bool $checkPermissions
@@ -91,9 +106,10 @@ class CreditNote extends Generic\DAOEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'void' => ['access CiviContribute', 'edit contributions'],
-      'computeTotal' => ['access CiviCRM', 'access CiviContribute'],
       'get' => ['access CiviCRM', 'access CiviContribute'],
+      'void' => ['access CiviContribute', 'edit contributions'],
+      'refund' => ['access CiviContribute', 'edit contributions'],
+      'computeTotal' => ['access CiviCRM', 'access CiviContribute'],
       'default' => ['access CiviCRM', 'access CiviContribute', 'edit contributions'],
       'delete' => ['access CiviCRM', 'access CiviContribute', 'delete in CiviContribute'],
       'deleteWithItems' => ['access CiviCRM', 'access CiviContribute', 'delete in CiviContribute'],

--- a/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
+++ b/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
@@ -119,8 +119,9 @@ class SearchDisplayRun {
         $column['val'] = \CRM_Utils_Money::format($creditNote['total_credit'], $creditNote['currency']);
       }
 
+      $allocatedTotal = $creditNote['allocated_manual_refund'] + $creditNote['allocated_online_refund'] + $creditNote['allocated_invoice'];
       if ($column['label'] == 'Allocated') {
-        $column['val'] = \CRM_Utils_Money::format($creditNote['allocated_invoice'], $creditNote['currency']);
+        $column['val'] = \CRM_Utils_Money::format($allocatedTotal, $creditNote['currency']);
       }
     }
   }

--- a/managed/SavedSearch_Credit_Notes.mgd.php
+++ b/managed/SavedSearch_Credit_Notes.mgd.php
@@ -200,7 +200,7 @@ $mgd = [
                   'target' => '',
                 ],
                 [
-                  'path' => 'civicrm/',
+                  'path' => 'civicrm/contribution/creditnote/refund?id=[id]',
                   'icon' => 'fa-retweet',
                   'text' => 'Record cash refund',
                   'style' => 'default',

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteRefund.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteRefund.tpl
@@ -1,0 +1,77 @@
+<div id="bootstrap-theme">
+
+  <div class="panel panel-default creditnote__refund-form-panel">
+    <div class="panel-body">
+      <div class="form-hoizontal">
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.contact_id.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+            {$form.contact_id.html}
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.amount.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+          {$form.currency.html} {$form.amount.html}
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.date.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+            {$form.date.html}
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.payment_instrument_id.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+            {$form.payment_instrument_id.html}
+          </div>
+        </div>
+        {include file='CRM/Core/BillingBlockWrapper.tpl'}
+
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.trxn_id.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+            {$form.trxn_id.html}
+          </div>
+        </div>
+
+
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.fee_amount.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+          {$form.currency.html} {$form.fee_amount.html}
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <div class="col-sm-2 control-label">
+            {$form.reference.label}
+          </div>
+          <div class="col-sm-7 col-md-5">
+            {$form.reference.html}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="crm-submit-buttons panel-footer">
+      {include file="CRM/common/formButtons.tpl" location="bottom"}
+    </div>
+  </div>
+</div>

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use Civi\Api4\CreditNote;
+use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+
+/**
+ * CreditNote.RefundAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
+
+  use CreditNoteTrait;
+
+  public function testCanRefundCreditNote() {
+    $creditNote = $this->createCreditNote(500);
+    $refundAllocation = $this->createRefund($creditNote['id']);
+
+    $this->assertNotEmpty($refundAllocation);
+    $this->assertEquals($refundAllocation['credit_note_id'], $creditNote['id']);
+  }
+
+  /**
+   * Assert the refund amount cannot be greatger than the remaining credit
+   */
+  public function testExceptionIsThrownForInvalidRefundAmount() {
+    $amountToRefund = 200;
+    $creditNote = $this->createCreditNote(500);
+    $this->allocateCredit($creditNote['id'], 'invoice', 400);
+
+    $this->expectException(CRM_Core_Exception::class);
+
+    $this->createRefund($creditNote['id'], $amountToRefund);
+  }
+
+  /**
+   * Tests that the expected entity financial transactions are created as part of the accounting entries.
+   */
+  public function testExpectedRefundEntityFinancialAccountingEntriesAreCreated() {
+    $amountToRefund = 200;
+    $creditNote = $this->createCreditNote(500);
+
+    $refundAllocation = $this->createRefund($creditNote['id'], $amountToRefund, [
+      'payment_instrument_id' => 3,
+      'check_number' => '1234',
+    ]);
+
+    $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_id', '=', $creditNote['id'])
+      ->addWhere('entity_table', '=', CRM_Financeextras_BAO_CreditNote::$_tableName)
+      ->addWhere('amount', '=', -$amountToRefund)
+      ->addWhere('financial_trxn_id', '=', $refundAllocation['financial_trxn_id'])
+      ->execute()
+      ->getArrayCopy();
+
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('total_amount', '=', -1 * $amountToRefund)
+      ->addWhere('id', '=', $refundAllocation['financial_trxn_id'])
+      ->addWhere('status_id', '=', 1)
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 3)
+      ->addWhere('check_number', '=', '1234')
+      ->addWhere('is_payment', '=', 1)
+      ->addWhere('check_number', '=', '1234')
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($financialTrxn);
+
+    $this->assertNotEmpty($entityFinancialTrxn);
+  }
+
+  public function testRefundFinancialTrxnHasExpectedToandFromAccountId() {
+    $creditNote = $this->createCreditNote(500);
+    $refundAllocation = $this->createRefund($creditNote['id']);
+
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('id', '=', $refundAllocation['financial_trxn_id'])
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    $expectedFromAccount = \CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $creditNote['items'][0]['financial_type_id'],
+      'Accounts Receivable Account is'
+    );
+    $expectedToAccount = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(1);
+
+    $this->assertEquals($financialTrxn['to_financial_account_id'], $expectedToAccount);
+    $this->assertEquals($financialTrxn['from_financial_account_id'], $expectedFromAccount);
+  }
+
+  public function testExpectedLineItemEntityTrxnRecordIsCreatedForRefund() {
+    $amountToRefund = 150;
+    $creditNote = $this->createCreditNote(500);
+    $refundAllocation = $this->createRefund($creditNote['id'], $amountToRefund);
+
+    $lineItemSum = array_reduce($creditNote['items'], function($previousSum, $currentLine) use ($refundAllocation) {
+      $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+        ->addWhere('entity_id', '=', $currentLine['id'])
+        ->addWhere('entity_table', '=', CRM_Financeextras_BAO_CreditNoteLine::$_tableName)
+        ->addWhere('financial_trxn_id', '=', $refundAllocation['financial_trxn_id'])
+        ->execute()
+        ->first();
+
+      return $previousSum + $entityFinancialTrxn['amount'];
+    });
+
+    $this->assertEquals(-1 * $amountToRefund, $lineItemSum);
+  }
+
+  private function createRefund($creditNoteId, $amountToRefund = 200, $paymentParam = []) {
+    return \Civi\Api4\CreditNote::refundAction()
+      ->setId($creditNoteId)
+      ->setAmount($amountToRefund)
+      ->setReference('reference')
+      ->setDate(date('Y-m-d'))
+      ->setPaymentParam(array_merge([
+        'payment_instrument_id' => 1,
+        'credit_card_type' => 'Visa',
+        'pan_truncation' => "2333",
+        'trxn_id' => mt_rand(1000, 6000),
+        'fee_amount' => '1.50',
+      ], $paymentParam))
+      ->execute()
+      ->first();
+  }
+
+  private function createCreditNote($creditAmount = 400) {
+    $creditNote = $this->getCreditNoteData();
+    $creditNote['items'][] = $this->getCreditNoteLineData(['quantity' => 1, 'unit_price' => $creditAmount / 2]);
+    $creditNote['items'][] = $this->getCreditNoteLineData(['quantity' => 1, 'unit_price' => $creditAmount / 2]);
+
+    return CreditNote::save()
+      ->addRecord($creditNote)
+      ->execute()
+      ->first();
+  }
+
+}

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -40,4 +40,9 @@
     <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteAllocate</page_callback>
     <access_arguments>edit contributions</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contribution/creditnote/refund</path>
+    <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteRefund</page_callback>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR adds the functionality that allows an admin user to record a cash refund for a credit note.

## Before
The functionality doesn't exist

## After
![refund100](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/c3cf27b4-22d6-446f-b4b8-8d4e127afd36)

## Technical Details
When a credit note cash refund is made, the following records are created during the reversal process:
- financial_trxn: A record of the refund payment.
- entity_financial_trxn for credit note: Links the credit note with the financial_trxn.
- entity_financial_trxn for credit note line: Each credit note line item is linked to the financial transaction, and the refunded amount is proportionally distributed among the credit note line items.