### PR TITLE
CIWEMB-514: Update Contribution and allocation Screen

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
@@ -62,7 +62,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteAllocate extends CRM_Core_Form
     $this->addButtons([
       [
         'type' => 'cancel',
-        'name' => E::ts('Cancel'),
+        'name' => E::ts('Skip'),
         'isDefault' => TRUE,
       ],
       [

--- a/Civi/Financeextras/Hook/AlterMailParams/AlterContributionReceipt.php
+++ b/Civi/Financeextras/Hook/AlterMailParams/AlterContributionReceipt.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Civi\Financeextras\Hook\AlterMailParams;
+
+/**
+ * Updates contribution receipt mail.
+ */
+class AlterContributionReceipt {
+
+  /**
+   * @param array $params
+   *   Mail parameters.
+   * @param string $context
+   *   Mail context.
+   */
+  public function __construct(private array &$params, private string $context) {
+  }
+
+  /**
+   * Updates contribution receipt mail.
+   */
+  public function handle() {
+    if (empty($this->params['tplParams']['contribution']) && !empty($this->params['tokenContext']['contributionId'])) {
+      $contribution = \Civi\Api4\Contribution::get()
+        ->addWhere('id', '=', $this->params['tokenContext']['contributionId'])
+        ->execute()
+        ->first();
+
+      if (!empty($contribution['tax_amount'])) {
+        $this->params['tplParams']['totalTaxAmount'] = $contribution['tax_amount'];
+      }
+
+      $this->params['tplParams']['contribution'] = $contribution;
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param array $params
+   *   Mail parameters.
+   * @param string $context
+   *   Mail context.
+   *
+   * @return bool
+   *   returns TRUE if hook should run, FALSE otherwise.
+   */
+  public static function shouldHandle(array $params, $context) {
+    $component = $params['valueName'] ?? '';
+    if ($component !== 'contribution_offline_receipt' || $context !== 'messageTemplate') {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -5,6 +5,8 @@ require_once 'financeextras.civix.php';
 
 use CRM_Financeextras_ExtensionUtil as E;
 use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
+use Civi\Financeextras\Hook\AlterMailParams\AlterContributionReceipt;
+
 // phpcs:enable
 
 /**
@@ -222,5 +224,29 @@ function financeextras_civicrm_buildForm($formName, &$form) {
     if ($hook::shouldHandle($form, $formName)) {
       (new $hook($form))->handle();
     }
+  }
+}
+
+/**
+ * Implements hook_civicrm_alterMailParams().
+ */
+function financeextras_civicrm_alterMailParams(&$params, $context) {
+  $hooks = [
+    AlterContributionReceipt::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($params, $context)) {
+      (new $hook($params, $context))->handle();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_alterMailContent().
+ */
+function financeextras_civicrm_alterMailContent(&$content) {
+  if (($content['workflow_name'] ?? NULL) === 'contribution_offline_receipt') {
+    $content['html'] = str_replace('$formValues.total_amount', '$contribution.total_amount', $content['html']);
   }
 }

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -11,21 +11,21 @@ CRM.$(function ($) {
   function setTotalAmount() {
     const recordPaymentAmount = document.querySelector("input[name=fe_record_payment_amount]");
     $('#total_amount').on("change", function() {
-      recordPaymentAmount.value = $('#total_amount').val();
+      recordPaymentAmount.value = Number($('#total_amount').val()).toFixed(2);
     });
   
     $('#price_set_id').on('change', function() {
-      recordPaymentAmount.value = $('#line-total').data('raw-total');
+      recordPaymentAmount.value = Number($('#line-total').data('raw-total')).toFixed(2);
       if (($(this).val() !== '')) {
-        recordPaymentAmount.value = $('#pricevalue').data('raw-total');
+        recordPaymentAmount.value = Number($('#pricevalue').data('raw-total')).toFixed(2);
         $('#pricevalue').on('change', function() {
-          recordPaymentAmount.value = $('#pricevalue').data('raw-total');
+          recordPaymentAmount.value = Number($('#pricevalue').data('raw-total')).toFixed(2);
         });
       }
     })
 
     $('#line-total').on('datachanged', function() {
-      recordPaymentAmount.value = $('#line-total').data('raw-total');
+      recordPaymentAmount.value = Number($('#line-total').data('raw-total')).toFixed(2);
     });
   }
 
@@ -85,5 +85,9 @@ CRM.$(function ($) {
     );
     $('tr.crm-contribution-fe-billing_row').after($('tr.crm-contribution-form-block-receipt_date'));
     $('#payment_information > fieldset > legend').hide();
+
+    $('tr#email-receipt label').text('Send Email Confirmation')
+    const email = $('tr#email-receipt #email-address')
+    $('tr#email-receipt .description').text('Automatically email a confirmation of this transaction to ').append(email).append('?')
   }
 });

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -8,6 +8,18 @@
       const isEmptyPriceSet = !$('#price_set_id').length || $('#price_set_id').val() === ''
 
       if (action == 1) {
+        $('tr.crm-contribution-form-block-financial_type_id').after(
+          $('<tr>').addClass('currency-select').append(
+            $('<td>').addClass('label').append(
+              $('<label>').text('Currency')
+            )
+          ).append(
+            $('<td>').append($('#currency').show())
+          )
+        )
+      }
+
+      if (action == 1) {
         // This dealy ensures the lineitem table has been built before trying to manipulate its field.
         setTimeout(() => {
           $('#lineitem-add-block').after(

--- a/templates/CRM/Financeextras/Form/Event/AddContribution.tpl
+++ b/templates/CRM/Financeextras/Form/Event/AddContribution.tpl
@@ -36,5 +36,11 @@
     #payment_information fieldset.pay-later_info-group legend {
       display: none;
     }
+    #check_number {
+      margin-left: 3px;
+    }
+    #fe_total_amount {
+      width: 80%;
+    }
 </style>
 {/literal}


### PR DESCRIPTION
## Overview
This PR introduces the following changes
- Update the Allocation close button label to skip
- Allow user to set new contribution currency
- Display contribution amount in 2 dp
- Ensure the contribution receipt shows the correct total
- Align contribution payment fields

## Before
_The allocation close button label shows cancel_
<img width="1353" alt="Screenshot 2023-09-29 at 07 23 13" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/5e054bfe-3f3e-4e97-b869-e6c76ef319fd">


_User cannot set new contribution currency_
<img width="923" alt="Screenshot 2023-09-29 at 07 20 59" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/cd021e99-dbde-49ea-9cbb-5e3325673263">

_Contribution payment amount is not in 2 dp_
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/56e661dd-b422-4e42-8e3a-03b807654caa)

_ The contribution receipt shows the total as 0.00_
<img width="751" alt="Screenshot 2023-09-29 at 07 18 39" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/9d50acd6-cafd-45de-b65a-45f847065889">

## After
_The allocation close button label changed to skip_
<img width="1351" alt="Screenshot 2023-09-29 at 07 13 57" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/37a59a82-38d7-4060-8591-2acf41071d69">

_Allow user to set new contribution currency_
<img width="931" alt="Screenshot 2023-09-29 at 07 14 55" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/4c714707-df5f-44b1-94e0-4f42f2cd3d5e">

_Display contribution amount in 2 dp_
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/4a8155b1-28e9-441b-936b-8e5f5f481747)

_ Ensure the contribution receipt shows the correct total_
<img width="751" alt="Screenshot 2023-09-29 at 07 17 46" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/d282213b-d9ce-4271-b6a4-a584fa6d0274">
