### PR TITLE
CIWEMB-463: Include tax amount in refund calculation

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -274,10 +274,10 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
     $data['is_payment'] = 1;
     $financialTrxn = self::createAccountingEntries($data, 'Completed');
 
-    $ratio = $data['amount'] / $creditNote['total_credit'];
+    $percent = 100 * $data['amount'] / $creditNote['total_credit'];
 
     foreach ($creditNote['line'] as $creditNoteLine) {
-      $amount = $creditNoteLine['line_total'] * $ratio * -1;
+      $amount = ($creditNoteLine['line_total'] + $creditNoteLine['tax_amount']) * $percent * 0.01 * -1;
       CRM_Financeextras_BAO_CreditNoteLine::refundAccountingEntries($creditNoteLine['id'], $financialTrxn['id'], $amount);
     }
 

--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
@@ -56,7 +56,7 @@
     $scope.deleteAllocation = (id) => {
         CRM.confirm({
           title: 'Confirm',
-          message: ts('Are you sure you want to delete this allocation? Please note that the allocation will be deleted immediately, regardless of whether the credit note is saved or not after this action')
+          message: ts('<p style="text-align:center"><strong>Are you sure you want to delete this allocation?</strong> <br> <br>Please note that the allocation will be deleted immediately, regardless of whether the credit note is saved or not after this action</p>')
         })
         .on('crmConfirm:yes', function() {
           CRM.$.blockUI();

--- a/financeextras.php
+++ b/financeextras.php
@@ -169,6 +169,7 @@ function financeextras_civicrm_fieldOptions($entity, $field, &$options, $params)
 
   if (in_array($entity, ['EntityFinancialTrxn']) && $field == 'entity_table') {
     $options[\CRM_Financeextras_DAO_CreditNote::$_tableName] = ts('Credit Note');
+    $options[\CRM_Financeextras_DAO_CreditNoteLine::$_tableName] = ts('Credit Note Line');
   }
 }
 


### PR DESCRIPTION
## Overview
Previously the tax amount was not included when splitting the refund amount between credit note line items, in this PR we ensure the tax amount is included in the split value.

We also reduced the allocation delete modal size.
## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/8035e02f-682a-4494-aa8c-fb29398de3e8)


## After
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/52390265-cbe7-4d58-ba1a-e450a5b41111)
