### PR TITLE
PROD-229: Convert tax amount to 2DP without rounding up

### DIFF
--- a/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
+++ b/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
@@ -145,7 +145,9 @@ class SearchDisplayRun {
       }
       foreach ($display['columns'] as &$column) {
         if (in_array($column['label'], ['Net Amount', 'Tax Amount'])) {
-          $column['val'] = \CRM_Utils_Money::format(abs(trim($column['val']) ?: 0));
+          $val = abs(trim($column['val']) ?: 0);
+          $val = floor($val * 100) / 100;
+          $column['val'] = \CRM_Utils_Money::format($val);
         }
       }
 

--- a/managed/SavedSearch_SOA_Finance_Report_Beta_v3.mgd.php
+++ b/managed/SavedSearch_SOA_Finance_Report_Beta_v3.mgd.php
@@ -268,7 +268,7 @@ $mgd = [
               'dataType' => 'String',
               'label' => 'Tax Amount',
               'sortable' => TRUE,
-              'rewrite' => "{if '[FinancialItem_LineItem_entity_id_01_LineItem_FinancialType_financial_type_id_01_FinancialType_EntityFinancialAccount_FinancialAccount_01.account_type_code]' == \"T8\"} {if [LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount] >= 0} {math equation=\"x * y\" x=[LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount] y=0.2 format=\"%.2f\"} {else}  {math equation=\"x * y * z\" x=[LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount] y=0.2 z=-1 format=\"%.2f\"} {/if}  {else} 0 {/if}",
+              'rewrite' => "{if '[FinancialItem_LineItem_entity_id_01_LineItem_FinancialType_financial_type_id_01_FinancialType_EntityFinancialAccount_FinancialAccount_01.account_type_code]' == \"T8\"} {if [LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount] >= 0} {math equation=\"x * y\" x=[LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount] y=0.2} {else}  {math equation=\"x * y * z\" x=[LOWER_FinancialItem_EntityFinancialTrxn_FinancialTrxn_01_amount] y=0.2 z=-1} {/if}  {else} 0 {/if}",
             ],
             [
               'type' => 'field',


### PR DESCRIPTION
## Overview
This PR converts the SOA tax amount to 2DP without rounding up, this is in a bid to ensure the tax amount calculated correlates with the tax amount  in the database as shown in the other financial reports

## Before
The computed tax amount for the line item with `Net Amount` of 116.78 shows as 23.36
![image](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/a7bdf5fa-6ec5-4a6d-a45c-7888d8be4b38)


## After
The computed tax amount for the line item with `Net Amount` of 116.78 shows as 23.35, which correlates with what is reported in other reports.
<img width="1280" alt="Screenshot 2024-05-16 at 09 27 17" src="https://github.com/compucorp/io.compuco.financeextras/assets/85277674/dfdd9cfe-4d04-4257-ab8b-0ee69bb31930">
