### PR TITLE
CIWEMB-570: Hide Credit Note Create Button

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -78,7 +78,7 @@ class ContributionCreate {
   }
 
   private function addCreditNoteCancelAction() {
-    if (!$this->form->_id) {
+    if (!$this->form->_id || $this->contributionHasStatus(['Cancelled', 'Refunded', 'Failed', 'Chargeback'])) {
       return;
     }
 
@@ -126,6 +126,25 @@ class ContributionCreate {
       \Civi::resources()->addVars('financeextras', ['contrib_currency' => $contribution['currency']]);
       \Civi::resources()->addVars('financeextras', ['contrib_total' => $total]);
     }
+  }
+
+  /**
+   * Checks contribution has any of the given statuses.
+   *
+   * @return bool
+   *   Whether the contribution has any of the given statuses.
+   *
+   * @throws \Civi\API\Exception
+   */
+  private function contributionHasStatus($statuses) {
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
+      ->addWhere('id', '=', $this->form->_id)
+      ->addWhere('contribution_status_id:name', 'IN', $statuses)
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    return !empty($contribution);
   }
 
   /**

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -20,7 +20,7 @@ class ContributionView {
   }
 
   private function addCreditNoteCancelAction() {
-    if (!$this->id || $this->isContributionCancelled()) {
+    if (!$this->id || $this->contributionHasStatus(['Cancelled', 'Refunded', 'Failed', 'Chargeback'])) {
       return;
     }
 
@@ -35,17 +35,17 @@ class ContributionView {
   }
 
   /**
-   * Checks contribution has been cancelled.
+   * Checks contribution has any of the given statuses.
    *
    * @return bool
-   *   Array with recurring contribution's data.
+   *   Whether the contribution has any of the given statuses.
    *
    * @throws \Civi\API\Exception
    */
-  private function isContributionCancelled() {
+  private function contributionHasStatus($statuses) {
     $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('id', '=', $this->id)
-      ->addWhere('contribution_status_id:name', '=', 'Cancelled')
+      ->addWhere('contribution_status_id:name', 'IN', $statuses)
       ->setLimit(1)
       ->execute()
       ->first();


### PR DESCRIPTION
## Overview
If contribution has a status of Cancelled, Refunded, Failed or Chargeback then this pr hides the credit note create button from edit and view contribution screens.

## Before
<img width="1792" alt="Screenshot 2024-03-12 at 2 45 50 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/e4ff33e8-c2c3-4f93-947c-b80d3a7aa76f">
<img width="1792" alt="Screenshot 2024-03-12 at 2 46 10 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/d53862cf-f394-42b0-9632-22a31fe9a206">



## After

<img width="1792" alt="Screenshot 2024-03-12 at 2 53 23 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/d34c541f-b331-4647-83d5-03600661f199">
<img width="1792" alt="Screenshot 2024-03-12 at 2 53 30 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/1a4ce860-d0ea-469b-a6d1-2367d75fc368">
