### PR TITLE
CSTMM-45: Ensure creditnote afform search is a creditnote entity

### DIFF
--- a/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
+++ b/Civi/Financeextras/APIWrapper/SearchDisplayRun.php
@@ -70,6 +70,10 @@ class SearchDisplayRun {
         ->execute()
         ->first();
 
+      if (empty($creditNote)) {
+        continue;
+      }
+
       $remaining = $creditNote['remaining_credit'];
       $lastIndex = count($display['columns']) - 1;
       $display['columns'][$lastIndex + 1] = $display['columns'][$lastIndex];


### PR DESCRIPTION
## Overview
This PR  ensures the entity that is being modified is a credit note entity and the entity exists

## Before
_no visual changes_

## After
_no visual changes_