### PR TITLE
CIWEMB-422: Add creditnote email/download activity type

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
+use Civi\Financeextras\Setup\Manage\CreditNoteActivityTypeManager;
 use Civi\Financeextras\Setup\Manage\CreditNoteAllocationTypeManager;
 use Civi\Financeextras\Setup\Manage\CreditNoteInvoiceTemplateManager;
 
@@ -15,6 +16,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function install() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
     ];
@@ -30,6 +32,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function uninstall() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
     ];
@@ -45,6 +48,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function enable() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
     ];
@@ -60,6 +64,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   public function disable() {
     $steps = [
       new CreditNoteStatusManager(),
+      new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
     ];

--- a/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
+++ b/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
@@ -6,6 +6,7 @@ use DateTime;
 use Civi\Financeextras\Event\CreditNoteMailedEvent;
 use Civi\Financeextras\Event\CreditNoteDownloadedEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Financeextras\Setup\Manage\CreditNoteActivityTypeManager;
 
 class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
 
@@ -26,7 +27,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
    *   The registration event. Add new tokens using register().
    */
   public function createDownloadActivity(CreditNoteDownloadedEvent $e) {
-    $activityType = 'Downloaded Invoice';
+    $activityType = CreditNoteActivityTypeManager::DOWNLOAD_INVOICE_ACTIVITY;
     $subject = 'Downloaded Credit Note PDF';
     $targetContactId = $this->getCreditNoteContactId($e->getCreditNoteId());
     $attachment = $this->storeFile($e->getCreditNoteInvoice()['html'], $e->getCreditNoteInvoice()['format']);
@@ -40,7 +41,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
    *   The registration event. Add new tokens using register().
    */
   public function createMailActivity(CreditNoteMailedEvent $e) {
-    $activityType = 'Emailed Invoice';
+    $activityType = CreditNoteActivityTypeManager::EMAIL_INVOICE_ACTIVITY;
     $attachment = $this->storeFile($e->getCreditNoteInvoice()['html'], $e->getCreditNoteInvoice()['format']);
     $this->createActivity($e->getMailedContacts(), $activityType, $e->getSubject(), $attachment, $e->getDetails());
   }

--- a/Civi/Financeextras/Setup/Manage/CreditNoteActivityTypeManager.php
+++ b/Civi/Financeextras/Setup/Manage/CreditNoteActivityTypeManager.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+/**
+ * Adds credit note specific activity types.
+ */
+class CreditNoteActivityTypeManager extends AbstractManager {
+
+  const EMAIL_INVOICE_ACTIVITY = 'financeextras_credit_note_email_activity';
+  const DOWNLOAD_INVOICE_ACTIVITY = 'financeextras_credit_note_download_activity';
+
+  /**
+   * Ensures Credit note activity types exists.
+   */
+  public function create(): void {
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'activity_type',
+      'name' => self::EMAIL_INVOICE_ACTIVITY,
+      'label' => 'Emailed credit note',
+      'is_reserved' => 1,
+      'is_active' => TRUE,
+    ]);
+
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'activity_type',
+      'name' => self::DOWNLOAD_INVOICE_ACTIVITY,
+      'label' => 'Downloaded credit note',
+      'is_reserved' => 1,
+      'is_active' => TRUE,
+    ]);
+  }
+
+  /**
+   * Removes the entity.
+   */
+  public function remove(): void {
+    \Civi\Api4\OptionValue::delete(FALSE)
+      ->addWhere('name', 'IN', [self::EMAIL_INVOICE_ACTIVITY, self::DOWNLOAD_INVOICE_ACTIVITY])
+      ->addWhere('option_group_id:name', '=', 'activity_type')
+      ->execute();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function toggle($status): void {
+    \Civi\Api4\OptionValue::update(FALSE)
+      ->addWhere('name', 'IN', [self::EMAIL_INVOICE_ACTIVITY, self::DOWNLOAD_INVOICE_ACTIVITY])
+      ->addWhere('option_group_id:name', '=', 'activity_type')
+      ->addValue('is_active', $status)
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
## Overview
This pull request introduces new activity types, "Downloaded credit note" and "Emailed credit note", which will be used to track credit note download and email activity respectively.

## Before
The activity types 'Downloaded Invoice' and 'Emailed Invoice' were used when a credit note is downloaded or emailed.

![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1de6ee96-6032-4e37-acd1-1490e1d6dde5)

## After
The `Downloaded credit note` and `Emailed credit note` are now used when a credit note is downloaded or emailed.

<img width="1249" alt="Screenshot 2023-08-16 at 07 52 13" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d38f576b-7d09-4065-b632-7994bea4c4b0">

<img width="520" alt="Screenshot 2023-08-16 at 08 05 00" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/ded919ce-754a-4731-8213-37ca03e37341">
