### PR TITLE
CIWEMB-413: Ensure the Credit note currency is set to the appropriate value

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
@@ -122,7 +122,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteAllocate extends CRM_Core_Form
    * @return array|bool
    */
   public function validateAllocation($amounts) {
-    if (!empty(array_filter($amounts, fn($n) => $n < 1))) {
+    if (!empty(array_filter($amounts, fn($n) => $n <= 0))) {
       CRM_Core_Session::setStatus('Amount to be refunded must be greater than zero.', 'Error', 'error');
       return FALSE;
     }

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -116,6 +116,9 @@
 
         $scope.contactId = contribution.contact_id
         $scope.creditnotes.contact_id = contribution.contact_id
+        $scope.creditnotes.currency = contribution.currency
+        $scope.currencySymbol = CurrencyCodes.getSymbol(contribution.currency);
+
         const lineItems = contribution.items;
         // Ensure the due amount is not less than zero
         const dueAmount = Math.max(contribution.total_amount - contribution.paid_amount, 0)
@@ -171,6 +174,7 @@
         $scope.creditnotes.id = creditnotes.id
         $scope.creditnotes.contact_id = creditnotes.contact_id
         $scope.creditnotes.currency = creditnotes.currency
+        $scope.currencySymbol = CurrencyCodes.getSymbol(creditnotes.currency);
         $scope.creditnotes.cn_number = creditnotes.cn_number
         $scope.creditnotes.date = $.datepicker.formatDate('yy-mm-dd', new Date(creditnotes.date))
         $scope.creditnotes.description = creditnotes.description


### PR DESCRIPTION
## Overview
This PR introduces the following changes:
- The currency used is taken from the contribution when creating credit notes from contributions.
- The minimum amount for credit note allocation has been set to zero.

## Before
The contribution is in USD, but the credit note shows GBP(i.e. the default currency).
![iiiioopb42](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/66a10c7a-28ec-4e74-afa5-1c9b23dd80af)



## After
The contribution is in USD, and the credit note now shows USD as expected.
![iiiioop](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/e86027fa-478b-4968-8517-018a21aa026e)
