### PR TITLE
CIWEMB-466: Update Contribution edit screen

### DIFF
--- a/CRM/Financeextras/Hook/Links/Contribution.php
+++ b/CRM/Financeextras/Hook/Links/Contribution.php
@@ -58,10 +58,10 @@ class CRM_Financeextras_Hook_Links_Contribution {
    *
    * @throws \Civi\API\Exception
    */
-  private function isContributionCancelled() {
+  private function contributionHasStatus($statuses) {
     $contribution = \Civi\Api4\Contribution::get()
       ->addWhere('id', '=', $this->contributionId)
-      ->addWhere('contribution_status_id:name', '=', 'Cancelled')
+      ->addWhere('contribution_status_id:name', 'IN', $statuses)
       ->setLimit(1)
       ->execute()
       ->first();
@@ -73,7 +73,7 @@ class CRM_Financeextras_Hook_Links_Contribution {
    * Adds credit note action to contribution links.
    */
   public function alterLinks() {
-    if (!$this->isContributionCancelled()) {
+    if (!$this->contributionHasStatus(['Cancelled', 'Refunded', 'Failed', 'Chargeback'])) {
       $this->links[] = [
         'name' => 'Add Credit Note',
         'url' => 'civicrm/contribution/creditnote',

--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -105,7 +105,7 @@
               ng-change="handleCurrencyChange()"
               placeholder="Currency"
               name="currency"
-              ng-disabled="isView || isUpdate"
+              ng-disabled="isView || isUpdate || disableCurrency"
               required
             >
             <option value="">{{ ts('Currency') }}</option>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -47,6 +47,7 @@
     $scope.crmUrl = CRM.url;
     $scope.formValid = true;
     $scope.roundTo = roundTo;
+    $scope.disableCurrency = false;
     $scope.formatMoney = formatMoney;
     $scope.isView = $scope.context == 'view'
     $scope.saveCreditnotes = saveCreditnotes;
@@ -117,6 +118,7 @@
         $scope.contactId = contribution.contact_id
         $scope.creditnotes.contact_id = contribution.contact_id
         $scope.creditnotes.currency = contribution.currency
+        $scope.disableCurrency = true
         $scope.currencySymbol = CurrencyCodes.getSymbol(contribution.currency);
 
         const lineItems = contribution.items;

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -64,6 +64,7 @@
       }
 
       if (action == 2) {
+        $("#add_item option[value='new']").remove();
         $('#Contribution > div.crm-block.crm-form-block.crm-contribution-form-block > table > tbody > tr:nth-child(3) > td.label').text('Line Items')
       }
       if (!isNotQuickConfig && action == 2) {

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -4,61 +4,71 @@
     CRM.$(function($) {
       const submittedRows = $.parseJSON('{/literal}{$lineItemSubmitted}{literal}');
       const action = '{/literal}{$action}{literal}';
+      isNotQuickConfig = '{/literal}{$pricesetFieldsCount}{literal}'
       const isEmptyPriceSet = !$('#price_set_id').length || $('#price_set_id').val() === ''
 
-      // This dealy ensures the lineitem table has been built before trying to manipulate its field.
-      setTimeout(() => {
-        $('#lineitem-add-block').after(
-          $('<div>').addClass('price-set-alt')
-          .append($('<div>').addClass('price-set-alt-or'))
-          .append($('<div>').addClass('price-set-alt-select'))
-          .append($('#lineitem-add-block > div:last-child'))
-        )
-        $('#totalAmount, #totalAmountORaddLineitem').hide()
-        $('#selectPriceSet').prepend( `<div id="lineItemSwitch" class="crm-hover-button">OR <a href="#">Switch back to using line items</a></div>`)
-        $('#lineItemSwitch').css('display', 'block').on('click', () => $('#price_set_id').val('').change())
+      if (action == 1) {
+        // This dealy ensures the lineitem table has been built before trying to manipulate its field.
+        setTimeout(() => {
+          $('#lineitem-add-block').after(
+            $('<div>').addClass('price-set-alt')
+            .append($('<div>').addClass('price-set-alt-or'))
+            .append($('<div>').addClass('price-set-alt-select'))
+            .append($('#lineitem-add-block > div:last-child'))
+          )
+          $('#totalAmount, #totalAmountORaddLineitem').hide()
+          $('#selectPriceSet').prepend( `<div id="lineItemSwitch" class="crm-hover-button">OR <a href="#">Switch back to using line items</a></div>`)
+          $('#lineItemSwitch').css('display', 'block').on('click', () => $('#price_set_id').val('').change())
 
-        if ((isEmptyPriceSet) && submittedRows.length <= 0) {
-          $('#add-items').click()
+          if ((isEmptyPriceSet) && submittedRows.length <= 0) {
+            $('#add-items').click()
+          }
+          toggleLineItemOrPricesetFields(isEmptyPriceSet);
+
+          $('#price_set_id').on('change', function() {
+            setTimeout(() => {
+              toggleLineItemOrPricesetFields($(this).val() === '');
+            }, 100);
+          });
+
+          $('#add-another-item').on('click', function() {
+            if ($('#price_set_id')) {
+              $('#totalAmountORPriceSet, #price_set_id').show();
+            }
+          });
+        }, 100);
+
+        const toggleLineItemOrPricesetFields = (show) => {
+          if (!show) {
+            $('#lineItemSwitch').show();
+            $('#selectPriceSet').prepend($('#price_set_id'))
+            $('#lineitem-add-block').hide();
+            $('.price-set-alt').hide();
+          } else {
+            $('#lineItemSwitch').hide();
+            $('#lineitem-add-block').show()
+            $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').css('display', 'none')
+            $('.price-set-alt').show()
+            if (action != 2) {
+              // On edit user can't switch from priceset to lineitem and viceversa.
+              $('.price-set-alt-or').append($('#totalAmountORPriceSet').show())
+              $('.price-set-alt-select').append($('#price_set_id').show())
+            }
+            if (action == 1) {
+              $( "#total_amount").val(0)
+            }
+            $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
+          }
         }
-        toggleLineItemOrPricesetFields(isEmptyPriceSet);
-
-        $('#price_set_id').on('change', function() {
-          setTimeout(() => {
-            toggleLineItemOrPricesetFields($(this).val() === '');
-          }, 100);
-        });
-
-        $('#add-another-item').on('click', function() {
-          if ($('#price_set_id')) {
-            $('#totalAmountORPriceSet, #price_set_id').show();
-          }
-        });
-      }, 100);
-
-      const toggleLineItemOrPricesetFields = (show) => {
-        if (!show) {
-          $('#lineItemSwitch').show();
-          $('#selectPriceSet').prepend($('#price_set_id'))
-          $('#lineitem-add-block').hide();
-          $('.price-set-alt').hide();
-        } else {
-          $('#lineItemSwitch').hide();
-          $('#lineitem-add-block').show()
-          $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').css('display', 'none')
-          $('.price-set-alt').show()
-          if (action != 2) {
-            // On edit user can't switch from priceset to lineitem and viceversa.
-            $('.price-set-alt-or').append($('#totalAmountORPriceSet').show())
-            $('.price-set-alt-select').append($('#price_set_id').show())
-          }
-          if (action == 1) {
-            $( "#total_amount").val(0)
-          }
-          $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
-        }
+        $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
       }
-      $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
+
+      if (action == 2) {
+        $('#Contribution > div.crm-block.crm-form-block.crm-contribution-form-block > table > tbody > tr:nth-child(3) > td.label').text('Line Items')
+      }
+      if (!isNotQuickConfig && action == 2) {
+        $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').css('display', 'none')
+      }
     })
   </script>
 {/literal}


### PR DESCRIPTION
## Overview
This PR updates the CiviCRM contribution edit screen to display as expected, also it introduces the following changes
- Disable the creditnote currency field when the form is prefilled from a contribution.
- Restrict statuses where the `Add Credit Note` link will be added to a contribution.
- Prevent a user from adding a line item to a contribution created from price set in the edit screen.

## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/894c6a7c-f6e6-419b-9acf-28093c1d147f)


## After
<img width="845" alt="Screenshot 2023-09-11 at 11 48 27" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/55831c46-76f7-4070-9d01-c66b81602b19">


*Prevent a user from adding a line item to a contribution created from the price set in the edit screen.*
<img width="1004" alt="Screenshot 2023-09-20 at 16 08 27" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/94200d5c-a5d3-4b51-92b3-aa4dc628a7a0">

