### PR TITLE
MMB-500: Add Settings For Insurance Premium Financial Type

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -33,6 +33,7 @@
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>smarty-v2@1.0.1</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
   </mixins>
   <upgrader>CRM_Financeextras_Upgrader</upgrader>
 </extension>

--- a/settings/insurancepremium.setting.php
+++ b/settings/insurancepremium.setting.php
@@ -1,0 +1,23 @@
+<?php
+return [
+  'insurance_premium_financial_type' => [
+    'group_name' => 'Contribute Preferences',
+    'group' => 'contribute',
+    'name' => 'insurance_premium_financial_type',
+    'html_type' => 'entity_reference',
+    'add' => '5.51.3',
+    'type' => 'String',
+    'title' => ts('Financial Type for insurance premium certificate tokens'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => '',
+    'default' => '',
+    'help_text' => '',
+    'settings_pages' => ['contribute' => ['weight' => 15]],
+    'entity_reference_options' => [
+      'entity' => 'FinancialType',
+      'select' => ['minimumInputLength' => 0],
+      'multiple' => TRUE,
+    ],
+  ],
+];


### PR DESCRIPTION
## Overview
This pr adds a setting to **civicontribute component settings** page to select any financial type for identifying insurance premium line items in a contribution.

## Before
The settings does not exist.

## After
<img width="1792" alt="Screenshot 2024-11-10 at 5 00 36 PM" src="https://github.com/user-attachments/assets/b9a8b67a-32d2-4374-8d0a-9479a37022fe">

