### PR TITLE
MAE-1105: Fix Contribution Bug

### DIFF
--- a/Civi/Financeextras/Refund/PaymentProcessor.php
+++ b/Civi/Financeextras/Refund/PaymentProcessor.php
@@ -48,7 +48,7 @@ class PaymentProcessor {
       $refundProcessorIDs = [];
       foreach ($processors as $processor) {
         $processor = \Civi\Payment\System::singleton()->getById($processor['id']);
-        if ($processor->supportsRefund()) {
+        if ($processor !== NULL && $processor->supportsRefund()) {
           $refundProcessorIDs[] = $processor->getID();
         }
       }


### PR DESCRIPTION
## Overview
This pr fixes a code glitch which caused any contribution page to error out.
## Before
[screencast-myisrael.civiplus.net-2024.01.29-08_49_49.webm](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/c1d52f94-7db5-4f28-8157-d2dd3e9fe82a)

## After
<img width="1792" alt="Screenshot 2024-01-31 at 11 50 30 AM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/4e738c44-f936-4e73-9b39-c28ea1c8be60">

## Technical Details
The issue occurred due to a bug in code as we were treating a processor variable as object but it can be null as well if the class name in the database for a processor does not fully match the class name for processor in code 