### PR TITLE
COMCL-537: Fix Event Registration And Info Pages

### DIFF
--- a/Civi/Financeextras/Hook/Links/ContributionRecur.php
+++ b/Civi/Financeextras/Hook/Links/ContributionRecur.php
@@ -58,7 +58,7 @@ class ContributionRecur {
     }
   }
 
-  public static function shouldHandle(string $op, string $objectName): bool {
+  public static function shouldHandle(string $op, ?string $objectName): bool {
     return $op === 'contribution.selector.recurring' && $objectName === 'Contribution';
   }
 


### PR DESCRIPTION
## Overview
This pr fixes a bug that prevented user from accessing event registration and info pages.

## Technical Details
The issue was caused by the type hinting for second parameter as string [here](https://github.com/compucorp/io.compuco.financeextras/blob/master/Civi/Financeextras/Hook/Links/ContributionRecur.php#L61) because its not always a string but sometimes its NULL as well as per the civi [documentation](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/#parameters)