### PR TITLE
CIVIMM-242: Set payment time for creditnote allocation

### DIFF
--- a/CRM/Financeextras/BAO/CreditNoteAllocation.php
+++ b/CRM/Financeextras/BAO/CreditNoteAllocation.php
@@ -148,7 +148,7 @@ class CRM_Financeextras_BAO_CreditNoteAllocation extends CRM_Financeextras_DAO_C
    *  The amount to be allocated.
    */
   private static function createAccountingEntries($allocationId, $creditNoteId, $contributionId, $amount) {
-    $date = date("Y-m-d");
+    $date = date("Y-m-d H:i:s");
     $params = [
       'contribution_id' => $contributionId,
       'total_amount' => $amount,


### PR DESCRIPTION
## Overview
Payment record made through credit note allocation have a default time 12:00am, in this PR we set the time to the correct value.

## Before
![image](https://github.com/user-attachments/assets/d34c9bcb-3dea-41c3-a681-8e3a8e60137c)


## After
![image](https://github.com/user-attachments/assets/47354bff-9508-4aab-8d9a-1aaf8e69f866)
