### PR TITLE
CIWEMB-508: Hide View Template Action For Recurring Contributions

### DIFF
--- a/Civi/Financeextras/Hook/Links/ContributionRecur.php
+++ b/Civi/Financeextras/Hook/Links/ContributionRecur.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Civi\Financeextras\Hook\Links;
+
+use Civi\Financeextras\Hook\Links\ContributionRecur\Template;
+
+/**
+ * ContributionRecur
+ * @package Civi\Financeextras\Hook\Links;
+ */
+class ContributionRecur {
+
+  /**
+   * @var array
+   */
+  private $links;
+
+  /**
+   * @var string
+   */
+  private $objectName;
+
+  /**
+   * @var string
+   */
+  private $objectId;
+
+  /**
+   * @var string
+   */
+  private $op;
+
+  /**
+   * Contribution constructor.
+   *
+   * @param string $op
+   * @param string $objectId
+   * @param string $objectName
+   * @param array $links
+   */
+  public function __construct(string $op, string $objectId, string $objectName, array &$links) {
+    $this->op = $op;
+    $this->objectId = $objectId;
+    $this->objectName = $objectName;
+    $this->links = &$links;
+  }
+
+  public function handle(): void {
+    $this->removeLinks();
+  }
+
+  private function removeLinks(): void {
+    $links = [
+      new Template((int) $this->objectId, $this->links),
+    ];
+    foreach ($links as $link) {
+      $link->remove();
+    }
+  }
+
+  public static function shouldHandle(string $op, string $objectName): bool {
+    return $op === 'contribution.selector.recurring' && $objectName === 'Contribution';
+  }
+
+}

--- a/Civi/Financeextras/Hook/Links/ContributionRecur/Template.php
+++ b/Civi/Financeextras/Hook/Links/ContributionRecur/Template.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Civi\Financeextras\Hook\Links\ContributionRecur;
+
+/**
+ * Template
+ * @package Civi\Financeextras\Hook\Links\ContributionRecur
+ */
+class Template {
+
+  /**
+   * @var array
+   */
+  private array $links;
+  /**
+   * @var int
+   */
+  private int $contributionID;
+
+  /**
+   * @param int $contributionID
+   * @param array $links
+   */
+  public function __construct(int $contributionID, array &$links) {
+    $this->links = &$links;
+    $this->contributionID = $contributionID;
+  }
+
+  /**
+   * Checks contribution has any of the given payment processors.
+   *
+   * @return bool
+   *   Whether contribution has any of the given payment processors.
+   *
+   * @throws \Civi\API\Exception
+   */
+  private function contributionHasPaymentProcessor(array $processors): bool {
+    $contribution = \Civi\Api4\ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->contributionID)
+      ->addWhere('payment_processor_id:name', 'IN', $processors)
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    return !empty($contribution);
+  }
+
+  /**
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function remove(): void {
+
+    if ($this->contributionHasPaymentProcessor(['Direct Debit', 'GoCardless'])) {
+      foreach ($this->links as $key => $link) {
+        if (!empty($link['name']) && $link['name'] === 'View Template') {
+          unset($this->links[$key]);
+          break;
+        }
+      }
+    }
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -79,6 +79,7 @@ function financeextras_civicrm_pageRun($page) {
 function financeextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
   $hooks = [
     \Civi\Financeextras\Hook\Links\Contribution::class,
+    \Civi\Financeextras\Hook\Links\ContributionRecur::class,
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr hides the **view template** action from action menus for a recurring contributions on contact view page if the payment processor for that contribution is either Direct Debit or GoCardless.

## Before
<img width="1792" alt="Screenshot 2024-03-22 at 2 54 06 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/66d58f79-0673-4577-884f-fbde3e8b5fc5">



## After
<img width="1792" alt="Screenshot 2024-03-22 at 2 35 13 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/7d744c1c-1231-425e-ab81-1422725968d1">
