### PR TITLE
COMCL-488: Fix Extension Upgrade

### DIFF
--- a/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
+++ b/Civi/Financeextras/Setup/Manage/AccountsReceivablePaymentMethod.php
@@ -15,17 +15,17 @@ class AccountsReceivablePaymentMethod extends AbstractManager {
   const TITLE = 'Accounts Receivable';
 
   public function create(): void {
-    $accountsReceivableFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
-      'return' => 'id',
-      'name' => self::TITLE,
-    ]);
+    $financialAccountId = $this->getAccountIdForAccountsReceivablePaymentMethod();
+    if ($financialAccountId === 0) {
+      throw new \Exception('Could not find a financial account to use with account receivable payment method.');
+    }
 
     if (empty($this->getAccountsReceivablePaymentMethodId())) {
       civicrm_api3('OptionValue', 'create', [
         'option_group_id' => 'payment_instrument',
         'label' => self::TITLE,
         'name' => self::NAME,
-        'financial_account_id' => $accountsReceivableFinancialAccountId,
+        'financial_account_id' => $financialAccountId,
         'is_reserved' => 1,
         'is_active' => 1,
       ]);
@@ -61,6 +61,38 @@ class AccountsReceivablePaymentMethod extends AbstractManager {
     }
 
     return NULL;
+  }
+
+  private function getAccountIdForAccountsReceivablePaymentMethod(): int {
+    try {
+      $financialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
+        'return' => 'id',
+        'name' => self::TITLE,
+      ]);
+
+      return $financialAccountId;
+    }
+    catch (\Throwable $e) {
+      $financialAccountId = 0;
+
+      $financialAccounts = \Civi\Api4\FinancialAccount::get(FALSE)
+        ->addWhere('financial_account_type_id:name', '=', 'Asset')
+        ->execute()
+        ->getArrayCopy();
+
+      if (empty($financialAccounts)) {
+        return $financialAccountId;
+      }
+
+      foreach ($financialAccounts as $financialAccount) {
+        if ((int) $financialAccount['is_default'] === 1) {
+          $financialAccountId = $financialAccount['id'];
+          break;
+        }
+      }
+
+      return (int) ($financialAccountId > 0 ? $financialAccountId : $financialAccounts[0]['id']);
+    }
   }
 
 }


### PR DESCRIPTION
## Overview

The "Accounts Receivable" financial account is not a reserved one, yet in this PR (https://github.com/compucorp/io.compuco.financeextras/pull/109/files), we relied on its existence to create the new "Account Receivable" payment method. As with any other payment method in Civi, it should be linked to a financial account. We decided to attach it to the "Accounts Receivable" financial account. This results in a failure in either the extension installation or upgrade if it happens on a CiviCRM site that does not have the "Accounts Receivable" financial account.

This pr aims to change that code to following logic 

Rather than hard coding and just sticking to use the “Accounts Receivable” financial account for creation of **Account receivable** payment method:

- We first try and use Accounts Receivable” financial account, if this does not exist then
- We use the Financial Account of financial_account_type = ASSET and is_default = yes.
- If this also does not exist then just use the first Financial Account of financial_account_type = ASSET

