### PR TITLE
CIWEM-18: Enforce 'Account Receivable' payment method for pending contributions

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -7,6 +7,7 @@ use Civi\Financeextras\Setup\Manage\CreditNoteInvoiceTemplateManager;
 use Civi\Financeextras\Setup\Manage\ContributionOwnerOrganizationManager;
 use Civi\Financeextras\Setup\Configure\SetDefaultCompany;
 use Civi\Financeextras\Setup\Manage\CreditNotePaymentInstrumentManager;
+use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod;
 
 /**
  * Collection of upgrade steps.
@@ -24,6 +25,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteInvoiceTemplateManager(),
       new ContributionOwnerOrganizationManager(),
       new CreditNotePaymentInstrumentManager(),
+      new AccountsReceivablePaymentMethod(),
     ];
     foreach ($manageSteps as $manageStep) {
       $manageStep->create();
@@ -48,6 +50,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteInvoiceTemplateManager(),
       new ContributionOwnerOrganizationManager(),
       new CreditNotePaymentInstrumentManager(),
+      new AccountsReceivablePaymentMethod(),
     ];
 
     foreach ($steps as $step) {
@@ -66,6 +69,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteInvoiceTemplateManager(),
       new ContributionOwnerOrganizationManager(),
       new CreditNotePaymentInstrumentManager(),
+      new AccountsReceivablePaymentMethod(),
     ];
 
     foreach ($steps as $step) {
@@ -84,6 +88,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteInvoiceTemplateManager(),
       new ContributionOwnerOrganizationManager(),
       new CreditNotePaymentInstrumentManager(),
+      new AccountsReceivablePaymentMethod(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -106,6 +106,8 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
       new CreditNoteAllocationTypeManager(),
       new CreditNoteInvoiceTemplateManager(),
       new ContributionOwnerOrganizationManager(),
+      new CreditNotePaymentInstrumentManager(),
+      new AccountsReceivablePaymentMethod(),
     ];
     foreach ($manageSteps as $manageStep) {
       $manageStep->create();

--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -62,6 +62,10 @@ class ContributionCreate {
         'template' => 'CRM/Financeextras/Form/Contribute/AddPayment.tpl',
         'region' => 'page-body',
       ]);
+
+      $accountsReceivablePaymentMethodId = array_search('accounts_receivable', \CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'validate'));
+      \Civi::resources()->addVars('financeextras', ['accounts_receivable_payment_method' => $accountsReceivablePaymentMethodId]);
+
       \Civi::resources()->addVars('financeextras', ['currencies' => \CRM_Core_OptionGroup::values('currencies_enabled')]);
       \Civi::resources()->addVars('financeextras', ['mode' => $this->form->_mode]);
       $template = \CRM_Core_Smarty::singleton();

--- a/Civi/Financeextras/Hook/BuildForm/MembershipCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/MembershipCreate.php
@@ -31,10 +31,15 @@ class MembershipCreate {
       $this->form->addElement('radio', 'fe_member_type', NULL, ts('Free Membership'), 'free_member');
       $this->form->add('checkbox', 'fe_record_payment_check', ts('Record Payment'), NULL);
       $this->form->add('text', 'fe_record_payment_amount', ts('Amount'), ['readonly' => TRUE]);
+
+      $accountsReceivablePaymentMethodId = array_search('accounts_receivable', \CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'validate'));
+      \Civi::resources()->addVars('financeextras', ['accounts_receivable_payment_method' => $accountsReceivablePaymentMethodId]);
+
       \Civi::resources()->add([
         'scriptFile' => [E::LONG_NAME, 'js/modifyMemberForm.js'],
         'region' => 'page-header',
       ]);
+
       \Civi::resources()->add([
         'template' => 'CRM/Financeextras/Form/Member/AddPayment.tpl',
         'region' => 'page-body',

--- a/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
@@ -42,6 +42,9 @@ class ParticipantCreate {
     ];
     $this->form->setDefaults(array_merge($this->form->_defaultValues, $defaults));
 
+    $accountsReceivablePaymentMethodId = array_search('accounts_receivable', \CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'validate'));
+    \Civi::resources()->addVars('financeextras', ['accounts_receivable_payment_method' => $accountsReceivablePaymentMethodId]);
+
     \Civi::resources()->add([
       'scriptFile' => [E::LONG_NAME, 'js/modifyParticipantForm.js'],
       'region' => 'page-header',

--- a/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
@@ -74,6 +74,7 @@ class ParticipantPostProcess {
       'participant_id' => $this->form->_id,
       'source' => $this->getSource(),
       'contribution_status_id' => OptionValueUtils::getValueForOptionValue('contribution_status', 'Pending'),
+      'payment_instrument_id' => $values['payment_instrument_id'],
     ];
 
     if (!empty($values['tax_amount'])) {

--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Civi\Financeextras\Setup\Manage;
+
+class AccountsReceivablePaymentMethod extends AbstractSetupManager {
+
+  /**
+   * The machine name of the payment method.
+   */
+  const NAME = 'accounts_receivable';
+
+  /**
+   * The title/label of the payment method.
+   */
+  const TITLE = 'Accounts Receivable';
+
+  public function create(): void {
+    $accountsReceivableFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
+      'return' => 'id',
+      'name' => self::TITLE,
+    ]);
+
+    if (empty($this->getAccountsReceivablePaymentMethodId())) {
+      civicrm_api3('OptionValue', 'create', [
+        'option_group_id' => 'payment_instrument',
+        'label' => self::TITLE,
+        'name' => self::NAME,
+        'financial_account_id' => $accountsReceivableFinancialAccountId,
+        'is_reserved' => 1,
+        'is_active' => 1,
+      ]);
+    }
+  }
+
+  public function remove(): void {
+    $accountsReceivablePaymentMethodId = $this->getAccountsReceivablePaymentMethodId();
+    if (!empty($accountsReceivablePaymentMethodId)) {
+      civicrm_api3('OptionValue', 'delete', [
+        'id' => $accountsReceivablePaymentMethodId,
+      ]);
+    }
+  }
+
+  protected function toggle($status): void {
+    civicrm_api3('OptionValue', 'get', [
+      'name' => self::NAME,
+      'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+
+  private function getAccountsReceivablePaymentMethodId(): ?int {
+    $paymentMethod = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'option_group_id' => 'payment_instrument',
+      'name' => self::NAME,
+    ]);
+
+    if (!empty($paymentMethod['id'])) {
+      return $paymentMethod['id'];
+    }
+
+    return NULL;
+  }
+
+}

--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Setup\Manage;
 
-class AccountsReceivablePaymentMethod extends AbstractSetupManager {
+class AccountsReceivablePaymentMethod extends AbstractManager {
 
   /**
    * The machine name of the payment method.

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -19,7 +19,7 @@ const totalChanged = new CustomEvent("totalChanged", {});
       recordPaymentAmount.value = Number($('#total_amount').val()).toFixed(2);
       recordPaymentAmount.dispatchEvent(totalChanged)
     });
-  
+
     $('#price_set_id').on('change', function() {
       recordPaymentAmount.value = Number($('#line-total').data('raw-total')).toFixed(2);
       recordPaymentAmount.dispatchEvent(totalChanged)
@@ -50,7 +50,7 @@ const totalChanged = new CustomEvent("totalChanged", {});
 
       $('.record_payment-block #currency-symbol').text(currencySymbol)
     };
-  
+
     setSymbol();
     $('select[name=currency]').on('change', function() {
       setSymbol();
@@ -59,10 +59,12 @@ const totalChanged = new CustomEvent("totalChanged", {});
 
   function toggleRecordPaymentBlock() {
     const recordPaymentCheck = document.querySelector("input[name=fe_record_payment_check]");
+    const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
     const toggle = (checked)  => {
       if (checked) {
         $('.record_payment-block').show();
       } else {
+        CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
         $('.record_payment-block').hide();
       }
     }

--- a/js/modifyMemberForm.js
+++ b/js/modifyMemberForm.js
@@ -21,10 +21,17 @@ CRM.$(function ($) {
   }
 
   function togglePaymentBlock() {
+    const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
+
     $('input[name=fe_record_payment_check]').prop("checked", true).trigger('change')
+    CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
 
     $('input[name=fe_record_payment_check]').on('change', () => {
       const recordPayment = $('input[name=fe_record_payment_check]').is(':checked')
+      if (!recordPayment) {
+        CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
+      }
+
       $('tr.record_payment-block_row').toggle(recordPayment)
     });
   }
@@ -61,7 +68,7 @@ CRM.$(function ($) {
       ))
     )
 
-    waitForElement($, 'input[name=contribution_type_toggle]', 
+    waitForElement($, 'input[name=contribution_type_toggle]',
       () => {
         $('tr.crm-membership-form-block-receive_date').before($('tr.crm-membership-form-block-financial_type_id'));
         $('tr.crm-contribution-form-block-financeextras_record_payment_amount').after(
@@ -101,10 +108,10 @@ CRM.$(function ($) {
 
   /**
    * Triggers callback when element attribute changes.
-   * 
-   * @param {object} $ 
-   * @param {string} elementPath 
-   * @param {object} callBack 
+   *
+   * @param {object} $
+   * @param {string} elementPath
+   * @param {object} callBack
    */
   function waitForElement($, elementPath, callBack) {
     (new MutationObserver(function() {
@@ -116,14 +123,14 @@ CRM.$(function ($) {
 
   /**
    * Observes change in property value for an element.
-   * 
-   * This method is used to listen for change in input fields 
+   *
+   * This method is used to listen for change in input fields
    * that doesn't emit a change event when their value changes.
-   * 
-   * @param {string} elementPath 
-   * @param {string} property 
-   * @param {function} callback 
-   * @param {number} delay 
+   *
+   * @param {string} elementPath
+   * @param {string} property
+   * @param {function} callback
+   * @param {number} delay
    */
   function observeElement(elementPath, property, callback, delay = 0) {
     const element = document.querySelector(elementPath)

--- a/js/modifyParticipantForm.js
+++ b/js/modifyParticipantForm.js
@@ -9,8 +9,8 @@ CRM.$(function ($) {
 
   /**
    * The event fees block for paid event is fetched via AJAX after the page has loaded.
-   * 
-   * Therefore, we need to ensure that the AJAX fetch is completed 
+   *
+   * Therefore, we need to ensure that the AJAX fetch is completed
    * before consolidating the payment fields and setting up event listeners.
    */
   function observeEventFeeIsDisplayed() {
@@ -60,16 +60,20 @@ CRM.$(function ($) {
   }
 
   function togglePaymentBlock() {
+    const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
+    CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
+
     if ($('input#record_contribution').is(':checked')) {
       $('input:radio[name=fe_ticket_type][value=paid_ticket]').click();
     }else {
       $('#payment_information').hide();
     }
-  
+
     $('input#record_contribution').on('input', () => {
       if ($('input#record_contribution').is(':checked')) {
         $('#billing-payment-block').show();
       }else {
+        CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
         $('#billing-payment-block').hide();
       }
     })
@@ -86,7 +90,7 @@ CRM.$(function ($) {
 
     //if no free ticket is selected, uncheck record payment and hide the record payment field
     toggleBlock();
-    $('input:radio[name=fe_ticket_type][value=paid_ticket]:checked').on('change', 
+    $('input:radio[name=fe_ticket_type][value=paid_ticket]:checked').on('change',
       () => $('input#record_contribution').prop("checked", true).trigger('click')
     );
 


### PR DESCRIPTION
## Overview

Adding new payment method `Accounts Receivable` which will be used as the default payment method for contributions that are created without recording a payment.

## Before

When creating a contribution , membership (non payment plan), or registering an event participant from the admin form, the resulting contribution will have the default payment method in CiviCRM set as the contribution payment method.  

## After

The `Accounts Receivable`  payment method will be used by default for contributions created  without recording a payment.



The Contribution form:

https://github.com/compucorp/io.compuco.financeextras/assets/6275540/eb5c8e9a-a0c7-4ccf-a7d0-8fe12356f9a9


The Membership form (Without Payment plan):

https://github.com/compucorp/io.compuco.financeextras/assets/6275540/b49a056a-3024-4051-b1ef-6b810c00fadd



The Membership form (with Payment plan):


https://github.com/compucorp/io.compuco.financeextras/assets/6275540/66835941-60d8-4ca8-b230-6fe6b8a75046


The event registration form: 

https://github.com/compucorp/io.compuco.financeextras/assets/6275540/af4b1269-e8bf-433e-a152-2c51bbc7d7bb




