### PR TITLE
CIWEMB-468: Allow Event contribution amount to be different from payment amount

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
@@ -4,6 +4,7 @@ namespace Civi\Financeextras\Hook\BuildForm;
 
 use CRM_Core_Action;
 use CRM_Financeextras_ExtensionUtil as E;
+use Civi\Financeextras\Utils\OptionValueUtils;
 
 class ParticipantCreate {
 
@@ -37,6 +38,7 @@ class ParticipantCreate {
     $defaults = [
       'fe_ticket_type' => $this->getDefaultTicketType(),
       'fe_contribution_amount' => 0,
+      'contribution_status_id' => OptionValueUtils::getValueForOptionValue('contribution_status', 'pending'),
     ];
     $this->form->setDefaults(array_merge($this->form->_defaultValues, $defaults));
 

--- a/js/modifyParticipantForm.js
+++ b/js/modifyParticipantForm.js
@@ -54,6 +54,7 @@ CRM.$(function ($) {
     $('.crm-event-eventfees-form-block-financial_type_id .description').hide()
     $('.fe-record_contribution-block #currency-symbol').text(window.symbol)
     $('#total_amount').before($('.fe-record_contribution-block #currency-symbol').clone().append(' '))
+    $('#total_amount').after($('#total_amount').clone().attr('id', 'fe_total_amount').attr('name', 'fe_total_amount')).hide()
     $('.crm-event-eventfees-form-block-contribution_status_id').hide();
   }
 
@@ -95,8 +96,10 @@ CRM.$(function ($) {
   }
 
   function setTotalAmount() {
+    $('input[name=fe_total_amount]').val($('#pricevalue').data('raw-total'));
     $('input[name=fe_contribution_amount]').val($('#pricevalue').data('raw-total'));
     $('#pricevalue').on('change', function() {
+      $('input[name=fe_total_amount]').val($('#pricevalue').data('raw-total'));
       $('input[name=fe_contribution_amount]').val($('#pricevalue').data('raw-total'));
     });
   }


### PR DESCRIPTION
## Overview
With this PR the Event payment amount is different from the contribution amount.

## 
The Event Contribution uses the payment amount as the contribution amount.
![124](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/61eb7a1e-c1b4-4e2a-8d3f-d314b249fe0b)
Before


## After
The Event contribution uses the event fee as the contribution amount, and the payment amount is separated.
![121](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/38d3a1d2-8a55-4bd3-b363-e16e8cba6d61)


## Technical Details
The issue with the current implementation is that the payment amount entered by the user when creating an event is reflected as the contribution amount instead of the event fee. leading to incorrect contribution status. For example, if the payment amount is greater than the contribution amount(i.e. the event fee), the contribution status should be `pending refund`, or if the contribution amount is less than the payment amount the contribution status should be `partially paid`, but instead the contribution status is always showing `completed`.

To fix this issue, we have implemented a two-step solution.
Firstly, we ensure that the actual event fee is always submitted to the backend as the contribution amount, and it is hidden from the user to prevent any changes.
Secondly, we handle the payment creation separately in the `post-process` hook using the payment amount entered by the user to allow for different values for the contribution and payment. This way the contribution will have the appropriate amount and status,  e.g. if the payment amount is greater than the event fee, the contribution status will be `pending refund`.

