### PR TITLE
CIWEMB-322: Remove unnecessary permission checks

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -243,9 +243,9 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
    *  The credit note for which allocation was made.
    */
   public static function updateCreditNoteStatusPostAllocation($allocationId) {
-    $allocation = \Civi\Api4\CreditNoteAllocation::get()
+    $allocation = \Civi\Api4\CreditNoteAllocation::get(FALSE)
       ->addWhere('id', '=', $allocationId)
-      ->addChain('credit_note', \Civi\Api4\CreditNote::get()
+      ->addChain('credit_note', \Civi\Api4\CreditNote::get(FALSE)
         ->addWhere('id', '=', '$credit_note_id')
         ->addWhere('status_id:name', 'IN', ['open', 'fully_allocated'])
         )
@@ -262,7 +262,7 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
       default => 'open'
     };
 
-    \Civi\Api4\CreditNote::update()
+    \Civi\Api4\CreditNote::update(FALSE)
       ->addValue('status_id:name', $status)
       ->addWhere('id', '=', $creditNote['id'])
       ->execute();
@@ -282,9 +282,9 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
    *   The credit note refund allocation data
    */
   public static function refund($creditNoteId, $allocationParam, $paymentParam) {
-    $creditNote = \Civi\Api4\CreditNote::get()
+    $creditNote = \Civi\Api4\CreditNote::get(FALSE)
       ->addWhere('id', '=', $creditNoteId)
-      ->addChain('line', \Civi\Api4\CreditNoteLine::get()
+      ->addChain('line', \Civi\Api4\CreditNoteLine::get(FALSE)
         ->addWhere('credit_note_id', '=', '$id')
       )
       ->execute()
@@ -301,7 +301,7 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
   }
 
   private static function createRefundAllocation(array $creditNote, array $data) {
-    return \Civi\Api4\CreditNoteAllocation::create()
+    return \Civi\Api4\CreditNoteAllocation::create(FALSE)
       ->addValue('credit_note_id', $creditNote['id'])
       ->addValue('type_id:name', 'manual_refund_payment')
       ->addValue('currency', $creditNote['currency'])

--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -148,7 +148,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       'trxn_date' => $date,
     ];
 
-    $creditNoteLine = \Civi\Api4\CreditNoteLine::get()
+    $creditNoteLine = \Civi\Api4\CreditNoteLine::get(FALSE)
       ->addWhere('credit_note_id.id', '=', $creditNoteId)
       ->execute()
       ->first();
@@ -235,7 +235,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       return NULL;
     }
 
-    $financialTrxn = \Civi\Api4\FinancialTrxn::get()
+    $financialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
       ->addWhere('id', '=', $entityTrxn->financial_trxn_id)
       ->addSelect('to_financial_account_id:label')
       ->execute()
@@ -259,10 +259,10 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
    *
    */
   private static function getCreditNoteAllocationById(int $id): array {
-    return \Civi\Api4\CreditNoteAllocation::get()
+    return \Civi\Api4\CreditNoteAllocation::get(FALSE)
       ->addWhere('id', '=', $id)
       ->addSelect('*', 'credit_note_id.contact_id')
-      ->addChain('line', \Civi\Api4\CreditNoteLine::get()
+      ->addChain('line', \Civi\Api4\CreditNoteLine::get(FALSE)
         ->addWhere('credit_note_id', '=', '$credit_note_id')
         )
       ->execute()

--- a/CRM/Financeextras/BAO/CreditNoteLine.php
+++ b/CRM/Financeextras/BAO/CreditNoteLine.php
@@ -136,7 +136,7 @@ class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditN
       ->execute()
       ->first();
 
-    $totalLineItemPaid = \Civi\Api4\EntityFinancialTrxn::get()
+    $totalLineItemPaid = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
       ->addSelect('SUM(amount) AS sum')
       ->addWhere('entity_table:name', '=', 'civicrm_financial_item')
       ->addWhere('entity_id', '=', $financialItem['id'])
@@ -172,7 +172,7 @@ class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditN
 
     if (!empty($lineItem['tax_amount']) && abs($lineItem['tax_amount']) > 0) {
       $taxAccount = FinancialAccountUtils::getFinancialTypeAccount($lineItem['financial_type_id'], 'Sales Tax Account is');
-      $taxAccountDesc = \Civi\Api4\FinancialAccount::get()
+      $taxAccountDesc = \Civi\Api4\FinancialAccount::get(FALSE)
         ->addSelect('description')
         ->addWhere('id', '=', $taxAccount)
         ->execute()

--- a/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.php
@@ -179,7 +179,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteAllocate extends CRM_Core_Form
    *   The allocation type value.
    */
   private function getAllocationTypeValueByName($name) {
-    $optionValues = \Civi\Api4\OptionValue::get()
+    $optionValues = \Civi\Api4\OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_allocation_type')
       ->addWhere('name', '=', $name)

--- a/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
@@ -176,7 +176,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
     try {
       $values = $this->getSubmitValues();
 
-      \Civi\Api4\CreditNote::refund()
+      \Civi\Api4\CreditNote::refund(FALSE)
         ->setId($this->crid)
         ->setAmount(round($values['amount'], 2))
         ->setReference($values['reference'])

--- a/CRM/Financeextras/Hook/Links/Contribution.php
+++ b/CRM/Financeextras/Hook/Links/Contribution.php
@@ -59,7 +59,7 @@ class CRM_Financeextras_Hook_Links_Contribution {
    * @throws \Civi\API\Exception
    */
   private function contributionHasStatus($statuses) {
-    $contribution = \Civi\Api4\Contribution::get()
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('id', '=', $this->contributionId)
       ->addWhere('contribution_status_id:name', 'IN', $statuses)
       ->setLimit(1)

--- a/CRM/Financeextras/Hook/PageRun/ContributionPageTab.php
+++ b/CRM/Financeextras/Hook/PageRun/ContributionPageTab.php
@@ -47,7 +47,7 @@ class CRM_Financeextras_Hook_PageRun_ContributionPageTab implements PageRunInter
    */
   private function setCreditNoteCounts($page) {
     $contactId = $page->getVar('_contactId');
-    $creditNotes = \Civi\Api4\CreditNote::get()
+    $creditNotes = \Civi\Api4\CreditNote::get(FALSE)
       ->selectRowCount()
       ->addSelect('COUNT(id) AS count')
       ->addWhere('contact_id', '=', $contactId)

--- a/Civi/Api4/Action/CreditNote/CreditNoteSaveAction.php
+++ b/Civi/Api4/Action/CreditNote/CreditNoteSaveAction.php
@@ -91,7 +91,7 @@ class CreditNoteSaveAction extends AbstractSaveAction {
    *   created credit note entity
    */
   private function createCreditNote(array $data) {
-    $optionValues = \Civi\Api4\OptionValue::get()
+    $optionValues = \Civi\Api4\OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_status')
       ->addWhere('name', '=', 'open')

--- a/Civi/Api4/Action/CreditNote/GetAction.php
+++ b/Civi/Api4/Action/CreditNote/GetAction.php
@@ -37,7 +37,7 @@ class GetAction extends DAOGetAction {
   }
 
   private function getAllocations($id) {
-    $allocations = \Civi\Api4\CreditNoteAllocation::get()
+    $allocations = \Civi\Api4\CreditNoteAllocation::get(FALSE)
       ->addSelect('*', 'type_id:name')
       ->addWhere('credit_note_id', '=', $id)
       ->addWhere('is_reversed', '=', FALSE)

--- a/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
+++ b/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
@@ -58,7 +58,7 @@ class SearchDisplayRun {
    */
   private static function alterCreditNoteSearchDisplay(&$result) {
     foreach ($result as &$display) {
-      $creditNote = \Civi\Api4\CreditNote::get()
+      $creditNote = \Civi\Api4\CreditNote::get(FALSE)
         ->addSelect('status_id:name', 'total_credit', 'currency')
         ->addWhere('id', '=', $display['data']['id'])
         ->execute()

--- a/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
+++ b/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
@@ -16,7 +16,7 @@ class ContributionPaymentUpdatedListener {
     $status = 'Pending';
     $allowedStatus = ['Pending', 'Completed', 'Partially paid', 'Refunded', 'Pending refund'];
 
-    $contribution = \Civi\Api4\Contribution::get()
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('id', '=', $contributionId)
       ->addWhere('contribution_status_id:name', 'IN', $allowedStatus)
       ->execute()

--- a/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
+++ b/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
@@ -58,7 +58,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
   private function createActivity($targetContactIds, $type, $subject, $attachment, $details) {
     $now = (new DateTime())->format('YmdHis');
     $currentUser = \CRM_Core_Session::singleton()->get('userID');
-    \Civi\Api4\Activity::create()
+    \Civi\Api4\Activity::create(FALSE)
       ->addValue('subject', $subject)
       ->addValue('target_contact_id', $targetContactIds)
       ->addValue('source_contact_id', $currentUser)
@@ -99,7 +99,7 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
    *   Credit Note contact ID
    */
   private function getCreditNoteContactId($id) {
-    return \Civi\Api4\CreditNote::get()
+    return \Civi\Api4\CreditNote::get(FALSE)
       ->addSelect('contact_id')
       ->addWhere('id', '=', $id)
       ->execute()

--- a/Civi/Financeextras/Hook/AlterMailParams/AlterContributionReceipt.php
+++ b/Civi/Financeextras/Hook/AlterMailParams/AlterContributionReceipt.php
@@ -21,7 +21,7 @@ class AlterContributionReceipt {
    */
   public function handle() {
     if (empty($this->params['tplParams']['contribution']) && !empty($this->params['tokenContext']['contributionId'])) {
-      $contribution = \Civi\Api4\Contribution::get()
+      $contribution = \Civi\Api4\Contribution::get(FALSE)
         ->addWhere('id', '=', $this->params['tokenContext']['contributionId'])
         ->execute()
         ->first();

--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -108,7 +108,7 @@ class ContributionCreate {
     ]);
 
     if ($this->isEdit()) {
-      $contribution = \Civi\Api4\Contribution::get()
+      $contribution = \Civi\Api4\Contribution::get(FALSE)
         ->addSelect('currency', 'total_amount')
         ->addWhere('id', '=', $this->form->_id)
         ->execute()

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -43,7 +43,7 @@ class ContributionView {
    * @throws \Civi\API\Exception
    */
   private function isContributionCancelled() {
-    $contribution = \Civi\Api4\Contribution::get()
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('id', '=', $this->id)
       ->addWhere('contribution_status_id:name', '=', 'Cancelled')
       ->setLimit(1)

--- a/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ParticipantCreate.php
@@ -72,7 +72,7 @@ class ParticipantCreate {
     }
 
     // Check if the event is a paid event based on its configuration
-    $event = \Civi\Api4\Event::get()
+    $event = \Civi\Api4\Event::get(FALSE)
       ->addSelect('is_monetary')
       ->addWhere('id', '=', $this->form->_eID)
       ->execute()

--- a/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
@@ -105,7 +105,7 @@ class ParticipantPostProcess {
       return $this->form->getSubmitValues()['source'];
     }
 
-    $event = \Civi\Api4\Event::get()
+    $event = \Civi\Api4\Event::get(FALSE)
       ->addSelect('title')
       ->addWhere('id', '=', $this->form->_eventId)
       ->execute()->first();
@@ -117,7 +117,7 @@ class ParticipantPostProcess {
   }
 
   private function syncLineItem($contributionId, $participantId) {
-    $lineItems = \Civi\Api4\LineItem::get()
+    $lineItems = \Civi\Api4\LineItem::get(FALSE)
       ->addWhere('entity_table', '=', 'civicrm_participant')
       ->addWhere('entity_id', '=', $participantId)
       ->execute();

--- a/Civi/Financeextras/Hook/ValidateForm/FinancialTypeAccount.php
+++ b/Civi/Financeextras/Hook/ValidateForm/FinancialTypeAccount.php
@@ -60,7 +60,7 @@ class FinancialTypeAccount {
    * Gets the Financial Accounts based on financial type id sent by the form
    */
   private function getExistingFinancialTypeAccountsCountAndOwner($financialTypeId) {
-    $result = \Civi\Api4\EntityFinancialAccount::get()
+    $result = \Civi\Api4\EntityFinancialAccount::get(FALSE)
       ->addSelect('COUNT(*) AS count', 'financial_account.contact_id')
       ->setJoin([['FinancialAccount AS financial_account', 'INNER', NULL, ['financial_account_id', '=', 'financial_account.id']]])
       ->setGroupBy(['financial_account.contact_id'])
@@ -79,7 +79,7 @@ class FinancialTypeAccount {
    * Gets the owner of the financial account from the submitted fields
    */
   private function getSelectedFinancialAccountOwnerOrganisationId() {
-    $result = \Civi\Api4\FinancialAccount::get()
+    $result = \Civi\Api4\FinancialAccount::get(FALSE)
       ->addSelect('contact_id')
       ->addWhere('id', '=', $this->fields['financial_account_id'])
       ->execute()

--- a/Civi/Financeextras/Service/CreditNoteInvoiceService.php
+++ b/Civi/Financeextras/Service/CreditNoteInvoiceService.php
@@ -151,7 +151,7 @@ class CreditNoteInvoiceService {
    *   The allocation type value
    */
   private function getAllocationType(string $name): int|null {
-    $allocationTypes = \Civi\Api4\OptionValue::get()
+    $allocationTypes = \Civi\Api4\OptionValue::get(FALSE)
       ->addSelect('value', 'name')
       ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_allocation_type')
       ->addWhere('name', '=', $name)

--- a/Civi/Financeextras/Setup/Configure/SetDefaultCompany.php
+++ b/Civi/Financeextras/Setup/Configure/SetDefaultCompany.php
@@ -18,7 +18,7 @@ class SetDefaultCompany implements ConfigurerInterface {
 
   public function apply() {
     try {
-      \Civi\Api4\Company::create()
+      \Civi\Api4\Company::create(FALSE)
         ->addValue('contact_id', $this->getDefaultDomainContact())
         ->addValue('invoice_template_id:name', 'Contributions - Invoice')
         ->addValue('invoice_prefix', $this->getDefaultInvoicePrefix())

--- a/ang/fe-creditnote.ang.php
+++ b/ang/fe-creditnote.ang.php
@@ -34,7 +34,7 @@ function financeextras_set_credit_note_status(&$options) {
  * Exposes credit note statuses to Angular.
  */
 function financeextras_set_companies(&$options) {
-  $options['companies'] = \Civi\Api4\Company::get()
+  $options['companies'] = \Civi\Api4\Company::get(FALSE)
     ->addSelect('contact_id.organization_name', 'contact_id')
     ->execute()
     ->getArrayCopy();

--- a/financeextras.php
+++ b/financeextras.php
@@ -152,7 +152,7 @@ function financeextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
 
   if ($objectName === 'Contribution' && in_array($op, ['create', 'edit'])) {
     \Civi::dispatcher()->dispatch(ContributionPaymentUpdatedEvent::NAME, new ContributionPaymentUpdatedEvent($objectId));
-    $contribution = \Civi\Api4\Contribution::get()
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('id', '=', $objectId)
       ->execute()
       ->first();


### PR DESCRIPTION
## Before

When enabling the extension inside and upgrader that runs during deployment, the default Company that is supposed to be created according to the work in this PR: https://github.com/compucorp/io.compuco.financeextras/pull/94 is not getting created.

## After

The default Company is getting created normally when installing the extension during deployment.

## Technical Details

In this class:

Civi/Financeextras/Setup/Configure/SetDefaultCompany.php

I create the default Company using API v4, but API v4 by default enforce permission check, but most of the time API calls that are done from the backend do not need a permission check, given most of the time other permissions are enforced at higher level so these API calls are already being executed from safe contexts.

And while the motivating for the work I did here was the issue mentioned, I took the opportunity to remove any permission check for API v4 backend calls within the whole extension to prevent potential problems with non admin users.  I also did something similar for Membershipextras extension in this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/505
