### PR TITLE
CIWEMB-520: Add custom Total Amount

### DIFF
--- a/Civi/Api4/Action/Currency/FormatAction.php
+++ b/Civi/Api4/Action/Currency/FormatAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Civi\Api4\Action\Currency;
+
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+
+/**
+ * Format a monetary string..
+ */
+class FormatAction extends AbstractAction {
+  use DAOActionTrait;
+
+  /**
+   * Currency to format to.
+   *
+   * @var string
+   */
+  protected $currency;
+
+  /**
+   * Value to be formatted.
+   *
+   * @var mixed
+   */
+  protected $value;
+
+  /**
+   * Symbol should be included in formatted string.
+   *
+   * @var bool
+   */
+  protected $onlyNumber = FALSE;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    $result[] = \CRM_Utils_Money::format($this->value, $this->currency, $this->onlyNumber);
+  }
+
+}

--- a/Civi/Api4/Currency.php
+++ b/Civi/Api4/Currency.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Civi\Api4;
+
+use Civi\Api4\Generic\DAOGetFieldsAction;
+use Civi\Api4\Action\Currency\FormatAction;
+
+class Currency extends \Civi\Api4\Generic\AbstractEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Generic\DAOGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new DAOGetFieldsAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * Creates or Updates a CreditNote with the line items.
+   *
+   * @param bool $checkPermissions
+   *   Should permission be checked for the user.
+   *
+   * @return Civi\Api4\Action\CreditNote\CreditNoteSaveAction
+   *   returns save order action
+   */
+  public static function format($checkPermissions = TRUE) {
+    return (new FormatAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+}

--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -103,6 +103,18 @@ class ContributionCreate {
       'template' => 'CRM/Financeextras/Form/Contribute/CustomLineItem.tpl',
       'region' => 'page-body',
     ]);
+
+    if ($this->isEdit()) {
+      $contribution = \Civi\Api4\Contribution::get()
+        ->addSelect('currency', 'total_amount')
+        ->addWhere('id', '=', $this->form->_id)
+        ->execute()
+        ->first();
+
+      $total = \CRM_Utils_Money::format($contribution['total_amount'], $contribution['currency']);
+      \Civi::resources()->addVars('financeextras', ['contrib_currency' => $contribution['currency']]);
+      \Civi::resources()->addVars('financeextras', ['contrib_total' => $total]);
+    }
   }
 
   /**

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -1,4 +1,5 @@
 CRM.$(function ($) {
+const totalChanged = new CustomEvent("totalChanged", {});
 
   (function() {
     setTotalAmount();
@@ -12,20 +13,25 @@ CRM.$(function ($) {
     const recordPaymentAmount = document.querySelector("input[name=fe_record_payment_amount]");
     $('#total_amount').on("change", function() {
       recordPaymentAmount.value = Number($('#total_amount').val()).toFixed(2);
+      recordPaymentAmount.dispatchEvent(totalChanged)
     });
   
     $('#price_set_id').on('change', function() {
       recordPaymentAmount.value = Number($('#line-total').data('raw-total')).toFixed(2);
+      recordPaymentAmount.dispatchEvent(totalChanged)
       if (($(this).val() !== '')) {
         recordPaymentAmount.value = Number($('#pricevalue').data('raw-total')).toFixed(2);
+        recordPaymentAmount.dispatchEvent(totalChanged)
         $('#pricevalue').on('change', function() {
           recordPaymentAmount.value = Number($('#pricevalue').data('raw-total')).toFixed(2);
+          recordPaymentAmount.dispatchEvent(totalChanged)
         });
       }
     })
 
     $('#line-total').on('datachanged', function() {
       recordPaymentAmount.value = Number($('#line-total').data('raw-total')).toFixed(2);
+      recordPaymentAmount.dispatchEvent(totalChanged)
     });
   }
 

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -1,3 +1,13 @@
+<div>
+  <table>
+    <tbody>
+      <tr class="crm-contribution-form-block-financeextras_custom_total_amount">
+        <td class="label"></td>
+        <td><span class="label"><strong>Total Amount:</strong>&nbsp;&nbsp;</span><span id="custom-total">0.00</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 {literal}
   <script>
@@ -20,7 +30,7 @@
       }
 
       if (action == 1) {
-        // This dealy ensures the lineitem table has been built before trying to manipulate its field.
+        // This ensures the lineitem table has been built before trying to manipulate its field.
         setTimeout(() => {
           $('#lineitem-add-block').after(
             $('<div>').addClass('price-set-alt')
@@ -72,15 +82,52 @@
             $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
           }
         }
+
         $('#Contribution tr.crm-contribution-form-block-total_amount > td.label > label').text('Line Items')
+        const recordPaymentAmount = $("input[name=fe_record_payment_amount]");
+        recordPaymentAmount.on("totalChanged", function() {
+          setCustomTotalAmount(recordPaymentAmount.val())
+        })
+        $('select[name=currency]').on('change', function() {
+          setCustomTotalAmount(recordPaymentAmount.val())
+        });
       }
+      $('tr.crm-contribution-form-block-total_amount').after(
+        $('tr.crm-contribution-form-block-financeextras_custom_total_amount')
+      )
+      $('#line-total').parent().hide()
 
       if (action == 2) {
         $("#add_item option[value='new']").remove();
         $('#Contribution > div.crm-block.crm-form-block.crm-contribution-form-block > table > tbody > tr:nth-child(3) > td.label').text('Line Items')
+        
+        $('#line-total').on('datachanged', function() {
+          setCustomTotalAmount($('#line-total').data('raw-total'));
+        });
+      }
+      if (isNotQuickConfig && action == 2) {
+        $('#line-total').parent().show();
+        $('#line-total').after($('#custom-total'));
+        $('tr.crm-contribution-form-block-financeextras_custom_total_amount').hide();
+        $('.total_amount-section > div:first-child').text('Contribution total: '+CRM.vars.financeextras.contrib_total);
       }
       if (!isNotQuickConfig && action == 2) {
         $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').css('display', 'none')
+      }
+      if (action == 2 && !isEmptyPriceSet) {
+        $('#line-total').parent().show();
+        $('tr.crm-contribution-form-block-financeextras_custom_total_amount').hide();
+      }
+
+      function setCustomTotalAmount(amount) {
+        const currencySelect = $('#currency').val() ?? CRM.vars.financeextras.contrib_currency ?? '';
+        
+        CRM.api4('Currency', 'format', {
+          currency: currencySelect,
+          value: amount
+        }).then(function(results) {
+          $('#custom-total').text(results[0]);
+        });
       }
     })
   </script>
@@ -127,6 +174,9 @@
   }
   .float-right {
     float: right;
+  }
+  #pricesetTotal, #line-total {
+    display: none;
   }
 </style>
 {/literal}


### PR DESCRIPTION
## Overview
In this PR we add a custom total amount label to the new and edit contribution screen. This allows us to resolve two issues, which are:
1. The displayed total amount does not reflect the selected currency on the new contribution screen.
2. The total contribution amount for a price set doesn't include the tax amount.

It's worth mentioning that these are core issued, and there could be a requirement to eliminate this temporary solution in the coming days once it gets resolved in CiviCRM.

## Before
The two issues mentioned above are reproducible as shown in the video below

![11rrloooo](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/545eba1b-751f-4968-b9a3-03393fd5daab)


## After
The two issues mentioned above are no longer reproducible as shown in the video below

![rrloooo](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/b2f26adb-7b25-4f92-a25a-13e967aac013)


## Technical Details
One of the major issues with updating the total amount when the currency changes is the difficulty in formatting the value appropriately.

To overcome this, we simply create a new API action `Currency.format` that takes a value and the currency and formats the value appropriately.

This API is called when the total value changes and when the currency changes.


## Comment
In a future PR the JS code in `CustomLineItem.tpl` and `modifyContributionForm.js` will be merged together and code properly refactored for readability.
