### PR TITLE
CIVIPLMMSR-383: Respect Default Payment Method On Contribution Pages

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/PaymentCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/PaymentCreate.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Civi\Financeextras\Hook\BuildForm;
+
+/**
+ * Sets the payment method to the default one instead of contribution payment method.
+ */
+class PaymentCreate {
+
+  /**
+   * @var \CRM_Contribute_Form_AdditionalPayment
+   *   Form object that is being altered.
+   */
+  private \CRM_Contribute_Form_AdditionalPayment $form;
+
+  /**
+   * PaymentCreate constructor.
+   *
+   * @param \CRM_Contribute_Form_AdditionalPayment $form
+   */
+  public function __construct(\CRM_Contribute_Form_AdditionalPayment &$form) {
+    $this->form = $form;
+  }
+
+  public function handle(): void {
+    $defaultPaymentMethod = key(\CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
+    if ($defaultPaymentMethod) {
+      $this->form->getElement('payment_instrument_id')->setValue($defaultPaymentMethod);
+    }
+  }
+
+  public static function shouldHandle($form, $formName) {
+    if ($formName !== 'CRM_Contribute_Form_AdditionalPayment' || !$form->elementExists('payment_instrument_id')) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -207,6 +207,7 @@ function financeextras_civicrm_buildForm($formName, &$form) {
     \Civi\Financeextras\Hook\BuildForm\FinancialBatchSearch::class,
     \Civi\Financeextras\Hook\BuildForm\FinancialAccount::class,
     \Civi\Financeextras\Hook\BuildForm\AdditionalPaymentButton::class,
+    \Civi\Financeextras\Hook\BuildForm\PaymentCreate::class,
     \Civi\Financeextras\Hook\BuildForm\RefundCreditNotePaymentInformation::class,
   ];
 

--- a/js/modifyContributionForm.js
+++ b/js/modifyContributionForm.js
@@ -1,5 +1,6 @@
 CRM.$(function ($) {
-const totalChanged = new CustomEvent("totalChanged", {});
+  const totalChanged = new CustomEvent("totalChanged", {});
+  const defaultPaymentMethod = CRM.$("#payment_instrument_id") && CRM.$("#payment_instrument_id").val() ? CRM.$("#payment_instrument_id").val() : null;
 
   (function() {
     setTotalAmount();
@@ -70,6 +71,9 @@ const totalChanged = new CustomEvent("totalChanged", {});
     const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
     const toggle = (checked)  => {
       if (checked) {
+        if (defaultPaymentMethod) {
+          CRM.$("#payment_instrument_id").val(defaultPaymentMethod).change();
+        }
         $('.record_payment-block').show();
       } else {
         CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
@@ -109,7 +113,7 @@ const totalChanged = new CustomEvent("totalChanged", {});
     $('tr#email-receipt label').text('Send Email Confirmation')
     const email = $('tr#email-receipt #email-address')
     $('tr#email-receipt .description').text('Automatically email a confirmation of this transaction to ').append(email).append('?')
-    
+
     if (!$('tr#email-receipt').length) {
       $('tr.crm-contribution-form-block-is_email_receipt label').text('Send Email Confirmation')
       let text = $('tr.crm-contribution-form-block-is_email_receipt .description').text()

--- a/js/modifyMemberForm.js
+++ b/js/modifyMemberForm.js
@@ -1,4 +1,5 @@
 CRM.$(function ($) {
+  const defaultPaymentMethod = CRM.$("#payment_instrument_id") && CRM.$("#payment_instrument_id").val() ? CRM.$("#payment_instrument_id").val() : null;
 
   (function() {
     setTotalAmount();
@@ -23,16 +24,17 @@ CRM.$(function ($) {
   function togglePaymentBlock() {
     const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
 
-    $('input[name=fe_record_payment_check]').prop("checked", true).trigger('change')
-    CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
+    $('input[name=fe_record_payment_check]').prop("checked", true).trigger('change');
 
     $('input[name=fe_record_payment_check]').on('change', () => {
       const recordPayment = $('input[name=fe_record_payment_check]').is(':checked')
       if (!recordPayment) {
         CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
+      } else {
+        CRM.$("#payment_instrument_id").val(defaultPaymentMethod).change();
       }
 
-      $('tr.record_payment-block_row').toggle(recordPayment)
+      $('tr.record_payment-block_row').toggle(recordPayment);
     });
   }
 
@@ -48,7 +50,7 @@ CRM.$(function ($) {
 
     if ((parseFloat($('#total_amount').val()) > 0 || $('input[name=record_contribution]').is(':checked')) && !$('input[name=fe_member_type][value=paid_member]').is(":checked")) {
       $('input[name=fe_member_type][value=paid_member]').prop("checked", true).trigger('change')
-    } 
+    }
     else if ((parseFloat($('#total_amount').val()) <= 0) && $('input[name=fe_member_type][value=paid_member]').is(":checked")) {
       $('input[name=fe_member_type][value=free_member]').prop("checked", true).trigger('change')
     }
@@ -71,7 +73,7 @@ CRM.$(function ($) {
       if (!$('input#record_contribution').is(":checked") && isPaid) {
         $('input#record_contribution').prop("checked", !isPaid).trigger('click')
       }
-      
+
     });
 
     $('tr#contri').hide();

--- a/js/modifyParticipantForm.js
+++ b/js/modifyParticipantForm.js
@@ -17,10 +17,10 @@ CRM.$(function ($) {
     const observer = new window.MutationObserver(function () {
       if ($('.crm-event-eventfees-form-block-record_contribution').length && !$('tr.fe_record_contribution-block_row').length) {
         observer.disconnect();
-
+        const defaultPaymentMethod = CRM.$("#payment_instrument_id") && CRM.$("#payment_instrument_id").val() ? CRM.$("#payment_instrument_id").val() : null;
         placePaymentFieldsTogether();
         toggleContributionBlock();
-        togglePaymentBlock();
+        togglePaymentBlock(defaultPaymentMethod);
         setTotalAmount();
 
         observer.observe(document.body, {
@@ -59,9 +59,8 @@ CRM.$(function ($) {
     $('.crm-event-eventfees-form-block-contribution_status_id').hide();
   }
 
-  function togglePaymentBlock() {
+  function togglePaymentBlock(defaultPaymentMethod) {
     const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
-    CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
 
     if ($('input#record_contribution').is(':checked')) {
       $('input:radio[name=fe_ticket_type][value=paid_ticket]').click();
@@ -71,6 +70,9 @@ CRM.$(function ($) {
 
     $('input#record_contribution').on('input', () => {
       if ($('input#record_contribution').is(':checked')) {
+        if (defaultPaymentMethod) {
+          CRM.$("#payment_instrument_id").val(defaultPaymentMethod).change();
+        }
         $('#billing-payment-block').show();
       }else {
         CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();


### PR DESCRIPTION
## Overview
In [this](https://github.com/compucorp/io.compuco.financeextras/pull/109) pr we fixed the **account receivable** payment method for contributions that will be created as pending but same pr also created a bug in which **account receivable** was getting selected for completed contributions as well even though the default payment method was selected as something else. This pr fixes this issue and now for contributions that tends to record payment have default payment method as selected by default on page load where as for pending contributions the **account receivable** is selected by default.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/f90066f4-d2f3-4a92-b3a3-4727983ddf50)

## After
![screen_recording_after](https://github.com/user-attachments/assets/e4f76dcb-e04f-4f22-884e-383dbf57d5bf)
