### PR TITLE
COMCL-1031: Fix Credit Note Template

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -222,4 +222,24 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
     }
   }
 
+  /**
+   * Executes upgrade 1005
+   */
+  public function upgrade_1005(): bool {
+    try {
+      $templateManager = new CreditNoteInvoiceTemplateManager();
+      $templateManager->replaceText(
+        '<img src="{$base_url}{crmResURL ext=io.compuco.financeextras file=images/cut.png}" style="height: 31px; width: auto;">',
+        '<img src="{$base_url}{crmResURL ext=\'io.compuco.financeextras\' file=\'images/cut.png\'}" style="height: 31px; width: auto;">'
+      );
+
+      return TRUE;
+    }
+    catch (\Throwable $e) {
+      $this->ctx->log->info($e->getMessage());
+
+      return FALSE;
+    }
+  }
+
 }

--- a/Civi/Financeextras/Setup/Manage/CreditNoteInvoiceTemplateManager.php
+++ b/Civi/Financeextras/Setup/Manage/CreditNoteInvoiceTemplateManager.php
@@ -58,6 +58,28 @@ class CreditNoteInvoiceTemplateManager extends AbstractManager {
     MessageTemplate::save(FALSE)->addRecord($params)->execute();
   }
 
+  public function replaceText(string $search, string $replace): void {
+    if (empty($search)) {
+      return;
+    }
+
+    $messageTemplate = MessageTemplate::get(FALSE)
+      ->addSelect('id', 'msg_html')
+      ->addWhere('workflow_name', '=', CreditNoteInvoice::WORKFLOW)
+      ->execute()
+      ->first();
+    if (empty($messageTemplate)) {
+      return;
+    }
+
+    $replaced = str_replace($search, $replace, $messageTemplate['msg_html']);
+
+    MessageTemplate::update(FALSE)
+      ->addValue('msg_html', $replaced)
+      ->addWhere('id', '=', $messageTemplate['id'])
+      ->execute();
+  }
+
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
## Overview
This PR fixes an issue that restricted user from emailing or downloading a credit note.

## Before
The users were not able to download or email a credit note.

## After
Users can download or email a credit note successfully.

## Technical Details
This issue was due to a syntax error in credit note template which will be fixed by this pr.
