### PR TITLE
CIVIPLMMSR-418: Add Upgrader To Fix Faulty Contributions

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -9,6 +9,7 @@ use Civi\Financeextras\Setup\Manage\CreditNoteInvoiceTemplateManager;
 use Civi\Financeextras\Setup\Manage\CreditNotePaymentInstrumentManager;
 use Civi\Financeextras\Setup\Manage\ContributionOwnerOrganizationManager;
 use Civi\Financeextras\Setup\Manage\AccountsReceivablePaymentMethod;
+use Civi\Financeextras\Service\IncompleteContributionFixService;
 
 /**
  * Collection of upgrade steps.
@@ -193,6 +194,24 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
         ->addClause('OR', ['price_field_id', 'IS NULL'], ['price_field_value_id', 'IS NULL'])
         ->addWhere('contribution_id', 'IS NOT NULL')
         ->execute();
+
+      return TRUE;
+    }
+    catch (\Throwable $e) {
+      $this->ctx->log->info($e->getMessage());
+
+      return FALSE;
+    }
+  }
+
+  /**
+   * Executes upgrade 1004
+   */
+  public function upgrade_1004(): bool {
+    try {
+      $contributionFix = new IncompleteContributionFixService();
+      $processedContributions = $contributionFix->execute();
+      $this->ctx->log->info(json_encode($processedContributions));
 
       return TRUE;
     }

--- a/Civi/Financeextras/Service/IncompleteContributionFixService.php
+++ b/Civi/Financeextras/Service/IncompleteContributionFixService.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Civi\Financeextras\Service;
+
+class IncompleteContributionFixService {
+
+  public function execute(): array {
+    $contributionStatuses = array_flip(\CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate'));
+    $affectedContributions = $this->fetchAffectedContributions($contributionStatuses);
+    $processedContributions = [];
+
+    while ($affectedContributions->fetch()) {
+      $affectedContribution = $affectedContributions->toArray();
+      $linkedMembership = $this->fetchLinkedMembership((int) $affectedContribution['id']);
+      if (empty($linkedMembership)) {
+        continue;
+      }
+
+      $processedContributions[] = $affectedContribution;
+      $this->createFinancialTrxn($affectedContribution);
+      $lineItem = $this->createLineItem($affectedContribution, $linkedMembership);
+
+      if ($affectedContribution['contribution_status_id'] == $contributionStatuses['Pending']) {
+        $updateStatusQuery = "
+        UPDATE civicrm_contribution SET contribution_status_id  = {$contributionStatuses['Completed']}
+        WHERE id = {$affectedContribution['id']}";
+        \CRM_Core_DAO::executeQuery($updateStatusQuery);
+        $affectedContribution['contribution_status_id'] = $contributionStatuses['Completed'];
+      }
+
+      \CRM_Financial_BAO_FinancialItem::add((object) $lineItem[0], (object) $affectedContribution);
+    }
+
+    return $processedContributions;
+  }
+
+  private function fetchAffectedContributions(array $contributionStatuses): object {
+    $affectedContributionsQuery = "
+    SELECT cc.* from civicrm_contribution cc
+    LEFT JOIN civicrm_line_item li ON cc.id = li.contribution_id
+    WHERE li.id IS NULL AND cc.contribution_status_id IN ({$contributionStatuses['Pending']}, {$contributionStatuses['Completed']})
+    AND cc.is_pay_later = 0";
+
+    $affectedContributions = \CRM_Core_DAO::executeQuery($affectedContributionsQuery);
+
+    return $affectedContributions;
+  }
+
+  private function fetchLinkedMembership(int $contributionId): array {
+    return civicrm_api3('MembershipPayment', 'get', [
+      'sequential' => 1,
+      'return' => ['membership_id', 'membership_id.membership_type_id'],
+      'contribution_id' => $contributionId,
+      'options' => ['limit' => 1],
+    ])['values'][0] ?? [];
+  }
+
+  private function createFinancialTrxn(array $contribution): void {
+    $createFinancialTrxn = TRUE;
+    $paymentProcessorId = $paymentInstrumentId = NULL;
+
+    $financialTrxns = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addWhere('trxn_id', '=', $contribution['trxn_id'])
+      ->execute()
+      ->getArrayCopy();
+
+    foreach ($financialTrxns as $financialTrxn) {
+      $paymentProcessorId = $financialTrxn['payment_processor_id'];
+      $paymentInstrumentId = $financialTrxn['payment_instrument_id'];
+      if (number_format($financialTrxn['total_amount'], 2) === number_format($contribution['total_amount'], 2)) {
+        $createFinancialTrxn = FALSE;
+        break;
+      }
+    }
+
+    if ($createFinancialTrxn) {
+      civicrm_api3('FinancialTrxn', 'create', [
+        'to_financial_account_id' => 'Payment Processor Account',
+        'trxn_date' => $contribution['receive_date'],
+        'total_amount' => $contribution['total_amount'],
+        'fee_amount' => $contribution['fee_amount'],
+        'net_amount' => $contribution['net_amount'],
+        'currency' => $contribution['currency'],
+        'is_payment' => 1,
+        'trxn_id' => $contribution['trxn_id'],
+        'status_id' => 'Completed',
+        'payment_instrument_id' => $paymentInstrumentId ?? 'Credit Card',
+        'payment_processor_id' => $paymentProcessorId ?? 'Stripe',
+        'entity_id' => $contribution['id'],
+        'contribution_id' => $contribution['id'],
+      ]);
+    }
+  }
+
+  private function createLineItem(array $contribution, array $membership): array {
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membership['membership_id.membership_type_id'],
+      'options' => ['limit' => 1, 'sort' => "id asc"],
+    ])['values'][0] ?? [];
+
+    $lineItem = civicrm_api3('LineItem', 'create', [
+      'sequential' => 1,
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['membership_id'],
+      'contribution_id' => $contribution['id'],
+      'price_field_id' => $priceFieldValue['price_field_id'],
+      'price_field_value_id' => $priceFieldValue['id'],
+      'label' => $priceFieldValue['name'],
+      'qty' => 1,
+      'unit_price' => $contribution['total_amount'],
+      'line_total' => $contribution['total_amount'],
+      'financial_type_id' => 'Member Dues',
+    ]);
+
+    return $lineItem['values'] ?? [];
+  }
+
+}

--- a/tests/phpunit/Civi/Financeextras/Service/IncompleteContributionFixServiceTest.php
+++ b/tests/phpunit/Civi/Financeextras/Service/IncompleteContributionFixServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Civi\Financeextras\Test\Fabricator\ContactFabricator;
+use Civi\Financeextras\Service\IncompleteContributionFixService;
+use Civi\Financeextras\Test\Fabricator\MembershipTypeFabricator;
+use Civi\Financeextras\Test\Fabricator\MembershipFabricator;
+
+/**
+ * Tests for the Refund class.
+ *
+ * @group headless
+ */
+class IncompleteContributionFixServiceTest extends BaseHeadlessTest {
+
+  public function testContributionWithoutLineItemsGetsFixed() {
+    $today = date('Y-m-d');
+    $trxnId = md5(time());
+    $contributionStatuses = array_flip(\CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate'));
+
+    $contact = ContactFabricator::fabricate();
+    $membershiptType = MembershipTypeFabricator::fabricate([
+      'name' => 'Main Membership',
+      'minimum_fee' => 200,
+    ]);
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $membershiptType['id'],
+      'join_date' => $today,
+      'start_date' => $today,
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+
+    $createContributionQuery = "
+    INSERT INTO civicrm_contribution
+    (contact_id, financial_type_id, receive_date, total_amount, payment_instrument_id, trxn_id, currency, contribution_status_id)
+    VALUES
+    ({$contact['id']}, 1, '{$today}', 200, 1, '{$trxnId}', 'GBP', {$contributionStatuses['Pending']});";
+    \CRM_Core_DAO::executeQuery($createContributionQuery);
+    $contributionId = CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()');
+
+    $createMembershipPaymentQuery = "
+    INSERT INTO civicrm_membership_payment
+    (contribution_id, membership_id)
+    VALUES
+    ({$contributionId}, {$membership['id']});";
+    \CRM_Core_DAO::executeQuery($createMembershipPaymentQuery);
+
+    $invalidContributionsQuery = "
+    SELECT count(cc.id) from civicrm_contribution cc
+    LEFT JOIN civicrm_line_item li ON cc.id = li.contribution_id
+    WHERE li.id IS NULL AND cc.contribution_status_id IN ({$contributionStatuses['Pending']}, {$contributionStatuses['Completed']})
+    AND cc.is_pay_later = 0";
+    $invalidContributionsCount = \CRM_Core_DAO::singleValueQuery($invalidContributionsQuery);
+    $this->assertEquals(1, $invalidContributionsCount);
+
+    $service = new IncompleteContributionFixService();
+    $service->execute();
+
+    $invalidContributionsCount = \CRM_Core_DAO::singleValueQuery($invalidContributionsQuery);
+
+    $this->assertEquals(0, $invalidContributionsCount);
+    $this->assertEquals(200, (int) \CRM_Core_BAO_FinancialTrxn::getTotalPayments($contributionId, TRUE));
+
+    $contributionStatus = \CRM_Core_DAO::singleValueQuery("SELECT contribution_status_id FROM civicrm_contribution WHERE id = {$contributionId}");
+    $this->assertEquals($contributionStatuses['Completed'], (int) $contributionStatus);
+  }
+
+}

--- a/tests/phpunit/Civi/Financeextras/Test/Fabricator/MembershipFabricator.php
+++ b/tests/phpunit/Civi/Financeextras/Test/Fabricator/MembershipFabricator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Civi\Financeextras\Test\Fabricator;
+
+class MembershipFabricator extends AbstractBaseFabricator {
+
+  protected static $entityName = 'Membership';
+
+}

--- a/tests/phpunit/Civi/Financeextras/Test/Fabricator/MembershipTypeFabricator.php
+++ b/tests/phpunit/Civi/Financeextras/Test/Fabricator/MembershipTypeFabricator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Civi\Financeextras\Test\Fabricator;
+
+class MembershipTypeFabricator extends AbstractBaseFabricator {
+
+  protected static $entityName = 'MembershipType';
+
+  protected static $defaultParams = [
+    'duration_unit' => 'year',
+    'period_type' => 'fixed',
+    'duration_interval' => 1,
+    'fixed_period_start_day' => 101,
+    'fixed_period_rollover_day' => 1231,
+    'domain_id' => 1,
+    'member_of_contact_id' => 1,
+    'financial_type_id' => 'Member Dues',
+  ];
+
+}


### PR DESCRIPTION
## Overview
This pr adds an upgrader to fix the faulty contribution records that does not have any line item attached to it.

## Technical Details
Such contributions gets created when a membership record is first created without a recurring contribution and then renewed with a contribution in CiviCRM. Systems who are migrated from another CRM and don’t have recurring contributions associated with memberships will likely experience this issue.

The root cause of this issue is renewing memberships without prior contribution (or if CiviCRM cannot find the contribution), the contribution created for the membership renewal will not have the appropriate line items.

This pr fixes these records by creating appropriate financial transactions, line items and financial items as well. Although it is possible that in past there were multiple transactions were there for a faulty contribution so we will just create the financial transaction records for the last transaction.