### PR TITLE
CIWEMB-461: Update credit note refund screen

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
@@ -73,9 +73,8 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
       'number',
       'amount',
       ts('Refund Amount'),
-      ['class' => 'form-control'],
-      TRUE,
-      ['min' => 0, 'step' => 0.01]
+      ['class' => 'form-control', 'min' => 0, 'step' => 0.01],
+      TRUE
     );
 
     $this->add(
@@ -106,10 +105,11 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
     );
 
     $this->add(
-      'text',
+      'number',
       'fee_amount',
       ts('Fee Amount'),
-      ['class' => 'form-control']
+      ['class' => 'form-control', 'min' => 0, 'step' => 0.01],
+      TRUE
     );
 
     $this->add(

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteRefund.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteRefund.tpl
@@ -88,7 +88,11 @@
   }
 
   #payment_information > fieldset > div div.content {
-  margin-left: 17%;
+    margin-left: 17%;
+  }
+
+  #payment_information > fieldset > legend {
+    display: none;
   }
   </style>
 {/literal}


### PR DESCRIPTION
## Overview
This PR introduces the following updates to the credit note refund screen
- Hide payment information heading
- Ensure refund/fee amount can only be in 2 decimal places

## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d1c5f3e1-0d13-4792-ad15-73a02775d673)

![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/f89f0821-6b04-4b80-9214-c413f1986b00)


## After
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/608d2173-5078-4807-b22e-4220916899bd)


![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/802da000-ea3c-49f0-9c46-a7f60ced6237)

