### PR TITLE
CIWEMB-569: Add Credit Note Tokens

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteEmail.php
@@ -54,7 +54,7 @@ class CRM_Financeextras_Form_Contribute_CreditNoteEmail extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function listTokens() {
-    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contactId']]);
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contactId'], 'creditNoteId' => $this->creditNoteId]);
     $tokens = $tokenProcessor->listTokens();
 
     return $tokens;

--- a/Civi/Financeextras/Token/CreditNote.php
+++ b/Civi/Financeextras/Token/CreditNote.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Civi\Financeextras\Token;
+
+use Civi\Token\Event\TokenValueEvent;
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenRow;
+
+/**
+ * Class CRM_Financeextras_Token_CreditNote
+ *
+ * Generate "credit_note.*" tokens.
+ *
+ * This class defines tokens for credit note fields.
+ */
+class CreditNote extends AbstractTokenSubscriber {
+
+  private const TOKEN = 'creditNote';
+
+  /**
+   * Class constructor.
+   */
+  public function __construct() {
+    parent::__construct('creditNote', $this->geTokens());
+  }
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.token.list' => 'registerTokens',
+      'civi.token.eval' => 'evaluateTokens',
+    ];
+  }
+
+  /**
+   * Determine whether this token-handler should be used with
+   * the given processor.
+   *
+   * @param \Civi\Token\TokenProcessor $processor
+   * @return bool
+   */
+  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+    $creditNoteId = $processor->getContextValues('creditNoteId');
+
+    return is_array($creditNoteId) && count($creditNoteId) === 1;
+  }
+
+  /**
+   * To perform a bulk lookup before rendering tokens
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return mixed
+   */
+  public function prefetch(TokenValueEvent $e): array {
+    $creditNoteId = $e->getTokenProcessor()->getContextValues('creditNoteId');
+    $resolvedTokens = [];
+
+    try {
+      if (is_array($creditNoteId) && count($creditNoteId) === 1) {
+        $creditNoteId = $creditNoteId[0];
+        $creditNote = CRM_Financeextras_BAO_CreditNote::findById($creditNoteId);
+
+        if (empty($creditNote)) {
+          return $resolvedTokens;
+        }
+
+        $resolvedTokens = array_merge($this->geTokens(), (array) $creditNote);
+      }
+    }
+    catch (Exception $e) {
+      CRM_Core_Session::setStatus('Error resolving credit note tokens');
+    }
+
+    return $resolvedTokens;
+  }
+
+  /**
+   * Evaluate the content of a single token.
+   *
+   * @param \Civi\Token\TokenRow $row
+   *   The record for which we want token values.
+   * @param string $entity
+   *   The name of the token entity.
+   * @param string $field
+   *   The name of the token field.
+   * @param mixed $prefetch
+   *   Any data that was returned by the prefetch().
+   */
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL): void {
+    $value = CRM_Utils_Array::value($field, $prefetch);
+    $prefix = CRM_Utils_String::munge(self::TOKEN);
+
+    if ($value) {
+      $row->format('text/plain')->tokens($prefix, $field, $value);
+      $row->format('text/html')->tokens($prefix, $field, $value);
+    }
+  }
+
+  private function geTokens(): array {
+    return [
+      'id' => 'Credit Note Id',
+      'contact_id' => 'Credit Note Contact Id',
+      'cn_number' => 'Credit Note Number',
+      'date' => 'Credit Note Date',
+      'reference' => 'Credit Note Reference',
+      'currency' => 'Credit Note Currency',
+      'description' => 'Credit Note Description',
+      'comment' => 'Credit Note Comment',
+      'subtotal' => 'Credit Note Sub Total',
+      'sales_tax' => 'Credit Note Sales Tax',
+      'total_credit' => 'Credit Note Total Credit',
+    ];
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -22,6 +22,7 @@ function financeextras_civicrm_config(&$config) {
   Civi::dispatcher()->addListener('fe.contribution.received_payment', ['\Civi\Financeextras\Event\Listener\ContributionPaymentUpdatedListener', 'handle']);
   Civi::dispatcher()->addListener('civi.api.prepare', ['Civi\Financeextras\APIWrapper\BatchListPage', 'preApiCall']);
   Civi::dispatcher()->addListener('civi.token.list', 'financeextras_register_tokens');
+  Civi::dispatcher()->addSubscriber(new Civi\Financeextras\Token\CreditNote());
 }
 
 /**


### PR DESCRIPTION
## Overview
This pr adds credit note tokens while emailing the credit note.

## Before
There were no credit note tokens to be used in subject or body of the email.

## After
![Screenshot from 2023-12-12 14-44-40](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/5e465e09-af5e-447c-9324-b56d6309cfbd)
