### PR TITLE
CIWEMB-532: Preventing adding of new item on priceset contribution

### DIFF
--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -99,6 +99,7 @@
 
       if (action == 2) {
         $("#add_item option[value='new']").remove();
+        $("#add-another-item").css('display', 'none');
         $('#Contribution > div.crm-block.crm-form-block.crm-contribution-form-block > table > tbody > tr:nth-child(3) > td.label').text('Line Items')
         
         $('#line-total').on('datachanged', function() {


### PR DESCRIPTION
## Overview
This PR prevents the user from adding new item on a price set contribution in the edit screen

## Before
<img width="1021" alt="Screenshot 2023-10-19 at 10 18 28" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/9bdf07da-5afe-41fe-b568-bee004b0e8f0">


## After
<img width="1172" alt="Screenshot 2023-10-19 at 10 17 51" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/86bc1d9b-8831-47de-b6f5-690cc63dcd30">
