### PR TITLE
COMCL-622: Fix Visibilities Of Services

### DIFF
--- a/Civi/Financeextras/Hook/Container/ServiceContainer.php
+++ b/Civi/Financeextras/Hook/Container/ServiceContainer.php
@@ -33,7 +33,7 @@ class ServiceContainer {
         \Civi\Financeextras\Service\CreditNoteInvoiceService::class,
         []
       )
-    )->setAutowired(TRUE);
+    )->setAutowired(TRUE)->setPublic(TRUE);
   }
 
 }


### PR DESCRIPTION
## Overview
This pr aligns the service definitions with the new version of symfony DI container. With new version of container we have to do two following things

- Specify the visibility for each service otherwise its assumed as a private service.
- Set the alias for the classes that are required to be autowired if the id of service is not exactly similar to the full name of the class.
