### PR TITLE
CIWEMB-466: Prevent user from updating contribution financial_type

### DIFF
--- a/Civi/Financeextras/Hook/ValidateForm/ContributionEdit.php
+++ b/Civi/Financeextras/Hook/ValidateForm/ContributionEdit.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Civi\Financeextras\Hook\ValidateForm;
+
+class ContributionEdit {
+
+  /**
+   * @param \CRM_Contribute_Form_Contribution $form
+   * @param array $fields
+   * @param array $errors
+   * @param string $formName
+   */
+  public function __construct(private \CRM_Contribute_Form_Contribution $form, private array &$fields, private array &$errors, private string $formName) {
+  }
+
+  public function handle() {
+    $this->validateFinancialTypeUpdate();
+  }
+
+  public function validateFinancialTypeUpdate() {
+    $contributionId = $this->form->_id;
+    if (!empty($this->fields['financial_type_id'])) {
+      $oldFinancialTypeId = \CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'financial_type_id');
+      if ($oldFinancialTypeId == $this->fields['financial_type_id']) {
+        return;
+      }
+
+      $this->errors['financial_type_id'] = 'One or more line items have a different financial type than the contribution. Editing the financial type is not yet supported in this situation.';
+    }
+  }
+
+  /**
+   * Checks if the hook should run.
+   *
+   * @param CRM_Core_Form $form
+   * @param string $formName
+   *
+   * @return bool
+   */
+  public static function shouldHandle($form, $formName) {
+    $isUpdate = ($form->getAction() & \CRM_Core_Action::UPDATE);
+    return $formName === "CRM_Contribute_Form_Contribution" && $isUpdate;
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -197,6 +197,7 @@ function financeextras_civicrm_fieldOptions($entity, $field, &$options, $params)
 function financeextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   $hooks = [
     \Civi\Financeextras\Hook\ValidateForm\MembershipCreate::class,
+    \Civi\Financeextras\Hook\ValidateForm\ContributionEdit::class,
     \Civi\Financeextras\Hook\ValidateForm\ContributionCreate::class,
     \Civi\Financeextras\Hook\ValidateForm\OwnerOrganizationValidator::class,
     \Civi\Financeextras\Hook\ValidateForm\PriceSetValidator::class,


### PR DESCRIPTION
## Overview
This PR prevents the user from updating the financial type of a contribution, we are doing this because when a contribution financial type is changed on edit the contribution is likely to have incorrect tax calculations.

This happens because on edit the core gets tax of the new financial type and adds it to the contribution total. these validation already exist for contributions with multiple line items https://github.com/civicrm/civicrm-core/blob/42cb6102f3ed25cf9d2438ca8eeb815c3a04f9eb/CRM/Contribute/BAO/Contribution.php#L3681, this PR extends this check to a single line item.

## Before
![gggggg](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/037a24a8-c110-4e4d-9eb2-b54a0464ae86)


## After
![ggggkkkgg](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/36b71d30-2705-42c7-bb92-05b188e902e1)



