### PR TITLE
CIWEMB-305: Only update contribution status for specific status

### DIFF
--- a/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
+++ b/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
@@ -14,8 +14,11 @@ class ContributionPaymentUpdatedListener {
 
   private static function updateContributionStatus($contributionId) {
     $status = 'Pending';
+    $allowedStatus = ['Pending', 'Completed', 'Partially paid', 'Refunded', 'Pending refund'];
+
     $contribution = \Civi\Api4\Contribution::get()
       ->addWhere('id', '=', $contributionId)
+      ->addWhere('contribution_status_id:name', 'IN', $allowedStatus)
       ->execute()
       ->first();
 

--- a/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php
@@ -40,7 +40,7 @@ class ContributionPostProcess {
     }
     catch (\Throwable $th) {
       $transaction->rollback();
-      \CRM_Core_Session::setStatus('Error creating contribution payment', ts('Contribution Payemnt Error'), 'error');
+      \CRM_Core_Session::setStatus('Error creating contribution payment', ts('Contribution Payment Error'), 'error');
       \Civi::log()->error('Error creating contribution payment: ' . $th->getMessage());
     }
 


### PR DESCRIPTION
## Overview
This PR ensures the Contribution status update logic only runs when the contribution has specific statuses.

## Technical Details

Previously the status update logic attempted to update the contribution status based on the amount paid, irrespective of the contribution status, For example, if a contribution status is cancelled and all the payments are paid, it will update the contribution status to `Completed`.

In this PR we ensure this doesn't happen, by limiting the update logic to only run when the contribution is of any of these statuses `[Pending', 'Completed', 'Partially paid', 'Refunded', 'Pending refund']`
