### PR TITLE
CIVIMM-213: Prevent extending Membership end date post credit note allocation

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -189,6 +189,8 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
     if (self::isContributionStatus($params['contribution_id'], 'Completed')) {
       $params['line_item'] = ContributionUtils::allocatePaymentToLineItem($params['total_amount'], $params['contribution_id']);
     }
+
+    self::preventExtendingMembershipEndDate();
     $transaction = \CRM_Financial_BAO_Payment::create($params);
 
     // The Payment API typically uses the "Accounts Receivable" as the "from" account
@@ -296,6 +298,16 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
       ->addWhere('contribution_status_id:name', '=', $status)
       ->execute()
       ->first());
+  }
+
+  private static function preventExtendingMembershipEndDate() {
+    $manager = \CRM_Extension_System::singleton()->getManager();
+    if ($manager->getStatus('uk.co.compucorp.membershipextras') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
+      return;
+    }
+
+    // This is to prevent the membershipextras extension from extending the membership date.
+    Civi::$statics['uk.co.compucorp.membershipextras']['paymentApiCalled'] = TRUE;
   }
 
 }


### PR DESCRIPTION
## Overview
Prevent Membership End Date Extension After Credit Note Allocation

## Before
The membership end date is extended after credit note allocation.  
![Before](https://github.com/user-attachments/assets/21a5f090-6592-45eb-9f8c-636549746393)

## After
The membership end date is no longer extended after credit note allocation.  
![After](https://github.com/user-attachments/assets/a4ecc1cd-2031-456b-a6e1-0c12aa675d8e)

## Technical Details
In CiviCRM, when a payment is made to a contribution linked to an entity, the entity is updated. However, this is not the expected behavior for memberships. For more details, refer to this PR: [#485](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/485), where we addressed this for standard payments. However, the PR did not cover credit note allocations, as these do not use the standard payment API but instead manually create the necessary payment entities.

In this PR, we have added the required check to ensure the membership end date is not extended when a credit note is allocated to a contribution.