### PR TITLE
COMCL-770: Use the price field and price field value of default priceset

### DIFF
--- a/Civi/Financeextras/Hook/Post/UpdateLineItemPriceFieldValues.php
+++ b/Civi/Financeextras/Hook/Post/UpdateLineItemPriceFieldValues.php
@@ -27,13 +27,26 @@ class UpdateLineItemPriceFieldValues {
 
       $priceSetId        = \CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_contribution_amount', 'id', 'name');
       $priceSet          = current(\CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
-      $priceFieldID      = \CRM_Price_BAO_PriceSet::getOnlyPriceFieldID($priceSet);
-      $priceFieldValueID = \CRM_Price_BAO_PriceSet::getOnlyPriceFieldValueID($priceSet);
+      $priceSet          = current(\CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
+      $priceField      = NULL;
+      foreach ($priceSet['fields'] as $field) {
+        if ($field['name'] == 'contribution_amount') {
+          $priceField = $field;
+          break;
+        }
+      }
+      if (empty($priceField)) {
+        return;
+      }
+      $priceFieldValueID = current($priceField['options'])['id'] ?? NULL;
+      if (empty($priceFieldValueID)) {
+        return;
+      }
 
       $lineItem = \Civi\Api4\LineItem::update(FALSE);
 
       if (in_array($record['price_field_id'], [NULL, 'null'])) {
-        $lineItem->addValue('price_field_id', $priceFieldID);
+        $lineItem->addValue('price_field_id', $priceField['id']);
       }
       if (in_array($record['price_field_value_id'], [NULL, 'null'])) {
         $lineItem->addValue('price_field_value_id', $priceFieldValueID);


### PR DESCRIPTION
## Overview
After this PR (https://github.com/compucorp/io.compuco.financeextras/pull/193), we had issues with failing upgraders during site deployment on existing sites with more price fields due to the method https://github.com/civicrm/civicrm-core/blob/2998081bf4b990739ddfcec0b9dd7d9e6c4e7a40/CRM/Price/BAO/PriceSet.php#L515 and https://github.com/civicrm/civicrm-core/blob/2998081bf4b990739ddfcec0b9dd7d9e6c4e7a40/CRM/Price/BAO/PriceSet.php#L530 used. We now manually fetch the price field and price field values  of the price set.

## Before
_no visual changes_

## After
_no visual changes_