### PR TITLE
PROD-240: Update Logic For Contribution's Payment Method Updation To Cater Membership Plan Contributions

### DIFF
--- a/Civi/Financeextras/Hook/Post/ContributionCreation.php
+++ b/Civi/Financeextras/Hook/Post/ContributionCreation.php
@@ -213,7 +213,7 @@ class ContributionCreation {
 
     \CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution SET invoice_number = '{$invoiceNumber}' WHERE id = {$this->contribution['id']}");
 
-    if ($this->contribution['is_pay_later'] && empty($_POST['fe_record_payment_check'])) {
+    if ($this->isContributionNotRecordingPayment()) {
       \CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution SET payment_instrument_id = '{$companyRecord->receivable_payment_method}' WHERE id = {$this->contribution['id']}");
 
       $entityFinancialTransaction = \CRM_Core_DAO::executeQuery("SELECT financial_trxn_id FROM civicrm_entity_financial_trxn WHERE entity_id = {$this->contribution['id']} AND entity_table = 'civicrm_contribution'");
@@ -246,6 +246,13 @@ class ContributionCreation {
     }
 
     return $invoiceUpdateFormula;
+  }
+
+  private function isContributionNotRecordingPayment(): bool {
+    return (
+      $this->contribution['is_pay_later'] &&
+      (empty($_POST['fe_record_payment_check']) || !empty($_POST['payment_plan_schedule']))
+    );
   }
 
 }


### PR DESCRIPTION
## Overview
[this](https://github.com/compucorp/io.compuco.financeextras/pull/178) pr updates the contribution's payment method and set it equal to the payment method of the owner organization when a **pay later** contribution is created. But there was a missed scenario due to which the code changes in that previous pr was not identifying the contributions that are created as a result of membership payment plan creation as **pay later** contribution hence not updating the payment method. This pr fixes this gap.
