### PR TITLE
CIWEMB-583: Hide CreditNote and AccountReceivable payment_methods

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -127,4 +127,14 @@ class CRM_Financeextras_Upgrader extends CRM_Financeextras_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_10002() {
+    \Civi\Api4\OptionValue::update(FALSE)
+      ->addValue('filter', 1)
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->addWhere('name', 'IN', ['credit_note', 'accounts_receivable'])
+      ->execute();
+
+    return TRUE;
+  }
+
 }

--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -28,6 +28,7 @@ class AccountsReceivablePaymentMethod extends AbstractManager {
         'financial_account_id' => $accountsReceivableFinancialAccountId,
         'is_reserved' => 1,
         'is_active' => 1,
+        'filter' => 1,
       ]);
     }
   }

--- a/Civi/Financeextras/Setup/Manage/CreditNotePaymentInstrumentManager.php
+++ b/Civi/Financeextras/Setup/Manage/CreditNotePaymentInstrumentManager.php
@@ -17,6 +17,7 @@ class CreditNotePaymentInstrumentManager extends AbstractManager {
       'name' => "credit_note",
       'is_active' => TRUE,
       'is_reserved' => TRUE,
+      'filter' => 1,
       'financial_account_id' => $this->getFinancialAccount(),
     ];
     \CRM_Core_BAO_OptionValue::ensureOptionValueExists($paymentInstrument);


### PR DESCRIPTION
## Overview
In this PR we set the `filter` field value of credit_note and account_receivable payment to `1`, this will hide them form CiviCRM contribution create and add record payment screen.