### PR TITLE
COMCL-431: Show payment method field for payment plan memberships

### DIFF
--- a/js/modifyMemberForm.js
+++ b/js/modifyMemberForm.js
@@ -96,8 +96,9 @@ CRM.$(function ($) {
 
   function hidePaymentFieldsOnPaymentToggler() {
     $('li[data-selector="payment_plan"]').click( () => {
-      $('tr.record_payment-block_row').hide()
+      $('tr.record_payment-block_row').show()
       $('div.record_payment-block_check').hide();
+      $('tr.crm-contribution-form-block-financeextras_record_payment_amount').hide();
     });
 
     $('li[data-selector="contribution"]').click( () => {


### PR DESCRIPTION
## Before

As part of the work we did here: 

https://github.com/compucorp/io.compuco.financeextras/pull/58

we no longer show the payment method and some of the payment related fields unless the user clicks on the "Record Payment" option, which is an option that is only added for non payment plan memberships:


https://github.com/compucorp/io.compuco.financeextras/assets/6275540/b026cfe9-6bb3-4226-a634-b104584322e2


But apparently the work in the PR above also affected the payment plan screen which used to show the payment method field, given without it the user cannot create [manual direct debit](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit) payment plans. 


## After


The Payment method field now shows up if the user selects the "payment plan" option on the membership creation form:

https://github.com/compucorp/io.compuco.financeextras/assets/6275540/31d7a17d-73dc-4ed5-bb13-851dcbc1e90b

