### PR TITLE
PROD-173: Use account receivable as creditnote payment instrument

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -2,6 +2,7 @@
 
 use Civi\Financeextras\Utils\OptionValueUtils;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
+use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod;
 use CRM_Financeextras_BAO_CreditNoteAllocation as CreditNoteAllocationBAO;
 use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager as CreditNoteStatus;
 
@@ -181,7 +182,7 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
       'is_payment' => $data['is_payment'] ?? 0,
       'status_id' => $statusId,
       'payment_processor_id' => NULL,
-      'payment_instrument_id' => $data['payment_instrument_id'] ?? 1,
+      'payment_instrument_id' => $data['payment_instrument_id'] ?? self::getAccountReceivableId(),
       'card_type_id' => $data['card_type_id'] ?? NULL,
       'check_number' => $data['check_number'] ?? NULL,
       'pan_truncation' => $data['pan_truncation'] ?? NULL,
@@ -191,6 +192,16 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
       'entity_id' => $data['id'],
     ];
     return \CRM_Core_BAO_FinancialTrxn::create($trxnParams)->toArray();
+  }
+
+  /**
+   * Returns the account receivable payment method ID
+   *
+   * @return int
+   *   Account receivable ID
+   */
+  private static function getAccountReceivableId() {
+    return OptionValueUtils::getValueForOptionValue('payment_instrument', AccountsReceivablePaymentMethod::NAME);
   }
 
   /**

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
@@ -1,9 +1,10 @@
 <?php
 
-use Civi\Api4\CreditNoteLine;
 use Civi\Api4\CreditNote;
+use Civi\Api4\CreditNoteLine;
 use Civi\Financeextras\Test\Helper\CreditNoteTrait;
 use CRM_Financeextras_BAO_CreditNote as CreditNoteBAO;
+use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod;
 
 /**
  * CreditNote.CreditNoteSaveAction API Test Case.
@@ -160,7 +161,7 @@ class Civi_Api4_CreditNote_CreditNoteSaveActionTest extends BaseHeadlessTest {
       ->addWhere('total_amount', '=', $creditNote['total_credit'] * -1)
       ->addWhere('status_id:name', '=', 'Pending')
       ->addWhere('payment_processor_id', 'IS NULL')
-      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('payment_instrument_id:name', '=', AccountsReceivablePaymentMethod::NAME)
       ->addWhere('check_number', 'IS NULL')
       ->addWhere('currency', '=', $creditNote['currency'])
       ->addWhere('to_financial_account_id', '=', $expectedToAccount)

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
@@ -3,8 +3,9 @@
 use Civi\Api4\CreditNote;
 use Civi\Financeextras\Utils\OptionValueUtils;
 use Civi\Financeextras\Test\Helper\CreditNoteTrait;
-use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
 use Civi\Financeextras\Utils\FinancialAccountUtils;
+use Civi\Financeextras\Setup\Manage\CreditNoteStatusManager;
+use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod;
 
 /**
  * CreditNote.VoidAction API Test Case.
@@ -102,7 +103,7 @@ class Civi_Api4_CreditNote_VoidActionTest extends BaseHeadlessTest {
       ->addWhere('total_amount', '=', $creditNote['total_credit'])
       ->addWhere('status_id:name', '=', 'Cancelled')
       ->addWhere('payment_processor_id', 'IS NULL')
-      ->addWhere('payment_instrument_id', '=', 1)
+      ->addWhere('payment_instrument_id:name', '=', AccountsReceivablePaymentMethod::NAME)
       ->addWhere('check_number', 'IS NULL')
       ->addWhere('currency', '=', $creditNote['currency'])
       ->addWhere('to_financial_account_id', '=', $expectedToAccount)


### PR DESCRIPTION
## Overview
This PR ensures payment method for accounting entries when creating credit notes is “Accounts Receivable”

## Before
The payment method for a credit note uses the ID 1 -> which is credit_card on most default installation

```
  {
    "id": 671,
    "total_amount": -48,
    "payment_instrument_id:name": "Credit Card"
  },
```

## After
The payment method for a credit note is now "Account Receivable"
```
  {
    "id": 672,
    "total_amount": -240,
    "payment_instrument_id:name": "accounts_receivable"
  },

```
