### PR TITLE
PROD-156: Create creditnote allocation for credit card refund

### DIFF
--- a/templates/CRM/Financeextras/Form/Payment/Refund.hlp
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.hlp
@@ -1,0 +1,3 @@
+{htxt id="create_credit_note"}
+  {ts}By checking the box the system will automatically create a credit note equal to the amount of the refund (applied pro-rata against each of the line items on the contribution) and apply the credit to this contribution, thus reducing the amount due to you. If you do not check the box the contact will continue to owe the original amount. You can always create a credit note manually if you do not enable this option.{/ts}
+{/htxt}

--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -54,6 +54,11 @@
     <td class="label">{$form.reason.label}</td>
     <td>{$form.reason.html}</td>
   </tr>
+
+  <tr class="crm-payment-refund-form-block-reason">
+    <td class="label">{$form.create_credit_note.html}</td>
+    <td>{$form.create_credit_note.label} {help id="create_credit_note" file="CRM/Financeextras/Form/Payment/Refund.hlp"}</td>
+  </tr>
 </table>
 <div class="crm-submit-buttons">
   {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Financeextras/Form/Payment/Refund.tpl
+++ b/templates/CRM/Financeextras/Form/Payment/Refund.tpl
@@ -64,3 +64,13 @@
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 </div>
+
+<script type="text/javascript">
+  {literal}
+    CRM.$(function($) {
+      $("a[target='crm-popup']").on('crmPopupFormSuccess', function (e) {
+        CRM.refreshParent(e);
+      });
+    });
+  {/literal}
+</script>


### PR DESCRIPTION
## Overview
Allow users to create credit notes and allocate the credit notes to the contribution while submitting a credit card refund

## Before
There is no option for the user to create a credit note for a credit card refund

## After
Users can now create a credit note for a credit card refund

![3211wwwww](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/502bd8c7-046a-41a6-9350-abd733e966ee)

A credit note is created and allocation is made again to that same contribution
