### PR TITLE
CIWEMB-517: Update CreditNote Invoice

### DIFF
--- a/Civi/Financeextras/Service/CreditNoteInvoiceService.php
+++ b/Civi/Financeextras/Service/CreditNoteInvoiceService.php
@@ -78,6 +78,7 @@ class CreditNoteInvoiceService {
       ->addChain('allocations', CreditNoteAllocation::get()
         ->addWhere('credit_note_id', '=', '$id')
         ->addSelect('*', 'type_id:label')
+        ->addWhere('is_reversed', '=', FALSE)
       )
       ->addChain('contact', Contact::get()
         ->addWhere('id', '=', '$contact_id'), 0

--- a/templates/CRM/Financeextras/MessageTemplate/CreditNoteInvoice.tpl
+++ b/templates/CRM/Financeextras/MessageTemplate/CreditNoteInvoice.tpl
@@ -124,11 +124,9 @@
                   <tr>
                     <td colspan="2" style="border: none;"></td>
                     <td colspan="2" style="text-align:right;white-space: nowrap; border: none;"><font size="1"><b>{ts}Less Credit to {/ts}</b> 
-                    {capture assign=contribUrl}{crmURL p='civicrm/contact/view/contribution'
-                    q="reset=1&id=`$allocation.contribution_id`&action=view&context=fulltext" h=0 a=1 fe=1}{/capture}
-                      <a href="{$contribUrl}">
+                      <span>
                         {ts}Invoice{/ts} {$allocation.contribution.invoice_number}
-                      </a>
+                      </span>
                       </font>
                     </td>
                     <td style="text-align:right;white-space: nowrap; border: none;"><font size="1">{$allocation.amount|crmMoney:$credit_note.currency}</font></td>


### PR DESCRIPTION
## Overview
This PR introduces two changes to the Credit note invoice
- Ensure reversed allocations are excluded from the credit note allocations list
- Remove the contribution page hyperlink 

## Before
<img width="738" alt="Screenshot 2023-10-04 at 06 13 51" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/aa314a01-8c35-468b-88d2-3bc482026d77">


## After
<img width="776" alt="Screenshot 2023-10-04 at 06 14 41" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/6cfa3ba4-c356-499d-adef-20f64e5a133c">
