### PR TITLE
CIWEMB-456: Align check number field

### DIFF
--- a/templates/CRM/Financeextras/Form/Contribute/AddPayment.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/AddPayment.tpl
@@ -29,5 +29,12 @@
     .crm-contribution-form-block-financeextras_record_payment_amount > #amount-label {
       vertical-align: baseline;
     }
+    #Contribution .crm-form-block>.form-layout-compressed tr.record_payment-block_row tr.crm-contribution-fe-billing_row > td:first-child {
+      padding-left: 0px;
+    }
+    #payment_information > fieldset > div > div > div.label {
+      width: 149px;
+      margin-right: 9px;
+    }
   </style>
 {/literal}


### PR DESCRIPTION
## Overview
[see title]

## Before
The check number field was not properly aligned.
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/81d5d6bd-8658-4939-8364-b428223fc0d7)


## After
The check number field is now properly aligned.
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/af8c202f-b481-4feb-bad8-267cd0367940)
