### PR TITLE
CIWEMB-519: Fix Credit Note Allocation Table Alignment

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.html
@@ -27,18 +27,18 @@
        <th ng-if="isUpdate"></th>
      </tr>
      <tr ng-repeat="allocation in allocations track by $index">
-      <td>{{ allocation['type_id:label'] }}</td>
-      <td>
-        <a 
+      <td class="allocation-cell">{{ allocation['type_id:label'] }}</td>
+      <td class="allocation-cell">
+        <a
           ng-href="{{crmUrl('civicrm/contact/view/contribution', {reset:1, id:allocation.contribution_id, action:'view'})}}">
             {{ (allocation['contribution_id.invoice_number']) || allocation['contribution_id']  }}
         </a>
       </td>
-      <td>{{ formatDate(allocation['date'], 'dd-M-yy') }}</td>
-      <td>{{ allocation['reference'] }}</td>
-      <td>{{ allocation['paid_from'] }}</td>
-      <td>{{ formatMoney(allocation['amount'], currency, true) }}</td>
-      <td ng-if="isUpdate && allocation['type_id:label'] == 'Invoice'">
+      <td class="allocation-cell">{{ formatDate(allocation['date'], 'dd-M-yy') }}</td>
+      <td class="allocation-cell">{{ allocation['reference'] }}</td>
+      <td class="allocation-cell">{{ allocation['paid_from'] }}</td>
+      <td class="allocation-cell">{{ formatMoney(allocation['amount'], currency, true) }}</td>
+      <td class="allocation-cell" ng-if="isUpdate && allocation['type_id:label'] == 'Invoice'">
         <div class="btn-group btn-group-sm">
           <button
             type="button"
@@ -76,3 +76,9 @@
     </div>
   </div>
 </div>
+
+<style>
+  #creditnote__view .table>tbody>tr>td.allocation-cell {
+    padding-left: 20px;
+  }
+</style>


### PR DESCRIPTION
## Overview
Align credit note allocation table rows with header.

## Before
![6d3df9f7-6e10-468a-8417-ffa25880e61c](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/3a0fcbc9-c326-4084-8927-584c52f9b237)


## After
![Screenshot from 2023-12-08 16-50-37](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/dc425592-77c7-4f32-998c-b053775bd3b8)
