### PR TITLE
CIWEMB-431: Add Contribution Credit note create button

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -16,6 +16,7 @@ class ContributionCreate {
 
   public function handle() {
     $this->addCustomLineItemTemplate();
+    $this->addCreditNoteCancelAction();
     $this->configureRecordPaymentField();
     $this->preventUserFromSettingContributionStatus();
   }
@@ -63,6 +64,20 @@ class ContributionCreate {
       ]);
       \Civi::resources()->addVars('financeextras', ['currencies' => \CRM_Core_OptionGroup::values('currencies_enabled')]);
     }
+  }
+
+  private function addCreditNoteCancelAction() {
+    if (!$this->form->_id) {
+      return;
+    }
+
+    \Civi::resources()->add([
+      'scriptFile' => [E::LONG_NAME, 'js/addContributionCreditNoteBtn.js'],
+      'region' => 'page-header',
+    ]);
+
+    $url = \CRM_Utils_System::url('civicrm/contribution/creditnote', 'reset=1&action=add&contribution_id=' . $this->form->_id);
+    \Civi::resources()->addVars('financeextras', ['creditnote_btn_url' => $url]);
   }
 
   private function isEdit() {

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Civi\Financeextras\Hook\BuildForm;
+
+use CRM_Financeextras_ExtensionUtil as E;
+
+class ContributionView {
+
+  private ?int $id;
+
+  /**
+   * @param \CRM_Contribute_Form_ContributionView $form
+   */
+  public function __construct(private \CRM_Contribute_Form_ContributionView $form) {
+    $this->id = $this->form->get('id');
+  }
+
+  public function handle() {
+    $this->addCreditNoteCancelAction();
+  }
+
+  private function addCreditNoteCancelAction() {
+    if (!$this->id || $this->isContributionCancelled()) {
+      return;
+    }
+
+    \Civi::resources()->add([
+      'scriptFile' => [E::LONG_NAME, 'js/addContributionCreditNoteBtn.js'],
+      'region' => 'page-header',
+    ]);
+
+    $url = \CRM_Utils_System::url('civicrm/contribution/creditnote', ['reset' => 1, 'action' => 'add', 'contribution_id' => $this->id]);
+    \Civi::resources()->addVars('financeextras', ['is_contribution_view' => TRUE]);
+    \Civi::resources()->addVars('financeextras', ['creditnote_btn_url' => $url]);
+  }
+
+  /**
+   * Checks contribution has been cancelled.
+   *
+   * @return bool
+   *   Array with recurring contribution's data.
+   *
+   * @throws \Civi\API\Exception
+   */
+  private function isContributionCancelled() {
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addWhere('id', '=', $this->id)
+      ->addWhere('contribution_status_id:name', '=', 'Cancelled')
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    return !empty($contribution);
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param \CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Contribute_Form_ContributionView";
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -178,6 +178,7 @@ function financeextras_civicrm_postProcess($formName, $form) {
  */
 function financeextras_civicrm_buildForm($formName, &$form) {
   $hooks = [
+    \Civi\Financeextras\Hook\BuildForm\ContributionView::class,
     \Civi\Financeextras\Hook\BuildForm\MembershipCreate::class,
     \Civi\Financeextras\Hook\BuildForm\ParticipantCreate::class,
     \Civi\Financeextras\Hook\BuildForm\ContributionCreate::class,

--- a/js/addContributionCreditNoteBtn.js
+++ b/js/addContributionCreditNoteBtn.js
@@ -1,0 +1,19 @@
+CRM.$(function ($) {
+  addCreditNoteBtn();
+
+  /**
+   * Add the Credit / Cancel action button beside the contribution status
+   */
+  function addCreditNoteBtn() {
+    const btnUrl = CRM.vars.financeextras.creditnote_btn_url.replace(/&amp;/g, '&');
+    const isView = CRM.vars.financeextras.is_contribution_view;
+    let statusRow = $('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)');
+    const actionBtn = $('<div>').css({ display: 'inline-flex', marginLeft: '10px' }).append($('<a>').addClass('button no-popup').attr('href', btnUrl).append($('<span>').text('Create New Credit Note')));
+    
+    if (isView) {
+      statusRow = $("tr:contains('Contribution Status') td:nth-child(2)");
+    }
+
+    statusRow.append(actionBtn)
+  }
+});


### PR DESCRIPTION
## Overview
This pull request adds a "create new credit note" button next to the contribution status on the contribution view screen.

clicking on the button opens up the credit note create screen, with line items populated from the contribution.

## Before
<img width="1212" alt="Screenshot 2023-08-22 at 18 22 09" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d1509784-6383-4ac2-8420-720fd1bd1cfe">

## After
![hhhh](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/cd78101d-efa7-4986-abf4-89117514ab45)
