### PR TITLE
PROD-155: Cree accounting entries for refund fee

### DIFF
--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -190,6 +190,8 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
       'fee_amount' => $data['fee_amount'] ?? NULL,
       'entity_table' => \CRM_Financeextras_DAO_CreditNote::$_tableName,
       'entity_id' => $data['id'],
+      'net_amount' => $data['net_amount'] ?? NULL,
+
     ];
     return \CRM_Core_BAO_FinancialTrxn::create($trxnParams)->toArray();
   }
@@ -305,10 +307,15 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
       throw new CRM_Core_Exception("Amount to be refunded cannot exceed the remaining credit");
     }
     $financialTrxn = self::createRefundAccountingEntries($creditNote, array_merge($allocationParam, $paymentParam));
+
+    $feeFinancialTrxnId = NULL;
+    if (!empty($paymentParam['fee_amount'])) {
+      $feeFinancialTrxnId = self::createFeeAccountingEntries($creditNote, array_merge($allocationParam, $paymentParam))['id'];
+    }
     $allocation = self::createRefundAllocation($creditNote, $allocationParam);
     CreditNoteAllocationBAO::createAllocationEntityTransactions($allocation['id'], $financialTrxn['id'], -$allocationParam['amount']);
 
-    return array_merge($allocation, ['financial_trxn_id' => $financialTrxn['id']]);
+    return array_merge($allocation, ['financial_trxn_id' => $financialTrxn['id'], 'fee_financial_trxn_id' => $feeFinancialTrxnId]);
   }
 
   private static function createRefundAllocation(array $creditNote, array $data) {
@@ -329,6 +336,7 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
     $data['from_account_id'] = FinancialAccountUtils::getFinancialTypeAccount($financialTypeId, 'Accounts Receivable Account is');
     $data['to_account_id'] = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($data['payment_instrument_id']);
     $data['is_payment'] = 1;
+    $data['net_amount'] = $data['total_credit'] - ($data['fee_amount'] ?? 0);
     $financialTrxn = self::createAccountingEntries($data, 'Completed');
 
     $percent = 100 * $data['amount'] / $creditNote['total_credit'];
@@ -339,6 +347,44 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
     }
 
     return $financialTrxn;
+  }
+
+  private static function createFeeAccountingEntries($creditNote, $data) {
+    $financialTypeId = $creditNote['line'][0]['financial_type_id'];
+    $data = [
+      'from_account_id' => CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($data['payment_instrument_id']),
+      'to_account_id' => FinancialAccountUtils::getFinancialTypeAccount($financialTypeId, 'Expense Account is'),
+      'date' => $data['date'],
+      'total_credit' => $data['fee_amount'],
+      'net_amount' => $data['fee_amount'],
+      'fee_amount' => 0,
+      'currency' => $data['currency'],
+      'is_payment' => 0,
+      'payment_processor_id' => NULL,
+      'payment_instrument_id' => $data['payment_instrument_id'] ?? self::getAccountReceivableId(),
+      'card_type_id' => $data['card_type_id'] ?? NULL,
+      'check_number' => $data['check_number'] ?? NULL,
+      'pan_truncation' => $data['pan_truncation'] ?? NULL,
+      'trxn_id' => $data['trxn_id'] ?? NULL,
+      'id' => $creditNote['id'],
+    ];
+
+    $trxn = self::createAccountingEntries($data, 'Completed');
+
+    $itemParams = [
+      'transaction_date' => date('Y-m-d'),
+      'contact_id' => $creditNote['contact_id'],
+      'currency' => $creditNote['currency'],
+      'amount' => $data['total_credit'],
+      'description' => 'Fee: ' . $trxn['id'],
+      'status_id' => OptionValueUtils::getValueForOptionValue('financial_item_status', 'Completed'),
+      'financial_account_id' => $data['to_account_id'],
+      'entity_table' => 'civicrm_financial_trxn',
+      'entity_id' => $trxn['id'],
+    ];
+    \CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxn);
+
+    return $trxn;
   }
 
   /**

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
@@ -119,6 +119,140 @@ class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
     $this->assertEquals(-1 * $amountToRefund, $lineItemSum);
   }
 
+  /**
+   * Tests that the expected entity financial transactions are created as part of the accounting entries for refund fee.
+   */
+  public function testExpectedRefundEntityFinancialAccountingEntriesAreCreatedForFee() {
+    $creditNote = $this->createCreditNote(500);
+    $amountToRefund = 200;
+    $feeAmount = 10;
+
+    $refundAllocation = $this->createRefund($creditNote['id'], $amountToRefund, [
+      'payment_instrument_id' => 3,
+      'fee_amount' => $feeAmount,
+      'check_number' => '1234',
+    ]);
+
+    $refundFinancialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('total_amount', '=', -1 * $amountToRefund)
+      ->addWhere('id', '=', $refundAllocation['financial_trxn_id'])
+      ->addWhere('net_amount', '=', -$amountToRefund - $feeAmount)
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 3)
+      ->addWhere('fee_amount', '=', $feeAmount)
+      ->addWhere('check_number', '=', '1234')
+      ->addWhere('check_number', '=', '1234')
+      ->addWhere('status_id', '=', 1)
+      ->addWhere('is_payment', '=', 1)
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($refundFinancialTrxn);
+
+    $expectedToAccount = \CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $creditNote['items'][0]['financial_type_id'],
+      'Expense Account is'
+    );
+
+    $expectedFromAccount = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(3);
+
+    $refundFeeFinancialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('id', '=', $refundAllocation['fee_financial_trxn_id'])
+      ->addWhere('from_financial_account_id', '=', $expectedFromAccount)
+      ->addWhere('to_financial_account_id', '=', $expectedToAccount)
+      ->addWhere('currency', '=', $refundFinancialTrxn['currency'])
+      ->addWhere('trxn_id', '=', $refundFinancialTrxn['trxn_id'])
+      ->addWhere('trxn_date', '=', $refundFinancialTrxn['trxn_date'])
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 3)
+      ->addWhere('total_amount', '=', $feeAmount)
+      ->addWhere('net_amount', '=', $feeAmount)
+      ->addWhere('check_number', '=', '1234')
+      ->addWhere('fee_amount', '=', 0)
+      ->addWhere('is_payment', '=', 0)
+      ->addWhere('status_id', '=', 1)
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($refundFeeFinancialTrxn);
+
+    $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_id', '=', $creditNote['id'])
+      ->addWhere('entity_table', '=', \CRM_Financeextras_DAO_CreditNote::$_tableName)
+      ->addWhere('financial_trxn_id', '=', $refundFeeFinancialTrxn['id'])
+      ->addWhere('amount', '=', $feeAmount)
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($entityFinancialTrxn);
+
+    $financialItem = \Civi\Api4\FinancialItem::get(FALSE)
+      ->addWhere('entity_id', '=', $refundFeeFinancialTrxn['id'])
+      ->addWhere('entity_table', '=', 'civicrm_financial_trxn')
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($financialItem);
+
+    $entityFinItemFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_id', '=', $financialItem['id'])
+      ->addWhere('entity_table', '=', 'civicrm_financial_item')
+      ->addWhere('financial_trxn_id', '=', $refundFeeFinancialTrxn['id'])
+      ->addWhere('amount', '=', $feeAmount)
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($entityFinItemFinancialTrxn);
+  }
+
+  /**
+   * Tests that the expected entity financial transactions is not created for refund fee.
+   */
+  public function testRefundEntityFinancialAccountingEntriesAreNotCreatedForFee() {
+    $creditNote = $this->createCreditNote(500);
+    $amountToRefund = 200;
+    $feeAmount = 0;
+
+    $refundAllocation = $this->createRefund($creditNote['id'], $amountToRefund, [
+      'payment_instrument_id' => 3,
+      'fee_amount' => $feeAmount,
+      'check_number' => '1234',
+    ]);
+
+    $refundFinancialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('total_amount', '=', -1 * $amountToRefund)
+      ->addWhere('id', '=', $refundAllocation['financial_trxn_id'])
+      ->addWhere('net_amount', '=', -$amountToRefund - $feeAmount)
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 3)
+      ->addWhere('fee_amount', '=', $feeAmount)
+      ->addWhere('check_number', '=', '1234')
+      ->addWhere('check_number', '=', '1234')
+      ->addWhere('status_id', '=', 1)
+      ->addWhere('is_payment', '=', 1)
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($refundFinancialTrxn);
+
+    $expectedToAccount = \CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $creditNote['items'][0]['financial_type_id'],
+      'Expense Account is'
+    );
+
+    $expectedFromAccount = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(3);
+
+    $refundFeeFinancialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('id', '=', $refundAllocation['fee_financial_trxn_id'])
+      ->addWhere('from_financial_account_id', '=', $expectedFromAccount)
+      ->addWhere('to_financial_account_id', '=', $expectedToAccount)
+      ->addWhere('currency', '=', $refundFinancialTrxn['currency'])
+      ->addWhere('trxn_id', '=', $refundFinancialTrxn['trxn_id'])
+      ->addWhere('trxn_date', '=', $refundFinancialTrxn['trxn_date'])
+      ->addWhere('payment_processor_id', 'IS NULL')
+      ->addWhere('payment_instrument_id', '=', 3)
+      ->addWhere('total_amount', '=', $feeAmount)
+      ->addWhere('net_amount', '=', $feeAmount)
+      ->addWhere('check_number', '=', '1234')
+      ->execute()
+      ->first();
+    $this->assertEmpty($refundFeeFinancialTrxn);
+  }
+
   private function createRefund($creditNoteId, $amountToRefund = 200, $paymentParam = []) {
     return \Civi\Api4\CreditNote::refundAction()
       ->setId($creditNoteId)
@@ -131,6 +265,7 @@ class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
         'pan_truncation' => "2333",
         'trxn_id' => mt_rand(1000, 6000),
         'fee_amount' => '1.50',
+        'currency' => 'GBP',
       ], $paymentParam))
       ->execute()
       ->first();


### PR DESCRIPTION
## Overview
When recording a cash refund we only create accounting entries for the main transaction amount, in this PR we also create accounting entries for the fee_amount.


## Before
Accounting entries are only created for the main refund transaction amount
<no visual change>

## After
Accounting entries are now created for refund transaction fee amount
<no visual change>


## Technical Details

Accounting Entries created are:

**Financial Transaction for fee amount**
```
"from_financial_account_id": "Financial Account of the Payment Method", +ve credit
"to_financial_account_id": "'Expense Account is' of the financial type of the first line item of the credit note"* +ve debit
"trxn_date": "date of the refund",
"total_amount": "fee amount (positive)",
"fee_amount": "null"
"net_amount": "fee amount (positive)"
"currency": "Currency",
"is_payment": "0",
"trxn_id": "Transaction ID", (should be the same as the main transaction)
"status_id": "1",
"payment_processor_id": NULL,
"payment_instrument_id": "Payment method Id"
```

**Entity Financial Item for Financial Transaction**
```
"id": "Increment",
"created_date": "Current date",
"transaction_date": "Current date",
"contact_id": "Contact of the credit note",
"description": "Fee: {Transaction ID}",
"amount": "Fee Amount **POSITIVE**",
"currency": "currency",
"financial_account_id": "Expense Account is' of the financial type of the first line item of the credit note",
"status_id": "1",
"entity_table": "civicrm_financial_trxn",
"entity_id": "financial_trxn Id of financial transaction (1) above"
```

**Entity Financial Transaction to link fee Financial Transaction with Credit Note**
```
"entity_table":"credit note table name"
"entity_ID":"Credit note id"
"financial_trxn_id":"Id of the financial transaction above
"Amount": +ve Fee Amount
```

**Entity Financial Item to link fee Financial Transaction with Financial Item**
```
"entity_table":"civicrm_financial_item"
"entity_ID":"financial_item.id above"
"financial_trxn_id":"Id of the financial transaction (1) above
"Amount": +ve Fee Amount
```
