### PR TITLE
CIWEMB-461: Fix creditnote refund functionality issues

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
@@ -33,8 +33,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
 
     $this->crid = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $this->creditNote = $this->getCreditNote();
-
-    $url = CRM_Utils_System::url('civicrm/contribution/creditnote/refund', 'reset=1&id=' . $this->crid);
+    $url = CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $this->creditNote['contact_id'] . '&selectedChild=contribute', FALSE);
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext($url);
     parent::preProcess();
@@ -64,19 +63,19 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
       '',
       array_combine(
         array_column(CurrencyUtils::getCurrencies(), 'name'),
-        array_column(CurrencyUtils::getCurrencies(), 'symbol')
+        array_column(CurrencyUtils::getCurrencies(), 'symbol'),
       ),
       FALSE,
-      ['disabled' => TRUE]
+      ['disabled' => TRUE, 'class' => 'form-control']
     );
 
     $this->add(
-      'text',
+      'number',
       'amount',
       ts('Refund Amount'),
-      [],
+      ['class' => 'form-control'],
       TRUE,
-      ['class' => 'form-control']
+      ['min' => 0, 'step' => 0.01]
     );
 
     $this->add(
@@ -96,38 +95,41 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
       ts('Payment Method'),
       ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'create'),
       TRUE,
-      ['onChange' => "return showHideByValue('payment_instrument_id', '{$checkPaymentID}','checkNumber','table-row','select',false);"]
+      ['onChange' => "return showHideByValue('payment_instrument_id', '{$checkPaymentID}','checkNumber','table-row','select',false);", 'class' => 'form-control']
     );
 
     $this->add(
       'text',
       'trxn_id',
-      ts('Transaction ID')
+      ts('Transaction ID'),
+      ['class' => 'form-control']
     );
 
     $this->add(
       'text',
       'fee_amount',
-      ts('Fee Amount')
+      ts('Fee Amount'),
+      ['class' => 'form-control']
     );
 
     $this->add(
       'text',
       'reference',
-      ts('Reference')
+      ts('Reference'),
+      ['class' => 'form-control']
     );
 
     parent::buildQuickForm();
 
     $this->addButtons([
       [
-        'type' => 'submit',
-        'name' => E::ts('Create'),
-      ],
-      [
         'type' => 'cancel',
         'name' => E::ts('Cancel'),
         'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'submit',
+        'name' => E::ts('Create'),
       ],
     ]);
   }

--- a/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
@@ -178,7 +178,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
 
       \Civi\Api4\CreditNote::refund()
         ->setId($this->crid)
-        ->setAmount($values['amount'])
+        ->setAmount(round($values['amount'], 2))
         ->setReference($values['reference'])
         ->setDate($values['date'])
         ->setPaymentParam([

--- a/Civi/Api4/Action/CreditNote/RefundAction.php
+++ b/Civi/Api4/Action/CreditNote/RefundAction.php
@@ -24,7 +24,7 @@ class RefundAction extends AbstractAction {
   /**
    * Refund Amount
    *
-   * @var int
+   * @var mixed
    */
   protected $amount;
 

--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
@@ -30,7 +30,7 @@
     $scope.remaining_credit = 0;
     $scope.isView = $scope.context == 'view'
     /*eslint-disable no-undef*/
-    $scope.formatDate = (date) => strftime(CRM['fe-creditnote'].shortDateFormat, date)
+    $scope.formatDate = (date) => strftime(CRM['fe-creditnote'].shortDateFormat,  new Date(date))
     $scope.formatMoney = MoneyFormat.formatMoney;
     $scope.isUpdate = $scope.context == 'update';
     $scope.hasAllocatePermission = CRM['fe-creditnote'].canEditContribution;

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteRefund.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteRefund.tpl
@@ -17,7 +17,9 @@
             {$form.amount.label}
           </div>
           <div class="col-sm-7 col-md-5">
-          {$form.currency.html} {$form.amount.html}
+            <div class="row">
+              <div class="col-sm-3">{$form.currency.html}</div> <div class="col-sm-9">{$form.amount.html}</div>
+            </div>
           </div>
         </div>
 
@@ -55,7 +57,9 @@
             {$form.fee_amount.label}
           </div>
           <div class="col-sm-7 col-md-5">
-          {$form.currency.html} {$form.fee_amount.html}
+            <div class="row">
+              <div class="col-sm-3">{$form.currency.html}</div> <div class="col-sm-9">{$form.fee_amount.html}</div>
+            </div>
           </div>
         </div>
 
@@ -75,3 +79,16 @@
     </div>
   </div>
 </div>
+
+{literal}
+  <style>
+  #payment_information div.label {
+    text-align: left;
+    padding-left: 0;
+  }
+
+  #payment_information > fieldset > div div.content {
+  margin-left: 17%;
+  }
+  </style>
+{/literal}


### PR DESCRIPTION
## Overview
This PR introduces the following changes to the credit note refund functionality:
1. Align the refund form fields
2. Ensure the refund amount is always in 2 decimal places


## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/3befdd58-eb64-4660-b2a1-709ab5410821)

## After
<img width="1217" alt="Screenshot 2023-08-28 at 13 02 22" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/b5f18f51-9ea4-4451-bbc0-63eefea87353">
