### PR TITLE
CIWEMB-370: Update Credit note view screen

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
@@ -6,7 +6,7 @@
         {{ts('Allocated')}}
       </label>
       <div class="col-sm-6" ng-if="hasAllocatePermission && isView">
-        <a ng-href="{{ crmUrl('civicrm/contribution/creditnote/allocate', {crid: creditNoteId}) }}" class="btn btn-primary-outline pull-right">Allocate Credit</a>
+        <a ng-href="{{ crmUrl('civicrm/contribution/creditnote/allocate', {crid: creditNoteId}) }}" class="btn btn-primary pull-right">Allocate Credit</a>
       </div>
     </div>
   </div>

--- a/ang/fe-creditnote/directives/creditnote-view.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.js
@@ -71,7 +71,7 @@
         $scope.currency = creditnotes.currency
         $scope.currencySymbol = CurrencyCodes.getSymbol(creditnotes.currency);
         /*eslint-disable no-undef*/
-        $scope.creditnotes.date = strftime(CRM['fe-creditnote'].shortDateFormat, creditnotes.date)
+        $scope.creditnotes.date = strftime(CRM['fe-creditnote'].shortDateFormat, new Date(creditnotes.date))
         creditnotes.items.forEach((element, i) => {
           element.financial_type = element['financial_type_id.name']
           handleFinancialTypeChange(i);


### PR DESCRIPTION
## Overview
This PR introduces the following changes to the credit note view screen:
- Uses the same button bg colour for the `Edit` and `Allocate` button
- Converts the credit note date string retrieved from the API into a JavaScript Date object before formatting. This ensures that the date is correctly formatted when passed to the `strftime` formatted function.

## Before
The credit note date is `25-08-2023` but shows as `08/07/2023` when formatted to `Month/Day/Year`.
<img width="1233" alt="Screenshot 2023-08-07 at 08 03 10" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/9ebebec1-b5aa-4e0f-bf36-198f268ed70a">


## After
The credit note date is `25-08-2023` and now shows as `08/25/2023` when formatted to `Month/Day/Year` as expected.
<img width="1237" alt="Screenshot 2023-08-07 at 08 01 23" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/64cf90d5-3823-401a-85a0-a19704b2646b">


