### PR TITLE
BTHAMM-31: Prevent resetting contribution total amount to zero

### DIFF
--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -21,6 +21,9 @@ const totalChanged = new CustomEvent("totalChanged", {});
     const recordPaymentAmount = document.querySelector("input[name=fe_record_payment_amount]");
     $('#total_amount').on("change", function() {
       recordPaymentAmount.value = Number($('#total_amount').val()).toFixed(2);
+      if ($('#total_amount').val() == 0 && $('#line-total').data('raw-total') > 0) {
+        return
+      }
       recordPaymentAmount.dispatchEvent(totalChanged)
     });
 

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -14,6 +14,9 @@
     CRM.$(function($) {
       const submittedRows = $.parseJSON('{/literal}{$lineItemSubmitted}{literal}');
       const action = '{/literal}{$action}{literal}';
+      const nonEmtyFinancialTypes = $('table#info select[id^="item_financial_type_id_"]').filter(function() {
+        return this.value;
+      });
       isNotQuickConfig = '{/literal}{$pricesetFieldsCount}{literal}'
       const isEmptyPriceSet = !$('#price_set_id').length || $('#price_set_id').val() === ''
 
@@ -42,8 +45,11 @@
           $('#selectPriceSet').prepend( `<div id="lineItemSwitch" class="crm-hover-button">OR <a href="#">Switch back to using line items</a></div>`)
           $('#lineItemSwitch').css('display', 'block').on('click', () => $('#price_set_id').val('').change())
 
-          if ((isEmptyPriceSet) && submittedRows.length <= 0) {
-            $('#add-items').click()
+          const hasValues = nonEmtyFinancialTypes.each(function() {
+              $(this).val(this.value).trigger('change');
+          }).length > 0;
+          if (!hasValues && isEmptyPriceSet && submittedRows.length <= 0) {
+              $('#add-items').click();
           }
           toggleLineItemOrPricesetFields(isEmptyPriceSet);
 
@@ -58,7 +64,7 @@
               $('#totalAmountORPriceSet, #price_set_id').show();
             }
           });
-        }, 100);
+        }, 500);
 
         const toggleLineItemOrPricesetFields = (show) => {
           if (!show) {


### PR DESCRIPTION
## Overview
This PR prevents resetting the contribution total amount to zero when the input fields have already been set from the backend.

THis PR is a supplement to this PR https://github.com/compucorp/uk.co.compucorp.civicase/pull/1033

## Before
No visual changes

## After
No visual changes