### PR TITLE
COMCL-643: Fix Contribution Issue

### DIFF
--- a/CRM/Financeextras/Hook/PageRun/ContributionPageTab.php
+++ b/CRM/Financeextras/Hook/PageRun/ContributionPageTab.php
@@ -23,7 +23,7 @@ class CRM_Financeextras_Hook_PageRun_ContributionPageTab implements PageRunInter
    * @return bool
    */
   public static function shouldHandle($page) {
-    return $page instanceof CRM_Contribute_Page_Tab && $page->_action == CRM_Core_Action::BROWSE;
+    return $page instanceof CRM_Contribute_Page_Tab && $page->getVar('_action') == CRM_Core_Action::BROWSE;
   }
 
   /**


### PR DESCRIPTION
## Overview
This pr resolves an issue related to contributions that restricted user from creating new contribution or accessing contribution tab on contact view page.

## Before
<img width="1792" alt="Screenshot 2024-07-25 at 4 15 40 PM" src="https://github.com/user-attachments/assets/9a324b33-6725-43d0-b440-2cde88e8dfee">


## After
<img width="1792" alt="Screenshot 2024-07-25 at 4 15 10 PM" src="https://github.com/user-attachments/assets/6cc76fa8-2977-4114-b171-e29ce379d724">


## Technical Details
A hook in this extension was accessing a property on CRM_Contribute_Page_Tab class which has been marked as protected in [this](https://github.com/civicrm/civicrm-core/commit/12aabedca0a882b55d6238693fb46859a1920006) commit recently which caused an error upon opening above mentioned pages