### PR TITLE
CIWEMB-457: Recalculate contribution status post-update

### DIFF
--- a/js/modifyParticipantForm.js
+++ b/js/modifyParticipantForm.js
@@ -53,6 +53,7 @@ CRM.$(function ($) {
     $('.fe-contribution-date').html($('#receive_date').parent())
     $('.crm-event-eventfees-form-block-financial_type_id .description').hide()
     $('.fe-record_contribution-block #currency-symbol').text(window.symbol)
+    $('#total_amount').before($('.fe-record_contribution-block #currency-symbol').clone().append(' '))
     $('.crm-event-eventfees-form-block-contribution_status_id').hide();
   }
 

--- a/templates/CRM/Financeextras/Form/Event/AddContribution.tpl
+++ b/templates/CRM/Financeextras/Form/Event/AddContribution.tpl
@@ -27,8 +27,14 @@
   </table>
   </fieldset>
 </div>
-<style>
-  .fe-record_contribution-fields > tbody > tr > td#amount-label {
-    vertical-align: baseline;
-  }
+{literal}
+  <style>
+    .fe-record_contribution-fields > tbody > tr > td#amount-label,
+    .crm-event-eventfees-form-block-total_amount > td.label {
+      vertical-align: baseline;
+    }
+    #payment_information fieldset.pay-later_info-group legend {
+      display: none;
+    }
 </style>
+{/literal}


### PR DESCRIPTION
## Overview
This PR introduces the following changes
- Add currency symbol to payment amount label in the event registration screen
- Recalculate contribution status post-update

## Before
The currency symbol is not displayed beside the amount label
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/5ef51fb8-2e72-4306-88da-bd9da2490983)


## After
The currency symbol is displayed beside the amount label
<img width="1205" alt="Screenshot 2023-08-24 at 08 31 16" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/485be575-3d6b-4a95-845b-9913326bc829">


## Technical Details

In this [PR](https://github.com/compucorp/io.compuco.financeextras/pull/56) where we added a new event to recalculate contribution status, we mentioned that we would later locate a centralized location to emit the event.

In this PR we have decided to do this in the  [hook_civicrm_post](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_post/).