### PR TITLE
CIWEMB-403: Allow non-admin users with appropriate permission to access Credit note action

### DIFF
--- a/Civi/Api4/Action/CreditNote/VoidAction.php
+++ b/Civi/Api4/Action/CreditNote/VoidAction.php
@@ -92,6 +92,7 @@ class VoidAction extends AbstractAction {
 
     $creditNoteAllocations = CreditNoteAllocation::get()
       ->addWhere('credit_note_id', '=', $this->id)
+      ->addWhere('is_reversed', '=', FALSE)
       ->execute()
       ->first();
 

--- a/Civi/Api4/CreditNoteLine.php
+++ b/Civi/Api4/CreditNoteLine.php
@@ -11,4 +11,15 @@ namespace Civi\Api4;
  */
 class CreditNoteLine extends Generic\DAOEntity {
 
+  /**
+   * {@inheritDoc}
+   */
+  public static function permissions() {
+    return [
+      'meta' => ['access CiviCRM'],
+      'get' => ['access CiviCRM', 'access CiviContribute'],
+      'default' => ['access CiviCRM', 'access CiviContribute', 'edit contributions'],
+    ];
+  }
+
 }

--- a/Civi/Financeextras/Service/CreditNoteInvoiceService.php
+++ b/Civi/Financeextras/Service/CreditNoteInvoiceService.php
@@ -181,7 +181,7 @@ class CreditNoteInvoiceService {
    * Returns the tax term.
    */
   private function getTaxTerm() {
-    $settings = Setting::get()
+    $settings = Setting::get(FALSE)
       ->addSelect('contribution_invoice_settings')
       ->execute()
       ->first()['value'];

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteEmail.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteEmail.tpl
@@ -49,6 +49,8 @@
     $('.crm-plaint_text_email-accordion').hide();
     $('#attachments').parent().parent().hide()
     $('#saveTemplate').parent().hide();
+    const cancelBtn = cj( "button:contains('Previous')" )
+    cancelBtn.html(cancelBtn.html().replace('Previous', 'Cancel'))
     var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkemail' q='id=1' h=0 }{literal}";
 
     var $form = $("form.{/literal}{$form.formClass}{literal}");

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -28,12 +28,12 @@
   <item>
     <path>civicrm/contribution/creditnote/delete</path>
     <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteDelete</page_callback>
-    <access_arguments>access CiviCRM, access CiviContribute, delete in CiviContribute</access_arguments>
+    <access_arguments>access CiviCRM,access CiviContribute,delete in CiviContribute</access_arguments>
   </item>
   <item>
     <path>civicrm/contribution/creditnote/void</path>
     <page_callback>CRM_Financeextras_Form_Contribute_CreditNoteVoid</page_callback>
-    <access_arguments>access CiviCRM, access CiviContribute, edit contributions</access_arguments>
+    <access_arguments>access CiviCRM,access CiviContribute,edit contributions</access_arguments>
   </item>
   <item>
     <path>civicrm/contribution/creditnote/allocate</path>


### PR DESCRIPTION
## Overview
Before this PR non-admin users(i.e. users without Administer CiviCRM role) couldn't perform some credit note-related actions such as `void`. 

## Before
![voidddd](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/5ed08896-5206-488c-9bba-19bded15aa70)


## After
![voidddd111333332](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1e155d50-ed7c-402e-9b68-c243cf56e40e)
