### PR TITLE
CIWEMB-465: Delete allocations while deleting credit note

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -186,6 +186,8 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
     $trxn->deleteRecord(['id' => $entityTrxn->financial_trxn_id]);
 
     $entityTrxn->delete();
+
+    CreditNoteAllocationBAO::deleteAccountingEntries($creditNoteId);
   }
 
   /**


### PR DESCRIPTION
## Overview
In this PR we also delete credit note allocations while deleting a credit note entity

## Before
Credit note allocations are not deleted

## After
Credit note allocations are deleted

![oopmascot](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/7ade0694-91a8-4e6e-bf9f-ca91450ab9b9)

