### PR TITLE
CIWEMB-423: Open a contribution with the line item editor by default

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -4,6 +4,7 @@ namespace Civi\Financeextras\Hook\BuildForm;
 
 use CRM_Financeextras_ExtensionUtil as E;
 use Civi\Financeextras\Utils\OptionValueUtils;
+use CRM_Core_Action;
 
 class ContributionCreate {
 
@@ -14,6 +15,7 @@ class ContributionCreate {
   }
 
   public function handle() {
+    $this->addCustomLineItemTemplate();
     $this->configureRecordPaymentField();
     $this->preventUserFromSettingContributionStatus();
   }
@@ -65,6 +67,27 @@ class ContributionCreate {
 
   private function isEdit() {
     return !empty($this->form->_id);
+  }
+
+  /**
+   * Defaults to opening a contribution with the line item editor view.
+   */
+  private function addCustomLineItemTemplate() {
+    $lineItemEditorIsInstalled = 'installed' ===
+    \CRM_Extension_System::singleton()->getManager()->getStatus('biz.jmaconsulting.lineitemedit');
+
+    if (!$lineItemEditorIsInstalled) {
+      return;
+    }
+
+    if (!in_array($this->form->_action, [CRM_Core_Action::ADD, CRM_Core_Action::UPDATE])) {
+      return;
+    }
+
+    \Civi::resources()->add([
+      'template' => 'CRM/Financeextras/Form/Contribute/CustomLineItem.tpl',
+      'region' => 'page-body',
+    ]);
   }
 
   /**

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -15,12 +15,18 @@ CRM.$(function ($) {
     });
   
     $('#price_set_id').on('change', function() {
+      recordPaymentAmount.value = $('#line-total').data('raw-total');
       if (($(this).val() !== '')) {
+        recordPaymentAmount.value = $('#pricevalue').data('raw-total');
         $('#pricevalue').on('change', function() {
           recordPaymentAmount.value = $('#pricevalue').data('raw-total');
         });
       }
     })
+
+    $('#line-total').on('datachanged', function() {
+      recordPaymentAmount.value = $('#line-total').data('raw-total');
+    });
   }
 
   function hideStatusField() {

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -1,0 +1,102 @@
+
+{literal}
+  <script>
+    CRM.$(function($) {
+      const submittedRows = $.parseJSON('{/literal}{$lineItemSubmitted}{literal}');
+      const action = '{/literal}{$action}{literal}';
+
+      // This dealy ensures the lineitem table has been built before trying to manipulate its field.
+      setTimeout(() => {
+        $('#lineitem-add-block').after(
+          $('<div>').addClass('price-set-alt')
+          .append($('<div>').addClass('price-set-alt-or'))
+          .append($('<div>').addClass('price-set-alt-select'))
+          .append($('#lineitem-add-block > div:last-child'))
+        )
+        $('#totalAmount, #totalAmountORaddLineitem').hide()
+        $('#selectPriceSet').prepend( `<div id="lineItemSwitch" class="crm-hover-button">OR <a href="#">Switch back to using line items</a></div>`)
+        $('#lineItemSwitch').css('display', 'block').on('click', () => $('#price_set_id').val('').change())
+
+        if ($('#price_set_id').val() === '' && submittedRows.length <= 0) {
+          $('#add-items').click()
+        }
+        toggleLineItemOrPricesetFields($('#price_set_id').val() === '');
+
+        $('#price_set_id').on('change', function() {
+          setTimeout(() => {
+            toggleLineItemOrPricesetFields($(this).val() === '');
+          }, 100);
+        });
+      }, 100);
+
+      const toggleLineItemOrPricesetFields = (show) => {
+        if (!show) {
+          $('#lineItemSwitch').show();
+          $('#selectPriceSet').prepend($('#price_set_id'))
+          $('#lineitem-add-block').hide();
+          $('.price-set-alt').hide();
+        } else {
+          $('#lineItemSwitch').hide();
+          $('#lineitem-add-block').show()
+          $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').css('display', 'none')
+          $('.price-set-alt').show()
+          if (action != 2) {
+            // On edit user can't switch from priceset to lineitem and viceversa.
+            $('.price-set-alt-or').append($('#totalAmountORPriceSet').show())
+            $('.price-set-alt-select').append($('#price_set_id').show())
+          }
+          if (action == 1) {
+            $( "#total_amount").val(0)
+          }
+          $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
+        }
+      }
+      $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
+    })
+  </script>
+{/literal}
+
+{literal}
+<style>
+  div#lineitem-add-block.status {
+    background-color: #fff;
+    border-color: #fff;
+    padding: 0px 0px;
+    margin: 0 0px 10px !important;
+  }
+  div#lineitem-add-block.status table#info {
+    border: 1px solid #ddd;
+    padding-bottom: 8px;
+    margin-bottom: 8px;
+  }
+  div#lineitem-add-block.status #add-another-item {
+    margin-bottom: 2px !important;
+  }
+  #choose-manual {
+    display: none;
+  }
+  .price_set-section label {
+    width: 100%;
+  }
+  .price-set-alt-select {
+    margin: 8px 0px;
+  }
+  #pricesetTotal > #pricelabel {
+    width: 30%;
+  }
+  #pricesetTotal > #pricelabel > span {
+    margin-right: 5px;
+    font-weight: bold;
+  }
+  #selectPriceSet div#lineItemSwitch {
+    margin-left: 15px !important;
+    text-align: left;
+  }
+  tr.line-item-row > td {
+    padding-left: 5px !important;
+  }
+  .float-right {
+    float: right;
+  }
+</style>
+{/literal}


### PR DESCRIPTION
## Overview
In this PR we open the line-item editor by default on the new contribution screen.

## Before
Users have to use the `add line-item(s)` button to open the line-item editor screen
![11gggwq212121](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/2a66950b-9ae0-4e5a-8edf-cc811c5a289a)


## After
The line-item editor screen is opened by default
![gggwq212121](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/a33c04ce-dfe4-424f-a500-35b272f8b362)


## Technical Details
The changes introduced in this pull request mostly involve UI updates to simplify the contributing total amounts display. Prior to this pull request, the new/edit contribution page allows the contribution total amount to be provided in three ways: Total Amount (single field), Add Line Items (one or more), and Price Sets.

With this PR the options are now limited to Add Line Items (one or more), and Price Sets.