### PR TITLE
COMCL-405: Ensure credit card contribution has correct total

### DIFF
--- a/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
@@ -16,6 +16,7 @@ class ContributionCreate {
   }
 
   public function handle() {
+    $this->updateTotalAmountFromLineTotal();
     $this->validatePaymentForm();
     $this->validateConsistentIncomeAccountOwners();
   }
@@ -24,6 +25,28 @@ class ContributionCreate {
     if (!empty($this->fields['fe_record_payment_check']) && empty($this->fields['fe_record_payment_amount'])) {
       $this->errors['fe_record_payment_amount'] = ts('Payment amount is required');
     }
+  }
+
+  /**
+   * Computes credit card contribution total from line items.
+   *
+   * Credit card contribution is unaware of the line items
+   * so it cant compute total value from them, `
+   * to avoid having empty total when line item is used,
+   * we manually set the contribution total to the line item total
+   * before form submission.
+   */
+  public function updateTotalAmountFromLineTotal() {
+    if ($this->form->_mode !== 'live') {
+      return;
+    }
+
+    $data = &$this->form->controller->container();
+    if (empty($this->fields['total_amount']) && !empty($this->fields['fe_record_payment_amount'])) {
+      $data = &$this->form->controller->container();
+      $data['values']['Contribution']['total_amount'] = $this->fields['fe_record_payment_amount'];
+    }
+
   }
 
   /**

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -11,6 +11,10 @@ const totalChanged = new CustomEvent("totalChanged", {});
       toggleRecordPaymentBlock();
       placePaymentFieldsTogether();
     }
+
+    if (mode == 'live') {
+      groupLivePaymentFields();
+    }
   })();
 
   function setTotalAmount() {
@@ -108,5 +112,11 @@ const totalChanged = new CustomEvent("totalChanged", {});
       text = text.replace('Automatically email a receipt for this payment to', 'Automatically email a confirmation of this transaction to')
       $('tr.crm-contribution-form-block-is_email_receipt .description').text(text)
     }
+  }
+
+  function groupLivePaymentFields() {
+    $('tr.crm-contribution-form-block-contribution_type_id').after(
+      $('tr.crm-contribution-form-block-financeextras_record_payment_amount').hide()
+    )
   }
 });


### PR DESCRIPTION
## Overview
This pull request addresses the issue of the credit card contribution total displaying zero. 

The problem arose due to the lack of explicit support for line items in the line item edit extension. Instead, users were expected to enter an amount in the total amount field. But, with this commit (https://github.com/compucorp/io.compuco.financeextras/commit/18810f80ea7cf95961f0108c0d90c438c4f98638), we have transitioned to using line items by default in the new contributions screen, and the total amount field hidden. in this pull request, the credit card contribution total amount  is now manually set based on the line item total.

## Before
The credit card contribution total amount was displaying as zero.
![Before Screenshot](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/1bb7a36e-2b6b-4a44-988e-024de119f50d)

## After
The credit card contribution total amount now reflects the correct value.
![After Screenshot](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/01d9883f-3e41-453c-90e8-5614b7e11b59)