### PR TITLE
CIWEMB-290: Add support for CreditNote entity to Financial entities API

### DIFF
--- a/financeextras.php
+++ b/financeextras.php
@@ -139,3 +139,21 @@ function financeextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
     \CRM_Financeextras_BAO_CreditNote::updateCreditNoteStatusPostAllocation($objectId);
   }
 }
+
+/**
+ * Implements fieldOptions hook().
+ *
+ * @param string $entity
+ * @param string $field
+ * @param array $options
+ * @param array $params
+ */
+function financeextras_civicrm_fieldOptions($entity, $field, &$options, $params) {
+  if (in_array($entity, ['FinancialItem']) && $field == 'entity_table') {
+    $options[\CRM_Financeextras_DAO_CreditNoteLine::$_tableName] = ts('Credit Note Line');
+  }
+
+  if (in_array($entity, ['EntityFinancialTrxn']) && $field == 'entity_table') {
+    $options[\CRM_Financeextras_DAO_CreditNote::$_tableName] = ts('Credit Note');
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds support for CreditNote and Credit Note line entity to FinancialItem and Entity Financial Transaction entity API

## Before
The FinancialItem and Entity Financial Transaction Get API does not retrieve records where the entity_table is either CreditNote or CreditNoteLine.
![pillow22](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/b030eb03-1ec5-4692-b902-a5b9955f6d3c)


## After
The FinancialItem and Entity Financial Transaction Get API now retrieve records where the entity_table is either CreditNote or CreditNoteLine.
![pillow](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/f93fa4cf-9c35-4e75-9f70-09a52906b919)

## Comment
Similar PR here https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/404
