### PR TITLE
CIWEMB-529: Credit note payment method

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -228,6 +228,8 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
     $entityTrxn = new \CRM_Financial_DAO_EntityFinancialTrxn();
     $entityTrxn->entity_table = \CRM_Financeextras_DAO_CreditNoteAllocation::$_tableName;
     $entityTrxn->entity_id = $id;
+    $entityTrxn->orderBy('id DESC');
+    $entityTrxn->limit(1);
     $entityTrxn->find(TRUE);
     if (empty($entityTrxn->financial_trxn_id)) {
       return NULL;

--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -1,8 +1,9 @@
 <?php
 
 use Civi\Api4\CreditNoteAllocation;
-use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
+use Civi\Financeextras\Utils\OptionValueUtils;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
+use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
 
 class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_CreditNoteAllocation {
 
@@ -175,8 +176,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
     $params = array_merge([
       'is_send_contribution_notification' => FALSE,
       'payment_processor_id' => NULL,
-    // Defaulting to 1 as payment instrument value doesn't matter for credit allocation
-      'payment_instrument_id' => 1,
+      'payment_instrument_id' => OptionValueUtils::getValueForOptionValue('payment_instrument', 'credit_note'),
     ], $paymentParams);
     $transaction = \CRM_Financial_BAO_Payment::create($params);
 

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -4,6 +4,7 @@ use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
 use Civi\Financeextras\Setup\Manage\CreditNoteActivityTypeManager;
 use Civi\Financeextras\Setup\Manage\CreditNoteAllocationTypeManager;
 use Civi\Financeextras\Setup\Manage\CreditNoteInvoiceTemplateManager;
+use Civi\Financeextras\Setup\Manage\CreditNotePaymentInstrumentManager;
 
 /**
  * Collection of upgrade steps.
@@ -19,6 +20,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
+      new CreditNotePaymentInstrumentManager(),
     ];
 
     foreach ($steps as $step) {
@@ -35,6 +37,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
+      new CreditNotePaymentInstrumentManager(),
     ];
 
     foreach ($steps as $step) {
@@ -51,6 +54,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
+      new CreditNotePaymentInstrumentManager(),
     ];
 
     foreach ($steps as $step) {
@@ -67,6 +71,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteActivityTypeManager(),
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
+      new CreditNotePaymentInstrumentManager(),
     ];
 
     foreach ($steps as $step) {

--- a/Civi/Financeextras/Setup/Manage/CreditNotePaymentInstrumentManager.php
+++ b/Civi/Financeextras/Setup/Manage/CreditNotePaymentInstrumentManager.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+/**
+ * Adds credit note payment instrument method.
+ */
+class CreditNotePaymentInstrumentManager extends AbstractManager {
+
+  /**
+   * Ensures Credit note payment instrument exists.
+   */
+  public function create(): void {
+    $paymentInstrument = [
+      'option_group_id' => "payment_instrument",
+      'label' => "Credit Note",
+      'name' => "credit_note",
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+      'financial_account_id' => $this->getFinancialAccount(),
+    ];
+    \CRM_Core_BAO_OptionValue::ensureOptionValueExists($paymentInstrument);
+  }
+
+  /**
+   * Removes the entity.
+   */
+  public function remove(): void {
+    \Civi\Api4\OptionValue::delete(FALSE)
+      ->addWhere('name', '=', 'credit_note')
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->execute();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function toggle($status): void {
+    \Civi\Api4\OptionValue::update(FALSE)
+      ->addWhere('name', '=', 'credit_note')
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->addValue('is_active', $status)
+      ->execute();
+  }
+
+  protected function getFinancialAccount() {
+    $financialAccounts = \Civi\Api4\FinancialAccount::get(FALSE)
+      ->addSelect('id', 'is_default', 'name')
+      ->addWhere('financial_account_type_id:name', '=', 'Asset')
+      ->addOrderBy('id', 'ASC')
+      ->execute();
+
+    $account = $financialAccounts->first()['id'];
+    foreach ($financialAccounts as $financialAccount) {
+      // If there's a default financial account, use that instead.
+      if ($financialAccount['is_default']) {
+        $account = $financialAccount['id'];
+      }
+    }
+
+    return $account;
+  }
+
+}

--- a/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/AllocateActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/AllocateActionTest.php
@@ -5,6 +5,7 @@ use Civi\Api4\CreditNote;
 use Civi\Api4\CreditNoteAllocation;
 use Civi\Financeextras\Test\Helper\CreditNoteTrait;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
+use Civi\Financeextras\Utils\OptionValueUtils;
 
 /**
  * CreditNote.AllocateAction API Test Case.
@@ -52,6 +53,7 @@ class Civi_Api4_CreditNoteAllocation_AllocateActionTest extends BaseHeadlessTest
 
     $this->assertNotEmpty($entityFinancialTrxn);
 
+    $creditNoteInstrument = OptionValueUtils::getValueForOptionValue('payment_instrument', 'credit_note');
     $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
       ->addWhere('from_financial_account_id', '=', $expectedAccount)
       ->addWhere('to_financial_account_id', '=', $expectedAccount)
@@ -59,7 +61,7 @@ class Civi_Api4_CreditNoteAllocation_AllocateActionTest extends BaseHeadlessTest
       ->addWhere('id', '=', $entityFinancialTrxn['financial_trxn_id'])
       ->addWhere('status_id', '=', 1)
       ->addWhere('payment_processor_id', 'IS NULL')
-      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('payment_instrument_id', '=', $creditNoteInstrument)
       ->addWhere('check_number', 'IS NULL')
       ->execute()
       ->first();

--- a/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/ReverseActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/ReverseActionTest.php
@@ -5,6 +5,7 @@ use Civi\Api4\CreditNote;
 use Civi\Api4\CreditNoteAllocation;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
 use Civi\Financeextras\Test\Helper\CreditNoteTrait;
+use Civi\Financeextras\Utils\OptionValueUtils;
 
 /**
  * CreditNote.ReverseAction API Test Case.
@@ -43,6 +44,7 @@ class Civi_Api4_CreditNoteAllocation_ReverseActionTest extends BaseHeadlessTest 
 
     $this->assertNotEmpty($entityFinancialTrxn);
 
+    $creditNoteInstrument = OptionValueUtils::getValueForOptionValue('payment_instrument', 'credit_note');
     $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
       ->addWhere('from_financial_account_id', '=', $expectedAccount)
       ->addWhere('to_financial_account_id', '=', $expectedAccount)
@@ -50,7 +52,7 @@ class Civi_Api4_CreditNoteAllocation_ReverseActionTest extends BaseHeadlessTest 
       ->addWhere('id', '=', $entityFinancialTrxn['financial_trxn_id'])
       ->addWhere('status_id', '=', 7)
       ->addWhere('payment_processor_id', 'IS NULL')
-      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('payment_instrument_id', '=', $creditNoteInstrument)
       ->addWhere('check_number', 'IS NULL')
       ->execute()
       ->first();


### PR DESCRIPTION
## Overview
This PR adds a payment instrument/method named `Credit note`, this payment instrument will be used for credit note allocations

## Before
The credit note allocations use `credit card` as the payment instrument for credit note allocations
<img width="806" alt="Screenshot 2023-10-11 at 13 34 19" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/30c10508-7918-4ebf-9835-21da37c1fd85">


## After
The credit note allocations use `credit note` as the payment instrument for credit note allocations
<img width="800" alt="Screenshot 2023-10-11 at 13 34 30" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/b5dbd033-8cf4-45e7-9ce0-3b07d8ab1544">
