### PR TITLE
MAE-1061: Avoid Loading Membership Plan Settings In Submit Credit Card Membership Form

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/MembershipCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/MembershipCreate.php
@@ -69,7 +69,7 @@ class MembershipCreate {
    * @return bool
    */
   public static function shouldHandle($form, $formName) {
-    return $formName === "CRM_Member_Form_Membership" && ($form->getAction() & \CRM_Core_Action::ADD);
+    return $formName === "CRM_Member_Form_Membership" && $form->_mode !== 'live' && ($form->getAction() & \CRM_Core_Action::ADD);
   }
 
 }


### PR DESCRIPTION
## Overview
This PR avoids unnecessarily loading payment plan settings for submit credit card membership form.

## Before
![MAE-1047 - Member-Event payment](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/2392ccf1-fe7c-47ba-bc4e-28aedccbdcdf)


## After
<img width="1792" alt="Screenshot 2024-02-14 at 6 05 26 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/6d8975f6-126a-4c7c-88e2-a33351ccdcd7">

## Technical Details
In this [PR] (https://github.com/compucorp/io.compuco.financeextras/pull/58)we added the ability to create a membership without a payment, and there it was assumed that `contribution_type_toggle`
input that allows selecting between a contribution or a payment plan is there, but that is not the case for "Submit membership with credit card"
form, given we never supported payment plans on such form before:
https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/6.1.0/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php#L47-L48

so this broke the JS code which in effect resulted in breaking the UI.


In general the ability to select between a free membership and paid membership is not important for memberships that are to be created using "Submit membership with credit card" given paying by credit card already implies there is a payment, so the fix here is just to not load this code that adds the option to select between the free or paid membership for such form, which we can easily tell by looking at the $form->_mode, given it will be = "live" only on the "Submit membership with credit card" form (because both the standard membership form and this form have the same name, so we can only rely on the _mode variable to tell the difference )
