### PR TITLE
COMCL-474: Fix Contribution Status Field Bug

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -29,6 +29,10 @@ class ContributionCreate {
    */
   private function preventUserFromSettingContributionStatus() {
     try {
+      if (!$this->form->elementExists(('contribution_status_id'))) {
+        return;
+      }
+
       $statusElement = $this->form->getElement('contribution_status_id');
       if (!$this->isEdit()) {
         // By default new contribution will have a pending status
@@ -134,7 +138,7 @@ class ContributionCreate {
    */
   public static function shouldHandle($form, $formName) {
     $addOrUpdate = ($form->getAction() & CRM_Core_Action::ADD) || ($form->getAction() & CRM_Core_Action::UPDATE);
-    return $formName === "CRM_Contribute_Form_Contribution" &&  $addOrUpdate;
+    return $formName === "CRM_Contribute_Form_Contribution" && $addOrUpdate;
   }
 
 }


### PR DESCRIPTION
## Overview
This pr fixes a bug in updation of contribution form due to which the form kept on saving forever. 

## Before
![COMCL-474-2](https://github.com/compucorp/io.compuco.financeextras/assets/147053234/2430e00b-1310-4c86-a848-430648c17ae5)


## After
The form is being updated successfully.

## Technical Details
The Civi/Financeextras/Hook/BuildForm/ContributionCreate.php hook was trying to modify the status field on contribution form but the field was non existent. So a check has been added to modify the field only when field is available in the form.