### PR TITLE
PROD-227: Update Navigation Label For Companies

### DIFF
--- a/financeextras.php
+++ b/financeextras.php
@@ -255,7 +255,7 @@ function financeextras_register_tokens(\Civi\Token\Event\TokenRegisterEvent $e) 
 function financeextras_civicrm_navigationMenu(&$menu) {
   $companyMenuItem = [
     'name' => 'financeextras_company',
-    'label' => ts('Companies (For Multi-company accounting)'),
+    'label' => ts('Companies'),
     'url' => 'civicrm/admin/financeextras/company',
     'permission' => 'administer CiviCRM',
     'separator' => 2,


### PR DESCRIPTION
## Overview
This pr updates the navigation label from **Companies (For Multi-Company Accounting)** to **Companies**

## Before
<img width="1792" alt="Screenshot 2024-05-27 at 1 14 58 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/d4aa84f9-161f-4ee6-a56b-d0138e0ba6d0">

## After
<img width="1792" alt="Screenshot 2024-05-27 at 1 13 58 PM" src="https://github.com/compucorp/io.compuco.financeextras/assets/147053234/05889942-a082-4417-9876-644e7409499d">
