### PR TITLE
COMCL-744: Remove methods and class depreceated in 5.75

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,14 +32,14 @@ jobs:
         run : composer self-update 2.2.5
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.94 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.75.0 --cms-ver 7.94 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.51.3
+          version: 5.75.0
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2
@@ -49,6 +49,25 @@ jobs:
       - name: Installing Finance Extras
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: cv en financeextras
+      
+
+      - name: Setup Test DB
+        run: echo "CREATE DATABASE civicrm_test;" | mysql -u root --password=root --host=mysql
+
+      - name: Update civicrm.settings.php
+        run: |
+          FILE_PATH="$GITHUB_WORKSPACE/site/web/sites/default/civicrm.settings.php"
+          INSERT_LINE="\$GLOBALS['_CV']['TEST_DB_DSN'] = 'mysql://root:root@mysql:3306/civicrm_test?new_link=true';"
+          TMP_FILE=$(mktemp)
+          while IFS= read -r line
+          do
+              echo "$line" >> "$TMP_FILE"
+              if [ "$line" = "<?php" ]; then
+                  echo "$INSERT_LINE" >> "$TMP_FILE"
+              fi
+          done < "$FILE_PATH"
+          mv "$TMP_FILE" "$FILE_PATH"
+          echo "File modified successfully."
 
       - name: Run phpunit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/io.compuco.financeextras

--- a/CRM/Financeextras/BAO/CreditNote.php
+++ b/CRM/Financeextras/BAO/CreditNote.php
@@ -334,7 +334,7 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
     $data = array_merge($creditNote, ['total_credit' => $data['amount'] * -1], $data);
     $financialTypeId = $creditNote['line'][0]['financial_type_id'];
     $data['from_account_id'] = FinancialAccountUtils::getFinancialTypeAccount($financialTypeId, 'Accounts Receivable Account is');
-    $data['to_account_id'] = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($data['payment_instrument_id']);
+    $data['to_account_id'] = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($data['payment_instrument_id']);
     $data['is_payment'] = 1;
     $data['net_amount'] = $data['total_credit'] - ($data['fee_amount'] ?? 0);
     $financialTrxn = self::createAccountingEntries($data, 'Completed');
@@ -352,7 +352,7 @@ class CRM_Financeextras_BAO_CreditNote extends CRM_Financeextras_DAO_CreditNote 
   private static function createFeeAccountingEntries($creditNote, $data) {
     $financialTypeId = $creditNote['line'][0]['financial_type_id'];
     $data = [
-      'from_account_id' => CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($data['payment_instrument_id']),
+      'from_account_id' => CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($data['payment_instrument_id']),
       'to_account_id' => FinancialAccountUtils::getFinancialTypeAccount($financialTypeId, 'Expense Account is'),
       'date' => $data['date'],
       'total_credit' => $data['fee_amount'],

--- a/CRM/Financeextras/BAO/CreditNoteLine.php
+++ b/CRM/Financeextras/BAO/CreditNoteLine.php
@@ -98,7 +98,7 @@ class CRM_Financeextras_BAO_CreditNoteLine extends CRM_Financeextras_DAO_CreditN
     $financialItem->find(TRUE);
 
     $entityTrxn = new \CRM_Financial_DAO_EntityFinancialTrxn();
-    $entityTrxn->entity_table = \CRM_Financial_BAO_FinancialItem::$_tableName;
+    $entityTrxn->entity_table = \CRM_Financial_BAO_FinancialItem::getTableName();
     $entityTrxn->entity_id = $financialItem->id;
     $entityTrxn->find(TRUE);
 

--- a/CRM/Financeextras/Page/Company.php
+++ b/CRM/Financeextras/Page/Company.php
@@ -38,11 +38,13 @@ class CRM_Financeextras_Page_Company extends CRM_Core_Page {
         'name'  => ts('Edit'),
         'url'   => 'civicrm/admin/financeextras/company/add',
         'qs'    => 'id=%%id%%&reset=1',
+        'weight' => 10,
       ],
       CRM_Core_Action::DELETE => [
         'name' => ts('Delete'),
         'url' => 'civicrm/admin/financeextras/company/delete',
         'qs' => 'id=%%id%%',
+        'weight' => 12,
       ],
     ];
   }

--- a/Civi/Financeextras/Event/ContributionPaymentUpdatedEvent.php
+++ b/Civi/Financeextras/Event/ContributionPaymentUpdatedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Event;
 
-use \Civi\Core\Event\GenericHookEvent as Event;
+use Civi\Core\Event\GenericHookEvent as Event;
 
 /**
  * The fe.contribution.received_payment event will be dispatched

--- a/Civi/Financeextras/Event/ContributionPaymentUpdatedEvent.php
+++ b/Civi/Financeextras/Event/ContributionPaymentUpdatedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use \Civi\Core\Event\GenericHookEvent as Event;
 
 /**
  * The fe.contribution.received_payment event will be dispatched

--- a/Civi/Financeextras/Event/CreditNoteDownloadedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteDownloadedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use \Civi\Core\Event\GenericHookEvent as Event;
 
 /**
  * The fe.creditnote.downloaded event is dispatched

--- a/Civi/Financeextras/Event/CreditNoteDownloadedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteDownloadedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Event;
 
-use \Civi\Core\Event\GenericHookEvent as Event;
+use Civi\Core\Event\GenericHookEvent as Event;
 
 /**
  * The fe.creditnote.downloaded event is dispatched

--- a/Civi/Financeextras/Event/CreditNoteMailedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteMailedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use \Civi\Core\Event\GenericHookEvent as Event;
 
 /**
  * The fe.creditnote.mailed event is dispatched

--- a/Civi/Financeextras/Event/CreditNoteMailedEvent.php
+++ b/Civi/Financeextras/Event/CreditNoteMailedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Financeextras\Event;
 
-use \Civi\Core\Event\GenericHookEvent as Event;
+use Civi\Core\Event\GenericHookEvent as Event;
 
 /**
  * The fe.creditnote.mailed event is dispatched

--- a/templates/CRM/Financeextras/MessageTemplate/CreditNoteInvoice.tpl
+++ b/templates/CRM/Financeextras/MessageTemplate/CreditNoteInvoice.tpl
@@ -194,7 +194,7 @@
             border: 1px dotted #000;
             border-style: none none dotted;
         ">
-        <img src="{$base_url}{crmResURL ext=io.compuco.financeextras file=images/cut.png}" style="height: 31px; width: auto;">
+        <img src="{$base_url}{crmResURL ext='io.compuco.financeextras' file='images/cut.png'}" style="height: 31px; width: auto;">
       </div>
 
       <div>

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/CreditNoteSaveActionTest.php
@@ -206,7 +206,7 @@ class Civi_Api4_CreditNote_CreditNoteSaveActionTest extends BaseHeadlessTest {
       // Financial item should have a entity financial transaction.
       $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
         ->addWhere('entity_id', '=', $financialItem['id'])
-        ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+        ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::getTableName())
         ->execute()
         ->first();
 
@@ -263,7 +263,7 @@ class Civi_Api4_CreditNote_CreditNoteSaveActionTest extends BaseHeadlessTest {
       foreach ([$financialItemForMainAmount, $financialItemForTax] as $financialItem) {
         $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
           ->addWhere('entity_id', '=', $financialItem['id'])
-          ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+          ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::getTableName())
           ->execute()
           ->first();
 

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/DeleteWithItemsActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/DeleteWithItemsActionTest.php
@@ -143,7 +143,7 @@ class Civi_Api4_CreditNote_DeleteWithItemsAction extends BaseHeadlessTest {
 
       $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
         ->addWhere('entity_id', '=', $financialItem['id'])
-        ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+        ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::getTableName())
         ->execute()
         ->first();
 

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/RefundActionTest.php
@@ -94,7 +94,7 @@ class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
       $creditNote['items'][0]['financial_type_id'],
       'Accounts Receivable Account is'
     );
-    $expectedToAccount = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(1);
+    $expectedToAccount = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount(1);
 
     $this->assertEquals($financialTrxn['to_financial_account_id'], $expectedToAccount);
     $this->assertEquals($financialTrxn['from_financial_account_id'], $expectedFromAccount);
@@ -153,7 +153,7 @@ class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
       'Expense Account is'
     );
 
-    $expectedFromAccount = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(3);
+    $expectedFromAccount = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount(3);
 
     $refundFeeFinancialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
       ->addWhere('id', '=', $refundAllocation['fee_financial_trxn_id'])
@@ -235,7 +235,7 @@ class Civi_Api4_CreditNote_RefundActionTest extends BaseHeadlessTest {
       'Expense Account is'
     );
 
-    $expectedFromAccount = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(3);
+    $expectedFromAccount = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount(3);
 
     $refundFeeFinancialTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
       ->addWhere('id', '=', $refundAllocation['fee_financial_trxn_id'])

--- a/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNote/VoidActionTest.php
@@ -165,7 +165,7 @@ class Civi_Api4_CreditNote_VoidActionTest extends BaseHeadlessTest {
       foreach ([$financialItemForMainAmount, $financialItemForTax] as $financialItem) {
         $entityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
           ->addWhere('entity_id', '=', $financialItem['id'])
-          ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::$_tableName)
+          ->addWhere('entity_table', '=', \CRM_Financial_BAO_FinancialItem::getTableName())
           ->execute()
           ->first();
 

--- a/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/AllocateActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/AllocateActionTest.php
@@ -91,7 +91,7 @@ class Civi_Api4_CreditNoteAllocation_AllocateActionTest extends BaseHeadlessTest
       ->first();
 
     $lineItemEntityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
-      ->addWhere('entity_table', '=', CRM_Financial_BAO_FinancialItem::$_tableName)
+      ->addWhere('entity_table', '=', CRM_Financial_BAO_FinancialItem::getTableName())
       ->addWhere('financial_trxn_id', '=', $entityFinancialTrxn['financial_trxn_id'])
       ->execute();
 

--- a/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/ReverseActionTest.php
+++ b/tests/phpunit/Civi/Api4/Action/CreditNoteAllocation/ReverseActionTest.php
@@ -82,7 +82,7 @@ class Civi_Api4_CreditNoteAllocation_ReverseActionTest extends BaseHeadlessTest 
       ->first();
 
     $lineItemEntityFinancialTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
-      ->addWhere('entity_table', '=', CRM_Financial_BAO_FinancialItem::$_tableName)
+      ->addWhere('entity_table', '=', CRM_Financial_BAO_FinancialItem::getTableName())
       ->addWhere('financial_trxn_id', '=', $entityFinancialTrxn['financial_trxn_id'])
       ->execute();
 

--- a/tests/phpunit/Civi/Financeextras/Hook/BuildForm/AdditionalPaymentButtonTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/BuildForm/AdditionalPaymentButtonTest.php
@@ -14,7 +14,7 @@ class AdditionalPaymentButtonTest extends BaseHeadlessTest {
 
   private $additionalPaymentForm;
 
-  public function setUp() {
+  public function setUp(): void {
     $formController = new CRM_Core_Controller();
     $this->additionalPaymentForm = new CRM_Contribute_Form_AdditionalPayment();
     $this->additionalPaymentForm->controller = $formController;
@@ -23,6 +23,7 @@ class AdditionalPaymentButtonTest extends BaseHeadlessTest {
   public function testSubmitRefundButtonLinkAddedToAdditionalPaymentForm() {
     $contact = ContactFabricator::fabricate();
     $paymentProcessor = PaymentProcessorFabricator::fabricate([
+      'name' => "Dummy",
       'payment_processor_type_id' => "Dummy",
       'financial_account_id' => "Payment Processor Account",
     ]);

--- a/tests/phpunit/Civi/Financeextras/Hook/PostProcess/FinancialBatchTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/PostProcess/FinancialBatchTest.php
@@ -90,6 +90,7 @@ class FinancialBatchTest extends BaseHeadlessTest {
     $form->_submitValues = $formValues;
     $form->_action = \CRM_Core_Action::ADD;
 
+    $form->set('BAOName', 'CRM_Financeextras_BAO_BatchOwnerOrganisation');
     $form->buildForm();
     $form->loadValues($formValues);
     $form->validate();

--- a/tests/phpunit/Civi/Financeextras/Hook/ValidateForm/ContributionValidatorTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/ValidateForm/ContributionValidatorTest.php
@@ -15,7 +15,7 @@ class ContributionValidatorTest extends BaseHeadlessTest {
 
   private $memberDuesFinancialTypeId;
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->donationFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [

--- a/tests/phpunit/Civi/Financeextras/Payment/RefundTest.php
+++ b/tests/phpunit/Civi/Financeextras/Payment/RefundTest.php
@@ -15,6 +15,7 @@ class RefundTest extends BaseHeadlessTest {
   public function testIsEligibleForRefund() {
     $contact = ContactFabricator::fabricate();
     $paymentProcessor = PaymentProcessorFabricator::fabricate([
+      'name'  => "Dummy",
       'payment_processor_type_id' => "Dummy",
       'financial_account_id' => "Payment Processor Account",
     ]);

--- a/tests/phpunit/Civi/Financeextras/Refund/PaymentProcessorTest.php
+++ b/tests/phpunit/Civi/Financeextras/Refund/PaymentProcessorTest.php
@@ -22,6 +22,7 @@ class PaymentProcessorTest extends BaseHeadlessTest {
 
   private function fabricateDummyProcessor() {
     return PaymentProcessorFabricator::fabricate([
+      'name' => "Dummy",
       'payment_processor_type_id' => "Dummy",
       'financial_account_id' => "Payment Processor Account",
     ]);

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,8 +2,13 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
+
+define('CIVICRM_CONTAINER_CACHE', 'never');
+define('CIVICRM_TEST', 1);
+putenv('CIVICRM_UF=' . ($_ENV['CIVICRM_UF'] = 'UnitTests'));
+
 // phpcs:disable
-eval(cv('php:boot --level=classloader', 'phpcode'));
+eval(cv('php:boot --level=settings', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();


### PR DESCRIPTION
## Overview
This PR removes methods and class deprecated in 5.75 causing issues such as users being unable to delete credit notes.

## Before
Users are unable to delete credit note
https://github.com/user-attachments/assets/75087e66-5091-4705-b21a-5d4956f5b309



## After
Users able to delete credit note
![qqq22222222](https://github.com/user-attachments/assets/8b417330-44f8-415e-a4a2-7f96a753ea57)

