### PR TITLE
COMCL-770: Fix Line Item Creations

### DIFF
--- a/Civi/Financeextras/Hook/Post/UpdateLineItemPriceFieldValues.php
+++ b/Civi/Financeextras/Hook/Post/UpdateLineItemPriceFieldValues.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Civi\Financeextras\Hook\Post;
+
+class UpdateLineItemPriceFieldValues {
+
+  public function __construct(
+    private string $op,
+    private string $objectName,
+    private int $objectId,
+    private $objectRef,
+  ) {
+  }
+
+  public function run() {
+    $this->updatePriceFieldValues();
+  }
+
+  private function updatePriceFieldValues(): void {
+    try {
+      $record = (array) $this->objectRef;
+
+      if ($this->objectName !== 'LineItem' || !in_array($this->op, ['create', 'edit'])
+        || ((!in_array($record['price_field_id'], [NULL, 'null'])) && (!in_array($record['price_field_value_id'], [NULL, 'null'])))) {
+        return;
+      }
+
+      $priceSetId        = \CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_contribution_amount', 'id', 'name');
+      $priceSet          = current(\CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
+      $priceFieldID      = \CRM_Price_BAO_PriceSet::getOnlyPriceFieldID($priceSet);
+      $priceFieldValueID = \CRM_Price_BAO_PriceSet::getOnlyPriceFieldValueID($priceSet);
+
+      $lineItem = \Civi\Api4\LineItem::update(FALSE);
+
+      if (in_array($record['price_field_id'], [NULL, 'null'])) {
+        $lineItem->addValue('price_field_id', $priceFieldID);
+      }
+      if (in_array($record['price_field_value_id'], [NULL, 'null'])) {
+        $lineItem->addValue('price_field_value_id', $priceFieldValueID);
+      }
+
+      $lineItem->addWhere('id', '=', $this->objectId)->execute();
+
+    }
+    catch (\Throwable $e) {
+    }
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -125,6 +125,7 @@ function financeextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
 
     (new \Civi\Financeextras\Hook\Post\UpdateContributionExchangeRate($objectId))->run();
   }
+  (new \Civi\Financeextras\Hook\Post\UpdateLineItemPriceFieldValues($op, $objectName, $objectId, $objectRef))->run();
 }
 
 /**


### PR DESCRIPTION
## Overview
This pr fixes the creation of line item that gets created without price field values as with newer civicrm version it is mandatory for a line items to have price field values.

## Technical Details
This pr adds a post hook that runs every time a line item is created without price field values and it updates the line item with price field value from default price set(the price set by the name of **default_contribution_amount**), this price set is created with civicrm installation. Secondly this pr also adds an upgrader which will fill price field values for existing line items.
