### PR TITLE
CSTMM-43: Fix Owner Organization Field On Credit Note Creation

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -119,9 +119,22 @@
           return
         }
 
+        let currentOwnerOrganization = $scope.creditnotes.owner_organization ? $scope.creditnotes.owner_organization
+          : String($scope.companies[0]?.contact_id);
+        let contributionOwnerOrganization = null;
+
+        $scope.companies.forEach((company) => {
+          if (company.contact_id !== null &&
+            String(contribution['financeextras_contribution_owner.owner_organization']) === String(company.contact_id)
+          ) {
+            contributionOwnerOrganization = String(company.contact_id);
+          }
+        });
+
         $scope.contactId = contribution.contact_id
         $scope.creditnotes.contact_id = contribution.contact_id
-        $scope.creditnotes.owner_organization = String(contribution['financeextras_contribution_owner.owner_organization'])
+        $scope.creditnotes.owner_organization = contributionOwnerOrganization ?
+          contributionOwnerOrganization : currentOwnerOrganization;
         $scope.creditnotes.currency = contribution.currency
         $scope.disableCurrency = true
         $scope.currencySymbol = CurrencyCodes.getSymbol(contribution.currency);


### PR DESCRIPTION
## Overview
Currently in a scenario where the owner organization on a contribution is empty and user tries to create a credit note for this contribution the owner organization field gets disabled on the credit note creation form and empty at the same time not allowing the user to create the credit note.

## Before
<img width="1792" alt="Screenshot 2024-10-24 at 11 46 40 AM" src="https://github.com/user-attachments/assets/b5ea06bf-b083-4cdf-89d9-eba4f0cdabec">


## After
User is allowed to select the owner organization if there are more than one comapny otherwise the available one company is selected and field gets disabled as shown below
<img width="1792" alt="Screenshot 2024-10-24 at 11 44 10 AM" src="https://github.com/user-attachments/assets/748d50a5-6830-4f96-9e1a-8f6aec2a4e78">

