### PR TITLE
CIWEMB-508: Fix 'View Template' Link Removal For Recurring Contributions

### DIFF
--- a/Civi/Financeextras/Hook/Links/ContributionRecur/Template.php
+++ b/Civi/Financeextras/Hook/Links/ContributionRecur/Template.php
@@ -35,14 +35,19 @@ class Template {
    * @throws \Civi\API\Exception
    */
   private function contributionHasPaymentProcessor(array $processors): bool {
-    $contribution = \Civi\Api4\ContributionRecur::get(FALSE)
-      ->addWhere('id', '=', $this->contributionID)
-      ->addWhere('payment_processor_id:name', 'IN', $processors)
-      ->setLimit(1)
-      ->execute()
-      ->first();
+    try {
+      $contribution = \Civi\Api4\ContributionRecur::get(FALSE)
+        ->addWhere('id', '=', $this->contributionID)
+        ->addWhere('payment_processor_id:name', 'IN', $processors)
+        ->setLimit(1)
+        ->execute()
+        ->first();
 
-    return !empty($contribution);
+      return !empty($contribution);
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
This pr fixes a query for a hook that is responsible for removing the **View Template** link for recurring contributions

## Technical Details
[This](https://github.com/compucorp/io.compuco.financeextras/blob/master/Civi/Financeextras/Hook/Links/ContributionRecur/Template.php#L38) query resulted in an exception if both gocardless and manual dd extensions are not installed so this pr just catches that exception and returns a false for that function since if both the extensions are not installed then we dont need to remove that link