### PR TITLE
ESEB-69: Add VAT text custom field

### DIFF
--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -102,5 +102,31 @@
       <in_selector>0</in_selector>
       <custom_group_name>financeextras_currency_exchange_rates</custom_group_name>
     </CustomField>
+    <CustomField>
+      <name>vat_text</name>
+      <label>VAT Text</label>
+      <data_type>String</data_type>
+      <html_type>Select</html_type>
+      <is_required>0</is_required>
+      <is_searchable>1</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>67</weight>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>vat_text</column_name>
+      <in_selector>0</in_selector>
+      <option_group_name>vat_text_values</option_group_name>
+      <custom_group_name>financeextras_currency_exchange_rates</custom_group_name>
+    </CustomField>
   </CustomFields>
+  <OptionGroups>
+    <OptionGroup>
+      <name>vat_text_values</name>
+      <title>VAT Text Values</title>
+      <is_active>1</is_active>
+    </OptionGroup>
+  </OptionGroups>
 </CustomData>


### PR DESCRIPTION
## Overview
This PR adds VAT text custom field to the currency exchange rate custom group

## Before
<img width="719" alt="Screenshot 2023-11-09 at 09 53 11" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/64672fef-9fec-42e4-88b1-fd215c80512e">

## After
<img width="636" alt="Screenshot 2023-11-09 at 09 51 54" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/46976df7-e8a5-4d60-b904-583b7a8730c4">

