### PR TITLE
CIVIPLMMSR-302: Prevent sending multiple payment receipts

### DIFF
--- a/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ContributionPostProcess.php
@@ -33,6 +33,7 @@ class ContributionPostProcess {
           'total_amount' => $values['fe_record_payment_amount'],
           'trxn_date' => $values['receive_date'] ?? date('YmdHis'),
           'payment_instrument_id' => $values['payment_instrument_id'],
+          'is_send_contribution_notification' => FALSE,
         ];
 
         \CRM_Financial_BAO_Payment::create($params);


### PR DESCRIPTION
## Overview
After we separated the payment from contribution, the payment now separately sends a receipt to the user even though the contribution creation process will still send a receipt to the user, which will also consider whether the user checks the "Email Confirmation" box or not.

## Before
The payment recording process sends a payment receipt to the user during payment creation.
![wer](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/6661c690-4f03-4682-a643-b8468b2f701a)


## After
The payment recording process no longer sends a payment receipt to the user during payment creation. Instead, the contribution recording process handles sending receipts to users, considering their preference for receiving email confirmations.

![asasasas](https://github.com/compucorp/io.compuco.financeextras/assets/85277674/4b248e2a-8881-4d56-a47a-f7f055f564dc)


## Technical Details
This happens because the default value of is_send_contribution_notification to the payment.create API is TRUE, we need to set it to FALSE and let the contribution recording process decide when to send email notifications to users.