### PR TITLE
COMCL-953: Move Angular Settings For Credit Note To Settings Class

### DIFF
--- a/CRM/Financeextras/Settings.php
+++ b/CRM/Financeextras/Settings.php
@@ -1,0 +1,36 @@
+<?php
+
+use Civi\Api4\OptionValue;
+use Civi\Api4\Company;
+use Civi\Financeextras\Utils\CurrencyUtils;
+
+/**
+ * Get a list of settings for angular pages.
+ */
+class CRM_Financeextras_Settings {
+
+  /**
+   * Get a list of settings for angular pages.
+   */
+  public static function getAll(): array {
+    $options = [
+      'shortDateFormat' => Civi::Settings()->get('dateformatshortdate'),
+      'canEditContribution' => CRM_Core_Permission::check('edit contributions'),
+      'currencyCodes' => CurrencyUtils::getCurrencies(),
+    ];
+
+    $options['creditNoteStatus'] = OptionValue::get(FALSE)
+      ->addSelect('id', 'value', 'name', 'label')
+      ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_status')
+      ->execute()
+      ->getArrayCopy();
+
+    $options['companies'] = Company::get(FALSE)
+      ->addSelect('contact_id.organization_name', 'contact_id')
+      ->execute()
+      ->getArrayCopy();
+
+    return $options;
+  }
+
+}

--- a/ang/fe-creditnote.ang.php
+++ b/ang/fe-creditnote.ang.php
@@ -3,47 +3,6 @@
 // in CiviCRM. See also:
 // \https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules/n
 
-use Civi\Api4\OptionValue;
-use Civi\Financeextras\Utils\CurrencyUtils;
-
-$options = [
-  'shortDateFormat' => Civi::Settings()->get('dateformatshortdate'),
-  'canEditContribution' => CRM_Core_Permission::check('edit contributions'),
-];
-
-/**
- * Exposes currency codes to Angular.
- */
-function financeextras_set_currency_codes(&$options) {
-  $options['currencyCodes'] = CurrencyUtils::getCurrencies();
-}
-
-/**
- * Exposes credit note statuses to Angular.
- */
-function financeextras_set_credit_note_status(&$options) {
-  $optionValues = OptionValue::get(FALSE)
-    ->addSelect('id', 'value', 'name', 'label')
-    ->addWhere('option_group_id:name', '=', 'financeextras_credit_note_status')
-    ->execute();
-
-  $options['creditNoteStatus'] = $optionValues->getArrayCopy();
-}
-
-/**
- * Exposes credit note statuses to Angular.
- */
-function financeextras_set_companies(&$options) {
-  $options['companies'] = \Civi\Api4\Company::get(FALSE)
-    ->addSelect('contact_id.organization_name', 'contact_id')
-    ->execute()
-    ->getArrayCopy();
-}
-
-financeextras_set_currency_codes($options);
-financeextras_set_credit_note_status($options);
-financeextras_set_companies($options);
-
 return [
   'js' => [
     'js/strftime.js',
@@ -64,5 +23,5 @@ return [
     'ngRoute',
     'afsearchCreditNotes',
   ],
-  'settings' => $options,
+  'settingsFactory' => ['CRM_Financeextras_Settings', 'getAll'],
 ];


### PR DESCRIPTION
## Overview
Previously all the settings needed for angular pages was being passed as plain array but to be compatible with new civicrm version the settings are being migrated to a settings class which fixes a warning on civicrm status page about unsupported settings.

## Before
![Screenshot 2024-11-27 at 20 41 24](https://github.com/user-attachments/assets/60bba554-50f8-4cd0-afad-9c528d213159)

## After
No such warnings are displayed
