### PR TITLE
CIWEMB-494: Clear alert on credit note view cancel

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
@@ -103,9 +103,9 @@ class CRM_Financeextras_Form_Contribute_CreditNoteAllocate extends CRM_Core_Form
         ->execute();
     }
 
-    CRM_Core_Session::setStatus('Credits allocated successfully.', '', 'success');
+    CRM_Core_Session::setStatus(ts('Credits allocated successfully.'), ts('Success'), 'success');
     $url = CRM_Utils_System::url('civicrm/contact/view',
-    ['cid' => $this->creditNote['contact_id'], 'selectedChild' => 'contribute']
+      ['reset' => 1, 'cid' => $this->creditNote['contact_id'], 'selectedChild' => 'contribute']
     );
     CRM_Utils_System::redirect($url);
 
@@ -123,14 +123,14 @@ class CRM_Financeextras_Form_Contribute_CreditNoteAllocate extends CRM_Core_Form
    */
   public function validateAllocation($amounts) {
     if (!empty(array_filter($amounts, fn($n) => $n <= 0))) {
-      CRM_Core_Session::setStatus('Amount to be refunded must be greater than zero.', 'Error', 'error');
+      CRM_Core_Session::setStatus(ts('Amount to be refunded must be greater than zero.'), ts('Error'), 'error');
       return FALSE;
     }
 
     $creditsToAllocate = array_sum($amounts);
 
     if ($creditsToAllocate > $this->creditNote['remaining_credit']) {
-      CRM_Core_Session::setStatus('Amount to be refunded cannot exceed the remaining credit.', 'Error', 'error');
+      CRM_Core_Session::setStatus(ts('Amount to be refunded cannot exceed the remaining credit.'), ts('Error'), 'error');
       return FALSE;
     }
 

--- a/ang/fe-creditnote/directives/creditnote-view.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-view.directive.html
@@ -74,8 +74,8 @@
       </table>
     </div>
     <div class="panel-footer flex-between crm-submit-buttons">
-        <button type="button" class="btn btn-primary-outline cancel crm-form-submit crm-button crm-button-type-cancel" history-back>
-          <span class="btn-icon"></span> {{ts('Cancel')}}</button>
+        <a type="button" class="btn btn-primary crm-form-submit crm-button crm-button-type-submit" ng-href="{{ crmUrl('civicrm/contact/view', {reset: 1, cid: creditnotes.contact_id, selectedChild: 'contribute'}) }}" >
+          <span class="btn-icon"></span> {{ts('Cancel')}}</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Overview
This PR ensures previous alert messages are not displayed when a user clicks the back button on the contribution view screen

## Before
Alert displayed on cancel button click
![yoro](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/c9fe139f-8d7d-43c5-8887-adf7ba2df38f)


## After
Alert not displayed on cancel button click
![yoroll](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/00fec5b7-1bec-4784-82d2-a99b6d17b5f7)
