### PR TITLE
CIWEMB-523: Hide Record payment field for live contributions

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -63,6 +63,9 @@ class ContributionCreate {
         'region' => 'page-body',
       ]);
       \Civi::resources()->addVars('financeextras', ['currencies' => \CRM_Core_OptionGroup::values('currencies_enabled')]);
+      \Civi::resources()->addVars('financeextras', ['mode' => $this->form->_mode]);
+      $template = \CRM_Core_Smarty::singleton();
+      $template->assign_by_ref('contribution_mode', $this->form->_mode);
     }
   }
 

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -3,9 +3,13 @@ CRM.$(function ($) {
   (function() {
     setTotalAmount();
     hideStatusField();
-    setAmountCurencySymbol();
-    toggleRecordPaymentBlock();
-    placePaymentFieldsTogether();
+    const mode = CRM.vars.financeextras.mode ?? null
+
+    if (!mode) {
+      setAmountCurencySymbol();
+      toggleRecordPaymentBlock();
+      placePaymentFieldsTogether();
+    }
   })();
 
   function setTotalAmount() {

--- a/js/modifyParticipantForm.js
+++ b/js/modifyParticipantForm.js
@@ -4,6 +4,7 @@ CRM.$(function ($) {
     $('.fe-record_contribution-block').hide();
 
     observeEventFeeIsDisplayed();
+    $('tr.crm-participant-form-block-note').parent().parent().parent().prepend('<legend>Registration Notes</legend>')
   })();
 
   /**

--- a/templates/CRM/Financeextras/Form/Contribute/AddPayment.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/AddPayment.tpl
@@ -18,6 +18,8 @@
     </tbody>
   </table>
 </div>
+
+{if empty($contribution_mode)}
 {literal}
   <style>
     #payment_information > fieldset > legend {
@@ -53,3 +55,15 @@
     }
   </style>
 {/literal}
+{else}
+{literal}
+  <style>
+    div.record_payment-block_check {
+      display: none;
+    }
+    div.record_payment-block {
+      display: none;
+    }
+  </style>
+{/literal}
+{/if}


### PR DESCRIPTION
## Overview
For the Credit Card contribution screen, we hide the record payment checkbox added by the extension, since recording of payment is mandated.
Beyond hiding, we also disable JS logics related to the record payment checkbox

## Before
The record payment checkbox is visible
![Screenshot 2023-10-04 at 14 38 49](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/207bf91f-b25b-4b8c-9e9d-5128826f1552)


## After
The record payment checkbox is not visible
![Screenshot 2023-10-04 at 14 33 47](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/0380ec24-12f7-4140-aaa8-5a9899eff879)



This PR also introduces a new change to the event registration screen; a header is added to the registration note field.
## Before 
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/e8630364-a893-4d71-b704-eefc6625ac75)


## After
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1fd0c626-1fe1-429d-8988-eba9b9ca27fe)
