### PR TITLE
CIWEMB-518 Adapt Refund Credit Note Form

### DIFF
--- a/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
+++ b/CRM/Financeextras/Form/Contribute/CreditNoteRefund.php
@@ -54,8 +54,8 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
         ],
       ],
       'readonly' => TRUE,
-      'class' => 'form-control',
-    ], TRUE);
+      'class' => 'form-control disabled',
+    ], TRUE, ['disabled' => TRUE]);
 
     $this->add(
       'select',
@@ -94,7 +94,11 @@ class CRM_Financeextras_Form_Contribute_CreditNoteRefund extends CRM_Contribute_
       ts('Payment Method'),
       ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'create'),
       TRUE,
-      ['onChange' => "return showHideByValue('payment_instrument_id', '{$checkPaymentID}','checkNumber','table-row','select',false);", 'class' => 'form-control']
+      [
+        'onChange' => "return showHideByValue('payment_instrument_id', '{$checkPaymentID}','checkNumber','table-row','select',false);",
+        'class' => 'form-control',
+        'style' => '-webkit-appearance: auto',
+      ]
     );
 
     $this->add(

--- a/Civi/Financeextras/Hook/BuildForm/RefundCreditNotePaymentInformation.php
+++ b/Civi/Financeextras/Hook/BuildForm/RefundCreditNotePaymentInformation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi\Financeextras\Hook\BuildForm;
+
+class RefundCreditNotePaymentInformation {
+
+  /**
+   * @param \CRM_Financial_Form_Payment $form
+   */
+  public function __construct(private \CRM_Financial_Form_Payment $form) {
+  }
+
+  public function handle() {
+    if ($this->form->elementExists('check_number')) {
+      $element = $this->form->getElement('check_number');
+      $element->setLabel(ts('Cheque Number'));
+    }
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param \CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    return $formName === 'CRM_Financial_Form_Payment' && isset($_GET['formName']) && $_GET['formName'] === 'CreditNoteRefund';
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -244,6 +244,7 @@ function financeextras_civicrm_buildForm($formName, &$form) {
     \Civi\Financeextras\Hook\BuildForm\FinancialBatchSearch::class,
     \Civi\Financeextras\Hook\BuildForm\FinancialAccount::class,
     \Civi\Financeextras\Hook\BuildForm\AdditionalPaymentButton::class,
+    \Civi\Financeextras\Hook\BuildForm\RefundCreditNotePaymentInformation::class,
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr changes the following things in refund credit note form.

- Correct the label for cheque number field
- Disable the contact field
- Add arrow to the payment method dropdown

## Before
![Screenshot from 2023-12-13 17-59-05](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/5d6bacf7-e41a-45d0-b1e7-c8fcd10beb66)


## After
![Screenshot from 2023-12-13 17-58-43](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/d766737c-39bb-435b-b507-031ecf9b359c)
