### PR TITLE
CIVIMM-270: Fix Participant Registering

### DIFF
--- a/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
+++ b/Civi/Financeextras/Hook/PostProcess/ParticipantPostProcess.php
@@ -90,6 +90,10 @@ class ParticipantPostProcess {
     ];
     \CRM_Event_BAO_ParticipantPayment::create($participantPaymentParams);
 
+    if ($contribution->id) {
+      $this->createFinancialItem($contribution);
+    }
+
     return $contribution->id;
   }
 
@@ -149,6 +153,17 @@ class ParticipantPostProcess {
       ];
 
       \CRM_Financial_BAO_Payment::create($params);
+    }
+  }
+
+  private function createFinancialItem(object $contribution): void {
+    $lineItem = new \CRM_Price_DAO_LineItem();
+    $lineItem->entity_table = 'civicrm_participant';
+    $lineItem->entity_id = $this->form->_id;
+    $lineItem->limit(1);
+
+    if ($lineItem->find(TRUE)) {
+      \CRM_Financial_BAO_FinancialItem::add($lineItem, $contribution);
     }
   }
 


### PR DESCRIPTION
## Overview
In [this](https://github.com/compucorp/io.compuco.financeextras/pull/74/commits/1afd536704fc470b1104e0145e06d53b86231b49) commit we created a contribution record for registering a participant but currently when user registers a participant through register participant form the financial item entry does not get created due to which information in bookkeeping reports are missing. This pr fixes the issue by creating relevant financial item entry after the participant has been registered.

## Before
<img width="1792" alt="Screenshot 2025-02-03 at 10 55 36 PM" src="https://github.com/user-attachments/assets/a1bd068c-3517-4ba1-aba3-f961c28f3890" />


## After
<img width="1792" alt="Screenshot 2025-02-03 at 10 55 09 PM" src="https://github.com/user-attachments/assets/aa0ecd07-af4d-4c8e-a469-4b0f187d51d1" />
