### PR TITLE
CIWEMB-580: Support credit allocation to completed contribution

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -43,6 +43,10 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       $allocation = self::create($data)->toArray();
 
       self::createAccountingEntries($allocation['id'], $data['credit_note_id'], $data['contribution_id'], $data['amount']);
+
+      if (!empty($allocation['contribution_id'])) {
+        \Civi::dispatcher()->dispatch(ContributionPaymentUpdatedEvent::NAME, new ContributionPaymentUpdatedEvent($allocation['contribution_id']));
+      }
     }
     catch (\Throwable $th) {
       $transaction->rollback();

--- a/templates/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CreditNoteAllocate.tpl
@@ -7,7 +7,19 @@
           <table class="table">
             <tbody>
               <tr>
-                <th><p>{ts}Remaining credit available to allocate{/ts}</p></th><td><p>{$creditNote.remaining_credit|crmMoney:$creditNote.currency}</p></td>
+                <th><p>{ts}Remaining Credit Balance to Allocate{/ts}</p></th><td><p>{$creditNote.remaining_credit|crmMoney:$creditNote.currency}</p></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="row" style="margin: 2em 0em;">
+        <div class="col-md-10">
+          <table class="table">
+            <tbody>
+              <tr>
+                <th><p>{ts}Include Completed Contributions{/ts} <span style="margin-left: 1em;">{$form.incl_completed.html}</span></p></th>
               </tr>
             </tbody>
           </table>
@@ -15,7 +27,7 @@
       </div>
 
 
-      <div class="row">
+      <div class="row" style="margin: 2em 0em;">
         <div class="col-md-10">
           <table class="table">
             <thead>
@@ -49,3 +61,28 @@
   </div>
   </div>
 </div>
+
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    const url = new URLSearchParams(window.location.search);
+    if (parseInt(url.get('completed_contribution')) == 1) {
+      $('#incl_completed_1').prop('checked', true)
+    }
+    let isChecked = $('#incl_completed_1').is(':checked');
+
+    function reloadPage(completedValue) {
+      const url = new URLSearchParams(window.location.search);
+      url.set('completed_contribution', completedValue)
+      window.location.href = window.location.origin + window.location.pathname + '?' + url.toString();
+    }
+
+    $('#incl_completed_1').change(function() {
+      isChecked = $(this).is(':checked');
+
+      // Reload the page with the appropriate completed_contribution value
+      reloadPage(isChecked ? 1 : 0);
+    });
+  });
+  {/literal}
+</script>


### PR DESCRIPTION
## Overview
This PR allows the user to allocate credit to a completed(fully paid) contribution

## Before
Completed contributions do not appear in the credit allocation screen, hence users are not able to allocate credit to them.
![lqwerrr](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/a6e893b3-87ff-402c-96f5-e6e3134f2d8e)


## After
With this PR, the user can allocate credit to completed contributions in the credit allocation screen.
![asaaa](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/2bda1242-a0e3-4d81-93d3-cbeaff4e0dc2)
