### PR TITLE
ESEB-67: Add sales tax conversion table token

### DIFF
--- a/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php
+++ b/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php
@@ -6,7 +6,7 @@ use CRM_Financeextras_CustomGroup_ContributionOwnerOrganisation as ContributionO
 
 /**
  * Provides separate invoicing template and tokens for each
- * company (legal entity).
+ * company (legal entity) and adds tax conversion table data.
  */
 class InvoiceTemplate {
 
@@ -22,6 +22,8 @@ class InvoiceTemplate {
   }
 
   public function handle() {
+    $this->addTaxConversionTable();
+
     $this->contributionOwnerCompany = ContributionOwnerOrganisation::getOwnerOrganisationCompany($this->contributionId);
     if (empty($this->contributionOwnerCompany)) {
       return;
@@ -29,6 +31,28 @@ class InvoiceTemplate {
 
     $this->useContributionOwnerOrganisationInvoiceTemplate();
     $this->replaceDomainTokensWithOwnerOrganisationTokens();
+  }
+
+  private function addTaxConversionTable() {
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
+      ->addSelect(
+        'financeextras_currency_exchange_rates.rate_1_unit_tax_currency',
+        'financeextras_currency_exchange_rates.rate_1_unit_contribution_currency',
+        'financeextras_currency_exchange_rates.sales_tax_currency'
+      )->setLimit(1)
+      ->addWhere('id', '=', $this->contributionId)
+      ->execute()
+      ->first();
+    if (empty($contribution['financeextras_currency_exchange_rates.rate_1_unit_tax_currency'])) {
+      return;
+    }
+
+    $this->templateParams['tplParams'] = array_merge($this->templateParams['tplParams'], [
+      'showTaxConversionTable' => TRUE,
+      'rate_1_unit_tax_currency' => $contribution['financeextras_currency_exchange_rates.rate_1_unit_tax_currency'],
+      'rate_1_unit_contribution_currency' => $contribution['financeextras_currency_exchange_rates.rate_1_unit_contribution_currency'],
+      'sales_tax_currency' => $contribution['financeextras_currency_exchange_rates.sales_tax_currency'],
+    ]);
   }
 
   /**

--- a/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php
+++ b/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php
@@ -38,20 +38,22 @@ class InvoiceTemplate {
       ->addSelect(
         'financeextras_currency_exchange_rates.rate_1_unit_tax_currency',
         'financeextras_currency_exchange_rates.rate_1_unit_contribution_currency',
-        'financeextras_currency_exchange_rates.sales_tax_currency'
+        'financeextras_currency_exchange_rates.sales_tax_currency',
+        'financeextras_currency_exchange_rates.vat_text'
       )->setLimit(1)
       ->addWhere('id', '=', $this->contributionId)
       ->execute()
       ->first();
     if (empty($contribution['financeextras_currency_exchange_rates.rate_1_unit_tax_currency'])) {
-      return;
+      $showTaxConversionTable = FALSE;
     }
 
     $this->templateParams['tplParams'] = array_merge($this->templateParams['tplParams'], [
-      'showTaxConversionTable' => TRUE,
-      'rate_1_unit_tax_currency' => $contribution['financeextras_currency_exchange_rates.rate_1_unit_tax_currency'],
-      'rate_1_unit_contribution_currency' => $contribution['financeextras_currency_exchange_rates.rate_1_unit_contribution_currency'],
-      'sales_tax_currency' => $contribution['financeextras_currency_exchange_rates.sales_tax_currency'],
+      'showTaxConversionTable' => $showTaxConversionTable,
+      'rate_1_unit_tax_currency' => $contribution['financeextras_currency_exchange_rates.rate_1_unit_tax_currency'] ?? "",
+      'rate_1_unit_contribution_currency' => $contribution['financeextras_currency_exchange_rates.rate_1_unit_contribution_currency'] ?? "",
+      'sales_tax_currency' => $contribution['financeextras_currency_exchange_rates.sales_tax_currency'] ?? "",
+      'rate_vat_text' => $contribution['financeextras_currency_exchange_rates.vat_text'] ?? "",
     ]);
   }
 

--- a/Civi/Financeextras/Hook/PostProcess/UpdateContributionExchangeRate.php
+++ b/Civi/Financeextras/Hook/PostProcess/UpdateContributionExchangeRate.php
@@ -34,7 +34,7 @@ class UpdateContributionExchangeRate {
     $exchangeRate = \Civi\Api4\ExchangeRate::get(FALSE)
       ->addOrderBy('exchange_date', 'ASC')
       ->addWhere('base_currency', '=', $salesTaxCurrency)
-      ->addWhere('exchange_date', '<=', $contribution['receive_date'])
+      ->addWhere('exchange_date', '<', $contribution['receive_date'])
       ->addWhere('conversion_currency', '=', $contribution['currency'])
       ->setLimit(1)
       ->execute()

--- a/financeextras.php
+++ b/financeextras.php
@@ -21,6 +21,7 @@ function financeextras_civicrm_config(&$config) {
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\Contribution', 'respond'], -101);
   Civi::dispatcher()->addListener('fe.contribution.received_payment', ['\Civi\Financeextras\Event\Listener\ContributionPaymentUpdatedListener', 'handle']);
   Civi::dispatcher()->addListener('civi.api.prepare', ['Civi\Financeextras\APIWrapper\BatchListPage', 'preApiCall']);
+  Civi::dispatcher()->addListener('civi.token.list', 'financeextras_register_tokens');
 }
 
 /**
@@ -273,6 +274,18 @@ function financeextras_civicrm_alterMailContent(&$content) {
   if (($content['workflow_name'] ?? NULL) === 'contribution_offline_receipt') {
     $content['html'] = str_replace('$formValues.total_amount', '$contribution.total_amount', $content['html']);
   }
+
+  if (($content['workflow_name'] ?? NULL) === 'contribution_invoice_receipt') {
+    $path = E::path('/templates/CRM/Financeextras/MessageTemplate/SalesTaxConversionRateTable.tpl');
+    $content['html'] = str_replace('{contribution.tax_exchange_rate_table}', file_get_contents($path), $content['html']);
+  }
+}
+
+/**
+ * Add financeextras tokens
+ */
+function financeextras_register_tokens(\Civi\Token\Event\TokenRegisterEvent $e) {
+  $e->entity('contribution')->register('tax_exchange_rate_table', ts('Tax exchange rate table'));
 }
 
 /**

--- a/templates/CRM/Financeextras/MessageTemplate/SalesTaxConversionRateTable.tpl
+++ b/templates/CRM/Financeextras/MessageTemplate/SalesTaxConversionRateTable.tpl
@@ -1,0 +1,31 @@
+
+{if $showTaxConversionTable}
+  <table style="padding-top:10px;font-family: Arial, Verdana, sans-serif;" border="0" width="100%" cellpadding="8" cellspacing="0">
+    <tr>
+      <td style="text-align:left;font-weight:bold;width:60%"></td>
+      <td colspan="3" style="border: 1px solid; border-bottom: 0px; font-weight: bold;"><font size="1">*{$sales_tax_currency} Equivalent Conversion</font></td>
+    </tr>
+    <tr>
+      <td style="text-align:left;font-weight:bold;width:60%"></td>
+      <td colspan="3" style="border: 1px solid; border-top: 0px"><font size="1">1 {$sales_tax_currency} = {$rate_1_unit_tax_currency} {$currency}</font></td>
+    </tr>
+    <tr>
+      <td style="text-align:left; font-weight:bold; width:60%"></td>
+      <td style="text-align:center; border-left: 1px solid; border-bottom: 1px solid; font-weight: bold;"><font size="1">VAT Rate</font></td>
+      <td style="text-align:center; border-bottom: 1px solid; font-weight: bold;"><font size="1">Net Amount</font></td>
+      <td style="text-align:center; border-right: 1px solid; border-bottom: 1px solid; font-weight: bold;"><font size="1">VAT</font></td>
+    </tr>
+    {foreach from=$lineItem item=value key=priceset}
+    <tr>
+      <td style="text-align:left;font-weight:bold;width:60%"></td>
+      <td style="text-align:center; border-left: 1px solid; border-bottom: 1px solid;"><font size="1">{if !empty($value.tax_rate)}{$value.tax_rate}{else}0{/if}%</font></td>
+      {math assign="net_amount" equation='x/y' x=$value.subTotal y=$rate_1_unit_tax_currency} 
+      <td style="text-align:center; border-bottom: 1px solid;"><font size="1">{$net_amount|string_format:"%.2f"}</font></td>
+      {if !empty($value.tax_rate)}
+      {math assign="vat" equation='a*b/100' a=$net_amount b=$value.tax_rate}
+      <td style="text-align:center; border-right: 1px solid; border-bottom: 1px solid;"><font size="1">{$vat|string_format:"%.2f"}</font></td>
+      {else}<td style="text-align:center; border-right: 1px solid; border-bottom: 1px solid;"><font size="1">0.00</font></td>{/if}
+    </tr>
+    {/foreach}
+  </table>  
+{/if}

--- a/templates/CRM/Financeextras/MessageTemplate/SalesTaxConversionRateTable.tpl
+++ b/templates/CRM/Financeextras/MessageTemplate/SalesTaxConversionRateTable.tpl
@@ -1,6 +1,13 @@
-
 {if $showTaxConversionTable}
-  <table style="padding-top:10px;font-family: Arial, Verdana, sans-serif;" border="0" width="100%" cellpadding="8" cellspacing="0">
+  {assign var="widthPercentage" value="60%"}
+  {assign var="padding" value="10px"}
+{else}
+  {assign var="widthPercentage" value="73%"}
+  {assign var="padding" value="2px"}
+{/if}
+
+<table style="padding-top:{$padding};font-family: Arial, Verdana, sans-serif;" border="0" width="100%" cellpadding="8" cellspacing="0">
+  {if $showTaxConversionTable}
     <tr>
       <td style="text-align:left;font-weight:bold;width:60%"></td>
       <td colspan="3" style="border: 1px solid; border-bottom: 0px; font-weight: bold;"><font size="1">*{$sales_tax_currency} Equivalent Conversion</font></td>
@@ -27,5 +34,15 @@
       {else}<td style="text-align:center; border-right: 1px solid; border-bottom: 1px solid;"><font size="1">0.00</font></td>{/if}
     </tr>
     {/foreach}
-  </table>  
-{/if}
+      <tr>
+        <td style="text-align:left;font-weight:bold;width:60%"></td>
+        <td colspan="3" style="border-top: 1px solid;"></td>
+      </tr>
+    {/if}
+    {if $rate_vat_text}
+      <tr>
+        <td style="text-align:left; font-weight:bold; width:{$widthPercentage}"></td>
+        <td colspan="3" style="border-bottom: 0px; font-weight: bold;"><font size="1"> {$rate_vat_text}</font></td>
+      </tr>
+    {/if}
+  </table>

--- a/tests/phpunit/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplateTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplateTest.php
@@ -77,6 +77,11 @@ class InvoiceTemplateTest extends BaseHeadlessTest {
     $alterInvoiceParams = new \Civi\Financeextras\Hook\AlterMailParams\InvoiceTemplate($templateParams, '');
     $alterInvoiceParams->handle();
     unset($templateParams['tplParams']['id']);
+    //Remove other keys added by the hook
+    $remove = ['showTaxConversionTable', 'rate_1_unit_tax_currency',
+      'rate_1_unit_contribution_currency', 'sales_tax_currency', 'rate_vat_text',
+    ];
+    $templateParams['tplParams'] = array_diff_key($templateParams['tplParams'], array_flip($remove));
 
     $expectedParams = [
       'domain_organization' => 'testorg1',

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -57,7 +57,7 @@
       <is_search_range>0</is_search_range>
       <weight>1</weight>
       <is_active>1</is_active>
-      <is_view>0</is_view>
+      <is_view>1</is_view>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
@@ -76,7 +76,7 @@
       <is_search_range>0</is_search_range>
       <weight>65</weight>
       <is_active>1</is_active>
-      <is_view>0</is_view>
+      <is_view>1</is_view>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
@@ -94,7 +94,7 @@
       <is_search_range>0</is_search_range>
       <weight>66</weight>
       <is_active>1</is_active>
-      <is_view>0</is_view>
+      <is_view>1</is_view>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>


### PR DESCRIPTION
## Overview
This PR adds a new token `{contribution.tax_exchange_rate_table}`, which, when added to the contribution invoice template, will display the contribution exchange rate VAT table and VAT text.

## Before
_N/A_

## After
Adding the token to the contribution invoice template
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/c5ee329d-09f8-443d-82d6-b5b1bdbc0493)

The Exchange rate table being displayed
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/08e7ffe1-9917-4b77-af03-92a84efa07dd)

The Exchange rate table and VAT text are dispalyed
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/932610be-d7ca-484a-879c-49702be3c1fe)

