### PR TITLE
CIWEMB-528: Delete allocation on contribution delete

### DIFF
--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -61,7 +61,7 @@ CREATE TABLE `financeextras_credit_note_allocation` (
   `is_reversed` tinyint NOT NULL DEFAULT 0 COMMENT 'Allocation has been deleted by user',
   PRIMARY KEY (`id`),
   CONSTRAINT FK_financeextras_credit_note_allocation_credit_note_id FOREIGN KEY (`credit_note_id`) REFERENCES `financeextras_credit_note`(`id`) ON DELETE CASCADE,
-  CONSTRAINT FK_financeextras_credit_note_allocation_contribution_id FOREIGN KEY (`contribution_id`) REFERENCES `civicrm_contribution`(`id`)
+  CONSTRAINT FK_financeextras_credit_note_allocation_contribution_id FOREIGN KEY (`contribution_id`) REFERENCES `civicrm_contribution`(`id`) ON DELETE CASCADE
 )
 ENGINE=InnoDB;
 

--- a/xml/schema/CRM/Financeextras/CreditNoteAllocation.xml
+++ b/xml/schema/CRM/Financeextras/CreditNoteAllocation.xml
@@ -45,6 +45,7 @@
     <name>contribution_id</name>
     <table>civicrm_contribution</table>
     <key>id</key>
+    <onDelete>CASCADE</onDelete>
   </foreignKey>
 
   <field>


### PR DESCRIPTION
## Overview
This PR ensures that when a contribution is deleted any linked credit note allocation is also deleted.

## Before
When a contribution with a credit note allocation is deleted a 500 server error is thrown
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/2f2fa822-bf67-45f3-8462-cd1e8feb77e4)

## After
When a contribution with a credit note allocation is deleted, the linked allocations are also deleted.
![221sassa](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/bf039632-5ae1-422b-a59d-aeaa3e0fd901)
