### PR TITLE
CIWEMB-323: Fix default company creation on fresh site

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -16,7 +16,7 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
   /**
    * Tasks to perform when the extension is installed.
    */
-  public function install() {
+  public function postInstall() {
     $manageSteps = [
       new CreditNoteStatusManager(),
       new CreditNoteActivityTypeManager(),

--- a/tests/phpunit/CRM/Financeextras/Form/Company/AddTest.php
+++ b/tests/phpunit/CRM/Financeextras/Form/Company/AddTest.php
@@ -66,6 +66,8 @@ class CRM_Financeextras_Form_Company_AddTest extends BaseHeadlessTest {
 
     $company = new CRM_Financeextras_DAO_Company();
     $company->contact_id = 1;
+    $company->invoice_prefix = 'INV_';
+    $company->next_invoice_number = '00001';
     $company->find();
     $records = $company->fetchAll();
 
@@ -95,6 +97,8 @@ class CRM_Financeextras_Form_Company_AddTest extends BaseHeadlessTest {
 
     $company = new CRM_Financeextras_DAO_Company();
     $company->contact_id = 1;
+    $company->invoice_prefix = 'XYZ';
+    $company->next_invoice_number = '000025';
     $company->find();
     $records = $company->fetchAll();
 

--- a/tests/phpunit/CRM/Financeextras/Form/Company/DeleteTest.php
+++ b/tests/phpunit/CRM/Financeextras/Form/Company/DeleteTest.php
@@ -22,6 +22,8 @@ class CRM_Financeextras_Form_Company_DeleteTest extends BaseHeadlessTest {
 
     $company = new CRM_Financeextras_DAO_Company();
     $company->contact_id = 1;
+    $company->invoice_prefix = 'INV_';
+    $company->next_invoice_number = '000001';
     $company->find();
     $records = $company->fetchAll();
 

--- a/tests/phpunit/CRM/Financeextras/Page/CompanyTest.php
+++ b/tests/phpunit/CRM/Financeextras/Page/CompanyTest.php
@@ -34,13 +34,16 @@ class CRM_Financeextras_Page_CompanyTest extends BaseHeadlessTest {
     $page->run();
 
     $rowsToShowInPage = $page->get_template_vars('rows');
-    $this->assertCount(2, $rowsToShowInPage);
-    $this->assertEquals('Default Organization', current($rowsToShowInPage)['company_name']);
-    $this->assertEquals($params1['next_invoice_number'], current($rowsToShowInPage)['next_invoice_number']);
+    // we look for 3 records because there is a one created
+    // by default when installing the extension.
+    $this->assertCount(3, $rowsToShowInPage);
+    $secondRowAfterDefaultRecord = next($rowsToShowInPage);
+    $this->assertEquals('Default Organization', $secondRowAfterDefaultRecord['company_name']);
+    $this->assertEquals($params1['next_invoice_number'], $secondRowAfterDefaultRecord['next_invoice_number']);
 
-    $secondRow = next($rowsToShowInPage);
-    $this->assertEquals('Default Organization', $secondRow['company_name']);
-    $this->assertEquals($params2['next_invoice_number'], $secondRow['next_invoice_number']);
+    $thirdRow = next($rowsToShowInPage);
+    $this->assertEquals('Default Organization', $thirdRow['company_name']);
+    $this->assertEquals($params2['next_invoice_number'], $thirdRow['next_invoice_number']);
   }
 
   private function disableReturningPageResult($page) {


### PR DESCRIPTION
## Before

Despite the work here: https://github.com/compucorp/io.compuco.financeextras/pull/113
the default company is still not getting created on fresh installation, and while I mentioned that it works now in that PR, that's because Financeextras is installed by default on Compuclient sites, so I thought that things are working fine, but if you uninstall the extension then try to install it again then the default Company won't be created.


## After

Installing the extension on a fresh site, or uninstalling then installing the extension creates the default Company correctly:

![image](https://github.com/compucorp/io.compuco.financeextras/assets/6275540/92d87756-d609-40c3-8620-3e316dad18fd)


## Technical Details

I used `\Civi\Api4\Company::create(FALSE)` v4 API to create the default Company, but when the `install()` hook runs this API is not loaded yet given the extension is not yet fully installed, and because I already ignore any exceptions thrown while creating the default Company: https://github.com/compucorp/io.compuco.financeextras/blob/CIWEMB-15-creditnote-workstream/Civi/Financeextras/Setup/Configure/SetDefaultCompany.php#L20-L31 no error will appear while installing the extension.

I went with a simple fix here which is moving all the code inside the `install()` hook to the `postInstall()` hook, it should not make a difference for the stuff we are doing during installation and all the classes and endpoints defined in this extension will be loaded there so they can be used without a problem.
