### PR TITLE
CIWEMB-463: Ensure financial item accounting entry has the right status

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteLine.php
+++ b/CRM/Financeextras/BAO/CreditNoteLine.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Financeextras\Utils\OptionValueUtils;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
 
 class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditNoteLine {
@@ -162,7 +163,7 @@ class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditN
       'currency' => $creditNote['currency'],
       'amount' => ($lineItem['quantity'] * $lineItem['unit_price']),
       'description' => $lineItem['description'],
-      'status_id' => $status,
+      'status_id' => OptionValueUtils::getValueForOptionValue('financial_item_status', $status),
       'financial_account_id' => $financialAccount,
       'entity_table' => \CRM_Financeextras_DAO_CreditNoteLine::$_tableName,
       'entity_id' => $lineItem['id'],

--- a/css/fe-creditnote.css
+++ b/css/fe-creditnote.css
@@ -39,3 +39,8 @@
 #creditnote__view #creditnote__detail>tbody> tr > td {
   border-top: none;
 }
+#creditnote__list > div > crm-angular-js > afsearch-credit-notes > div > crm-search-display-table > div > table > tbody > tr ul.dropdown-menu li:nth-child(2) > a,
+#creditnote__list > div > crm-angular-js > afsearch-credit-notes > div > crm-search-display-table > div > table > tbody > tr ul.dropdown-menu li:nth-child(8) > a {
+  border-bottom: 1px solid #eee;
+}
+

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
@@ -240,7 +240,8 @@ class Civi_Api4_CreditNote_CreditNoteSaveActionTest extends BaseHeadlessTest {
         ->addWhere('entity_id', '=', $lineItem['id'])
         ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNoteLine::$_tableName)
         ->addWhere('currency', '=', $creditNote['currency'])
-        ->addWhere('contact_id', '=', $creditNote['contact_id']);
+        ->addWhere('contact_id', '=', $creditNote['contact_id'])
+        ->addWhere('status_id', '=', 3);
 
       $all = \Civi\Api4\FinancialItem::get(FALSE)
         ->addWhere('entity_id', '=', $lineItem['id'])

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
@@ -53,6 +53,17 @@ class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
       ->execute()
       ->getArrayCopy();
 
+    foreach ($creditNote['items'] as $creditNoteLine) {
+      $creditNoteLineEntityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+        ->addWhere('entity_id', '=', $creditNoteLine['id'])
+        ->addWhere('financial_trxn_id', '=', $refundAllocation['financial_trxn_id'])
+        ->addWhere('entity_table', '=', CRM_Financeextras_BAO_CreditNoteLine::$_tableName)
+        ->execute()
+        ->getArrayCopy();
+
+      $this->assertNotEmpty($creditNoteLineEntityFinancialTrxn);
+    }
+
     $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
       ->addWhere('total_amount', '=', -1 * $amountToRefund)
       ->addWhere('id', '=', $refundAllocation['financial_trxn_id'])

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
@@ -142,7 +142,8 @@ class Civi_Api4_CreditNote_VoidActionTest extends BaseHeadlessTest {
         ->addWhere('entity_id', '=', $lineItem['id'])
         ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNoteLine::$_tableName)
         ->addWhere('currency', '=', $creditNote['currency'])
-        ->addWhere('contact_id', '=', $creditNote['contact_id']);
+        ->addWhere('contact_id', '=', $creditNote['contact_id'])
+        ->addWhere('status_id', '=', 1);
 
       // Financial item should be created for Voided credit note line item.
       $financialItemForMainAmount = (clone $financialItemAPI)->addWhere('amount', '=', ($lineItem['quantity'] * $lineItem['unit_price']))

--- a/tests/phpunit/Civi/Financeextras/Service/CreditNoteInvoiceServiceTest.php
+++ b/tests/phpunit/Civi/Financeextras/Service/CreditNoteInvoiceServiceTest.php
@@ -10,6 +10,9 @@ use Civi\Financeextras\Test\Helper\CreditNoteTrait;
 use Civi\Financeextras\WorkflowMessage\CreditNoteInvoice;
 use CRM_Financeextras_BAO_CreditNote as CreditNoteBAO;
 
+/**
+ * @group headless
+ */
 class CreditNoteInvoiceServiceTest extends BaseHeadlessTest {
 
   use CreditNoteTrait;


### PR DESCRIPTION
## Overview
This PR majorly corrects the financial item accounting entry that had the wrong status, and also (UI update) added a separator to the credit note list menu items.

## Before
The financial item status for credit note line is `0`
```json
  {
    "id": 168,
    "created_date": "2023-08-30 14:35:57",
    "transaction_date": "2023-08-30 00:00:00",
    "contact_id": 22,
    "description": "Contribution Amount - Taax",
    "amount": -40,
    "currency": "GBP",
    "financial_account_id": 15,
    "status_id": 0,
    "entity_table": "financeextras_credit_note_line",
    "entity_id": 8
  }
```

No separator can be seen between the action items.
<img width="262" alt="Screenshot 2023-09-05 at 09 49 43" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/b416266a-de18-4929-84ca-d3ecece9d683">


## After
The financial item status for credit note line is `3` - `Unpaid`
```json
  {
    "id": 188,
    "created_date": "2023-09-05 09:08:30",
    "transaction_date": "2023-09-05 00:00:00",
    "contact_id": 2,
    "description": "Polikok",
    "amount": -516,
    "currency": "GBP",
    "financial_account_id": 3,
    "status_id": 3,
    "entity_table": "financeextras_credit_note_line",
    "entity_id": 7
  },
```


A separator can be seen between the action items.
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d63b63b5-b64e-457b-bb6c-9e822356abfc)


