### PR TITLE
CIWEMB-525: Ensure the successful deletion of a voided credit note

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -109,9 +109,11 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       $entityTrxn->find();
 
       while ($entityTrxn->fetch()) {
-        $trxn = new \CRM_Financial_DAO_FinancialTrxn();
-        $trxn->id = $entityTrxn->financial_trxn_id;
-        $trxn->delete();
+        if (!empty($entityTrxn->financial_trxn_id)) {
+          $trxn = new \CRM_Financial_DAO_FinancialTrxn();
+          $trxn->id = $entityTrxn->financial_trxn_id;
+          $trxn->delete();
+        }
       }
       $entityTrxn->delete();
 

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -99,5 +99,12 @@ const totalChanged = new CustomEvent("totalChanged", {});
     $('tr#email-receipt label').text('Send Email Confirmation')
     const email = $('tr#email-receipt #email-address')
     $('tr#email-receipt .description').text('Automatically email a confirmation of this transaction to ').append(email).append('?')
+    
+    if (!$('tr#email-receipt').length) {
+      $('tr.crm-contribution-form-block-is_email_receipt label').text('Send Email Confirmation')
+      let text = $('tr.crm-contribution-form-block-is_email_receipt .description').text()
+      text = text.replace('Automatically email a receipt for this payment to', 'Automatically email a confirmation of this transaction to')
+      $('tr.crm-contribution-form-block-is_email_receipt .description').text(text)
+    }
   }
 });


### PR DESCRIPTION
## Overview
This PR Ensure the successful deletion of a voided credit note and also updates the send receipt label of the new contribution form

## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/e24b828a-f887-4152-b25b-72c6051bc110)

## After
![asasa](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/5c77d29a-f93a-4341-8f5a-151a5c5f83a1)

## Before
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/7fee9efc-cb05-46ea-b263-4f4c157840b7)


## After
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/80afba6d-582d-44ed-b841-31f125733a37)

