### PR TITLE
COMCL-861: Calculate live credit card payment total from line items

### DIFF
--- a/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
@@ -45,7 +45,7 @@ class ContributionCreate {
     $data = &$this->form->controller->container();
     if (empty($this->fields['total_amount']) && !empty($this->fields['fe_record_payment_amount'])) {
       $data = &$this->form->controller->container();
-      $data['values']['Contribution']['total_amount'] = $this->fields['fe_record_payment_amount'];
+      $data['values']['Contribution']['total_amount'] = array_sum($data['values']['Contribution']['item_line_total']) ?? $this->fields['fe_record_payment_amount'];
     }
 
   }

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -5,6 +5,7 @@ const totalChanged = new CustomEvent("totalChanged", {});
     setTotalAmount();
     hideStatusField();
     const mode = CRM.vars.financeextras.mode ?? null
+    $('#selectPriceSet').hide();
 
     if (!mode) {
       setAmountCurencySymbol();

--- a/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/CustomLineItem.tpl
@@ -42,7 +42,7 @@
             .append($('#lineitem-add-block > div:last-child'))
           )
           $('#totalAmount, #totalAmountORaddLineitem').hide()
-          $('#selectPriceSet').prepend( `<div id="lineItemSwitch" class="crm-hover-button">OR <a href="#">Switch back to using line items</a></div>`)
+          $('.price-set-alt-select').prepend( `<div id="lineItemSwitch" class="crm-hover-button">OR <a href="#">Switch back to using line items</a></div>`)
           $('#lineItemSwitch').css('display', 'block').on('click', () => $('#price_set_id').val('').change())
 
           const hasValues = nonEmtyFinancialTypes.each(function() {
@@ -71,7 +71,6 @@
             $('#lineItemSwitch').show();
             $('#selectPriceSet').prepend($('#price_set_id'))
             $('#lineitem-add-block').hide();
-            $('.price-set-alt').hide();
           } else {
             $('#lineItemSwitch').hide();
             $('#lineitem-add-block').show()


### PR DESCRIPTION
## Overview
This PR is a follow-up to this PR https://github.com/compucorp/lineitemedit/pull/15 where we resolve an issue with credit card payment and the line item editor extension.

Here we ensure we compute the correct total from the line items.

Also we corrected the issue with the "Price set selector" field appearing twice

## Before
<img width="826" alt="Screenshot 2024-10-02 at 10 15 15" src="https://github.com/user-attachments/assets/67eaab58-76ee-42c8-b1be-ba019dc401a5">


## After
<img width="809" alt="Screenshot 2024-10-02 at 10 15 42" src="https://github.com/user-attachments/assets/ceb81774-e068-4b39-b7ec-07d09fb9fab6">
