### PR TITLE
CIWEMB-446: Display confirmation box before deleting allocation

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
@@ -51,17 +51,23 @@
     }
 
     $scope.deleteAllocation = (id) => {
-      CRM.$.blockUI();
-      crmApi4('CreditNoteAllocation', 'reverse', {
-        id
-      }).then(function() {
-        CRM.alert(ts('Credit note allocation has been successfully deleted'), ts('Success'), 'success');
-        getAllocations();
-      }, function() {
-        CRM.alert(ts('Unable to delete credit note allocation'), ts('Error'), 'error');
-      }).finally(function() {
-        CRM.$.unblockUI();
-      })
+        CRM.confirm({
+          title: 'Confirm',
+          message: ts('Are you sure you want to delete this allocation? Please note that the allocation will be deleted immediately, regardless of whether the credit note is saved or not after this action')
+        })
+        .on('crmConfirm:yes', function() {
+          CRM.$.blockUI();
+          crmApi4('CreditNoteAllocation', 'reverse', {
+            id
+          }).then(function() {
+            CRM.alert(ts('Credit note allocation has been successfully deleted'), ts('Success'), 'success');
+            getAllocations();
+          }, function() {
+            CRM.alert(ts('Unable to delete credit note allocation'), ts('Error'), 'error');
+          }).finally(function() {
+            CRM.$.unblockUI();
+          })
+        })
     }
 
     (function init() {


### PR DESCRIPTION
## Overview
This PR displays a confirmation box to the user before deleting a credit note allocation.

## Before
No confirmation box was displayed when deleting a credit note allocation

## After
A confirmation box is displayed before deleting a credit note allocation

![confirmrrr](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/7a52a51b-248a-4272-b637-7bef966fadd4)

