### PR TITLE
ESEB-66: Ensure the contribution invoice have the valid exchange rate table

### DIFF
--- a/CRM/Financeextras/Form/ExchangeRate/Settings.php
+++ b/CRM/Financeextras/Form/ExchangeRate/Settings.php
@@ -19,7 +19,7 @@ class CRM_Financeextras_Form_ExchangeRate_Settings extends CRM_Core_Form {
       ts('Display currency conversion for Tax on invoices')
     );
 
-    $this->addCurrency('sales_tax_currency', ts('Sales Tax Currency'), FALSE);
+    $this->addCurrency('sales_tax_currency', ts('Sales Tax Currency'));
 
     $this->addButtons([
       [

--- a/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php
+++ b/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php
@@ -34,6 +34,7 @@ class InvoiceTemplate {
   }
 
   private function addTaxConversionTable() {
+    $showTaxConversionTable = TRUE;
     $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addSelect(
         'financeextras_currency_exchange_rates.rate_1_unit_tax_currency',

--- a/Civi/Financeextras/Hook/PostProcess/LocalizationPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/LocalizationPostProcess.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Civi\Financeextras\Hook\PostProcess;
+
+class LocalizationPostProcess {
+
+  private $form;
+
+  public function __construct($form) {
+    $this->form = $form;
+  }
+
+  public function handle() {
+    $this->updateSalexTaxCurrencyField();
+  }
+
+  public function updateSalexTaxCurrencyField() {
+    \Civi\Api4\CustomField::update()
+      ->addValue('option_group_id.name', 'currencies_enabled')
+      ->addWhere('name', '=', 'sales_tax_currency')
+      ->execute();
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === "CRM_Admin_Form_Setting_Localization";
+  }
+
+}

--- a/Civi/Financeextras/Hook/PostProcess/UpdateContributionExchangeRate.php
+++ b/Civi/Financeextras/Hook/PostProcess/UpdateContributionExchangeRate.php
@@ -32,7 +32,7 @@ class UpdateContributionExchangeRate {
     }
 
     $exchangeRate = \Civi\Api4\ExchangeRate::get(FALSE)
-      ->addOrderBy('exchange_date', 'ASC')
+      ->addOrderBy('exchange_date', 'DESC')
       ->addWhere('base_currency', '=', $salesTaxCurrency)
       ->addWhere('exchange_date', '<', $contribution['receive_date'])
       ->addWhere('conversion_currency', '=', $contribution['currency'])

--- a/financeextras.php
+++ b/financeextras.php
@@ -215,6 +215,7 @@ function financeextras_civicrm_validateForm($formName, &$fields, &$files, &$form
 function financeextras_civicrm_postProcess($formName, $form) {
   $hooks = [
     \Civi\Financeextras\Hook\PostProcess\ParticipantPostProcess::class,
+    \Civi\Financeextras\Hook\PostProcess\LocalizationPostProcess::class,
     \Civi\Financeextras\Hook\PostProcess\ContributionPostProcess::class,
     \Civi\Financeextras\Hook\PostProcess\AdditionalPaymentPostProcess::class,
     \Civi\Financeextras\Hook\PostProcess\FinancialBatchPostProcess::class,


### PR DESCRIPTION
## Overview
This PR introduces multiple fixes to ensure the contribution invoice has a valid exchange rate table
- [Ensure sales tax currency option group ID is always up to date](https://github.com/compucorp/io.compuco.financeextras/commit/9e32e5d7e05c299da3a8a3c35f26fe6ca7ce28d1)
- [Ensure the user cannot save empty tax currency settings](https://github.com/compucorp/io.compuco.financeextras/commit/68b390d9357dd0165ccb30a1c69cc66a032b6924)
- [Ensure tax conversion table is displayed](https://github.com/compucorp/io.compuco.financeextras/commit/917e421e88d639e095e8b5253b7e159070338a2a)
- [Use most recent exchange rate](https://github.com/compucorp/io.compuco.financeextras/commit/682e11a99ae026481b3b57297b2f29dea5297ec4)


## Before
The exchange rate on the invoice is not correct, and the sales tax currency is not set.
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/72945cc6-0874-4dfe-b752-94e826d471db)


## After
The exchange rate on the invoice is correct, and the sales tax currency is set.
<img width="774" alt="Screenshot 2023-11-17 at 15 15 58" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/aa665910-4f6b-4e4d-816d-423ba59223dd">

