### PR TITLE
CIVIPLMMSR-420: Fix Extension Upgrade

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -141,8 +141,10 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
    * This upgrade updates company table
    */
   public function upgrade_1002() {
-    $this->ctx->log->info('Applying update 1002');
-    $this->executeSqlFile('sql/upgrade_1002.sql');
+    if (!\CRM_Core_BAO_SchemaHandler::checkIfFieldExists('financeextras_company', 'receivable_payment_method', FALSE)) {
+      $this->ctx->log->info('Applying update 1002');
+      $this->executeSqlFile('sql/upgrade_1002.sql');
+    }
 
     $defaultAccountReceivableAccount = \Civi\Api4\OptionValue::get(FALSE)
       ->setCheckPermissions(FALSE)


### PR DESCRIPTION
## Overview
This pr fixes the extension upgrade by checking if column **receivable_payment_method** already exists before trying to add it to **financeextras_company** table. As for some clients the table when created through auto_install script already includes that column and when they try to upgrade the extension to version 1002 it failed as the 1002 upgrade tries to add the above mentioned column.