### PR TITLE
PROD-230: Run Contribution Status Update Listener When Payment Apis Are Called

### DIFF
--- a/Civi/Financeextras/APIWrapper/Payment.php
+++ b/Civi/Financeextras/APIWrapper/Payment.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Civi\Financeextras\APIWrapper;
+
+use Civi\Financeextras\Event\ContributionPaymentUpdatedEvent;
+
+class Payment {
+
+  public static function Prepare($event) {
+    try {
+      $requestSignature = $event->getApiRequestSig();
+      $request          = $event->getApiRequest();
+
+      if ($requestSignature === '3.payment.delete' && !empty($request['params']['id'])) {
+        $eftParams = ['entity_table' => 'civicrm_contribution', 'financial_trxn_id' => $request['params']['id'], 'return' => ['entity_id']];
+        $entity    = civicrm_api3('EntityFinancialTrxn', 'getsingle', $eftParams);
+        if (!empty($entity['entity_id'])) {
+          $session = \CRM_Core_Session::singleton();
+          $session->set('contributionIdForDeletedPayment', $entity['entity_id']);
+        }
+      }
+    }
+    catch (\Throwable $e) {
+    }
+  }
+
+  public static function Respond($event) {
+    try {
+      $requestSignature = $event->getApiRequestSig();
+      $contributionId   = 0;
+
+      switch ($requestSignature) {
+        case '3.payment.create':
+          $request        = $event->getApiRequest();
+          $contributionId = !empty($request['params']['contribution_id']) ? $request['params']['contribution_id'] : 0;
+          break;
+
+        case '3.payment.cancel':
+          $request = $event->getApiRequest();
+          if (!empty($request['params']['id'])) {
+            $eftParams      = ['entity_table' => 'civicrm_contribution', 'financial_trxn_id' => $request['params']['id'], 'return' => ['entity_id']];
+            $entity         = civicrm_api3('EntityFinancialTrxn', 'getsingle', $eftParams);
+            $contributionId = !empty($entity['entity_id']) ? $entity['entity_id'] : 0;
+          }
+          break;
+
+        case '3.payment.delete':
+          $session        = \CRM_Core_Session::singleton();
+          $contributionId = !empty($session->get('contributionIdForDeletedPayment')) ? $session->get('contributionIdForDeletedPayment') : 0;
+          $session->set('contributionIdForDeletedPayment', 0);
+          break;
+      }
+
+      if (!empty($contributionId)) {
+        \Civi::dispatcher()->dispatch(
+          ContributionPaymentUpdatedEvent::NAME,
+          new ContributionPaymentUpdatedEvent($contributionId)
+        );
+      }
+    }
+    catch (\Throwable $e) {
+    }
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -19,6 +19,8 @@ function financeextras_civicrm_config(&$config) {
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\SearchDisplayRun', 'respond'], -100);
   Civi::dispatcher()->addSubscriber(new Civi\Financeextras\Event\Subscriber\CreditNoteInvoiceSubscriber());
   Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\Contribution', 'respond'], -101);
+  Civi::dispatcher()->addListener('civi.api.prepare', ['Civi\Financeextras\APIWrapper\Payment', 'prepare'], -102);
+  Civi::dispatcher()->addListener('civi.api.respond', ['Civi\Financeextras\APIWrapper\Payment', 'respond'], -103);
   Civi::dispatcher()->addListener('fe.contribution.received_payment', ['\Civi\Financeextras\Event\Listener\ContributionPaymentUpdatedListener', 'handle']);
   Civi::dispatcher()->addListener('civi.api.prepare', ['Civi\Financeextras\APIWrapper\BatchListPage', 'preApiCall']);
   Civi::dispatcher()->addListener('civi.token.list', 'financeextras_register_tokens');

--- a/tests/phpunit/Civi/Financeextras/ApiWrapper/PaymentTest.php
+++ b/tests/phpunit/Civi/Financeextras/ApiWrapper/PaymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Civi\Financeextras\Test\Fabricator\ContactFabricator;
+use Civi\Financeextras\Test\Fabricator\ContributionFabricator;
+
+/**
+ * Tests for the Refund class.
+ *
+ * @group headless
+ */
+class PaymentTest extends BaseHeadlessTest {
+
+  protected static array $contribution = [];
+
+  public static function setupBeforeClass(): void {
+    $contact = ContactFabricator::fabricate();
+    $contributionParams = [
+      'financial_type_id' => 'Donation',
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 200,
+      'contact_id' => $contact['id'],
+      'payment_instrument_id' => 'Credit Card',
+      'trxn_id' => md5(time()),
+      'currency' => 'GBP',
+      'contribution_status_id' => 2,
+    ];
+
+    self::$contribution = ContributionFabricator::fabricate($contributionParams);
+  }
+
+  public function setUp() {
+  }
+
+  public function testMakingPartialPaymentUpdatesContributionToPartiallyPaid(): void {
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => self::$contribution['id'],
+      'total_amount' => 100,
+      'trxn_date' => date('Y-m-d H:i:s'),
+      'trxn_id' => self::$contribution['trxn_id'],
+      'is_send_contribution_notification' => FALSE,
+    ]);
+    $contribution = civicrm_api3('Contribution', 'getSingle', ['id' => self::$contribution['id']]);
+
+    $this->assertEquals('Partially paid', $contribution['contribution_status']);
+  }
+
+  public function testMakingFullPaymentUpdatesContributionToCompleted(): void {
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => self::$contribution['id'],
+      'total_amount' => 200,
+      'trxn_date' => date('Y-m-d H:i:s'),
+      'trxn_id' => self::$contribution['trxn_id'],
+      'is_send_contribution_notification' => FALSE,
+    ]);
+    $contribution = civicrm_api3('Contribution', 'getSingle', ['id' => self::$contribution['id']]);
+
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+  }
+
+}


### PR DESCRIPTION
## Overview
In this extension we have an [event listener](https://github.com/compucorp/io.compuco.financeextras/blob/master/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php) that listens for various events and updates the contribution status according to the payments made against a contribution. Previously this listener did not run when payment apis were called, this pr make this listener to run for payment api calls as well.

## Technical Details
This pr calls the listener for following three payment apis

- Create
- Cancel
- Delete
