### PR TITLE
PROD-223: Limit credit note query alter to CSV

### DIFF
--- a/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
+++ b/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
@@ -140,10 +140,25 @@ class SearchDisplayRun {
    */
   private static function alterFinanceReportDisplay(&$result) {
     foreach ($result as &$display) {
+      if (!is_array($display)) {
+        continue;
+      }
       foreach ($display['columns'] as &$column) {
         if (in_array($column['label'], ['Net Amount', 'Tax Amount'])) {
           $column['val'] = \CRM_Utils_Money::format(abs(trim($column['val']) ?: 0));
         }
+      }
+
+      $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+        ->addWhere('entity_table', '=', 'civicrm_financial_item')
+        ->addWhere('entity_id', '=', $display['key'])
+        ->addWhere('financial_trxn_id', '=', $display['data']['FinancialItem_EntityFinancialTrxn_FinancialTrxn_01.id'])
+        ->execute()
+        ->first();
+
+      $key = $entityFinancialTrxn['id'] ?? NULL;
+      if (!empty($key)) {
+        $display['key'] = $key;
       }
     }
   }

--- a/Civi/Financeextras/Hook/BatchExport/UpdateQuery.php
+++ b/Civi/Financeextras/Hook/BatchExport/UpdateQuery.php
@@ -10,6 +10,13 @@ class UpdateQuery {
   public function __construct(public string &$query) {}
 
   public function addCreditNoteToQuery() {
+
+    $export_format = \CRM_Utils_Request::retrieve('export_format', 'String');
+
+    if (!in_array($export_format, ['CSV'])) {
+      return;
+    }
+
     $this->query = "SELECT
       ft.id as financial_trxn_id,
       ft.trxn_date,

--- a/managed/SavedSearch_SOA_Finance_Report_Beta_v3.mgd.php
+++ b/managed/SavedSearch_SOA_Finance_Report_Beta_v3.mgd.php
@@ -31,6 +31,7 @@ $mgd = [
             'LOWER(FinancialItem_EntityFinancialTrxn_FinancialTrxn_01.amount) AS LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount',
             'FinancialItem_Contact_contact_id_01.display_name',
             'FinancialItem_Contact_contact_id_01.id',
+            'FinancialItem_EntityFinancialTrxn_FinancialTrxn_01.id',
           ],
           'orderBy' => [],
           'where' => [],


### PR DESCRIPTION
## Overview
This sequel to this PR https://github.com/compucorp/io.compuco.financeextras/pull/154, where we add custom query to set invoice number to credit note number, in this PR we ensure this query altering is limited to CSV export.
