### PR TITLE
CIWEMB-480: Update contribution status on allocation reverse

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -81,6 +81,10 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
     ];
     self::createPayment($account, $params);
 
+    if (!empty($allocation['contribution_id'])) {
+      \Civi::dispatcher()->dispatch(ContributionPaymentUpdatedEvent::NAME, new ContributionPaymentUpdatedEvent($allocation['contribution_id']));
+    }
+
     return $allocation;
   }
 


### PR DESCRIPTION
## Overview
When a credit note allocation is reversed, we need the contribution status to reflect that the payment has been refunded


## Technical Details
In a previous pull request, https://github.com/compucorp/io.compuco.financeextras/pull/56, we introduced an event that enables the reevaluation of contribution status based on the total payment amount. Then in a subsequent pull request,  https://github.com/compucorp/io.compuco.financeextras/pull/73, we invoke this event within a hook. This configuration ensures that the event is triggered whenever a contribution is updated.

However, when it comes to credit note functionalities such as refunds or allocation reversals, it becomes necessary to manually initiate this event after performing these specific actions. This is essential because the contribution hook will not be automatically invoked in such cases.