### PR TITLE
COMCL-802: Fix Amounts Display On View Credit Note Page

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-allocation-table.directive.js
@@ -43,13 +43,13 @@
         chain: {"allocations":["CreditNoteAllocation", "get", {"where":[["credit_note_id", "=", "$id"], ["is_reversed", "=", false]], "select":["*", "type_id:label", "contribution_id.invoice_number"]}]}
       }).then(function(result) {
         const creditnotes = result[0] ?? null;
-  
+
         $scope.isVoid = creditnotes["status_id:name"] == "void"
         $scope.currency = creditnotes.currency
         $scope.allocations = creditnotes.allocations ?? []
         $scope.total_credit = creditnotes.total_credit
-        $scope.remaining_credit = creditnotes.remaining_credit
-        $scope.allocated_credit = creditnotes.total_credit - creditnotes.remaining_credit
+        $scope.remaining_credit = creditnotes.remaining_credit ?? $scope.remaining_credit
+        $scope.allocated_credit = creditnotes.remaining_credit ? creditnotes.total_credit - creditnotes.remaining_credit : $scope.allocated_credit
       });
     }
 


### PR DESCRIPTION
## Overview
This pr fixes a bug on view credit note page due to which the remaining amount and allocated amount were shown to users as NAN when the quantity in line item is selected as 0

## Before
<img width="1792" alt="Screenshot 2024-09-10 at 2 58 52 PM" src="https://github.com/user-attachments/assets/bbec195c-6dcc-4b60-be13-6a4cf2b2cbe8">

## After
<img width="1792" alt="Screenshot 2024-09-10 at 2 55 47 PM" src="https://github.com/user-attachments/assets/297bb02f-a5de-4955-96ae-542d3014f0ad">
