### PR TITLE
BTHAMM-61: Update mail content with organisation mail template

### DIFF
--- a/Civi/Financeextras/Hook/AlterMailContent/ContributionTemplate.php
+++ b/Civi/Financeextras/Hook/AlterMailContent/ContributionTemplate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Civi\Financeextras\Hook\AlterMailContent;
+
+/**
+ * @file
+ *
+ * This hook is called when the organisation contribution template is being rendered.
+ */
+class ContributionTemplate {
+
+  public function __construct(private array &$content) {
+  }
+
+  public function handle() {
+    $this->replaceWithOrganisationTemplate();
+  }
+
+  private function replaceWithOrganisationTemplate() {
+    $templateContent = \Civi::cache('session')->get('fe_org_message_template');
+    if (empty($templateContent)) {
+      return;
+    }
+
+    $this->content = json_decode(base64_decode($templateContent), TRUE);
+    \Civi::cache('session')->clear('fe_org_message_template');
+  }
+
+  public static function shouldHandle($content) {
+    return ($content['workflow_name'] ?? NULL) === 'contribution_invoice_receipt';
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -238,6 +238,16 @@ function financeextras_civicrm_alterMailParams(&$params, $context) {
  * Implements hook_civicrm_alterMailContent().
  */
 function financeextras_civicrm_alterMailContent(&$content) {
+  $hooks = [
+    \Civi\Financeextras\Hook\AlterMailContent\ContributionTemplate::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($content)) {
+      (new $hook($content))->handle();
+    }
+  }
+
   if (($content['workflow_name'] ?? NULL) === 'contribution_offline_receipt') {
     $content['html'] = str_replace('$formValues.total_amount', '$contribution.total_amount', $content['html']);
   }

--- a/tests/phpunit/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplateTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplateTest.php
@@ -28,6 +28,7 @@ class InvoiceTemplateTest extends BaseHeadlessTest {
     \CRM_Financeextras_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($contribution['id'], $this->company['contact_id']);
 
     $templateParams['messageTemplateID'] = NULL;
+    $templateParams['isTest'] = TRUE;
     $templateParams['tplParams']['id'] = $contribution['id'];
     $alterInvoiceParams = new \Civi\Financeextras\Hook\AlterMailParams\InvoiceTemplate($templateParams, '');
     $alterInvoiceParams->handle();
@@ -72,6 +73,7 @@ class InvoiceTemplateTest extends BaseHeadlessTest {
     ]);
     \CRM_Financeextras_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($contribution['id'], $this->company['contact_id']);
 
+    $templateParams['isTest'] = TRUE;
     $templateParams['tplParams'] = NULL;
     $templateParams['tplParams']['id'] = $contribution['id'];
     $alterInvoiceParams = new \Civi\Financeextras\Hook\AlterMailParams\InvoiceTemplate($templateParams, '');
@@ -117,6 +119,7 @@ class InvoiceTemplateTest extends BaseHeadlessTest {
     ]);
     \CRM_Financeextras_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($contribution['id'], $this->company['contact_id']);
 
+    $templateParams['isTest'] = TRUE;
     $templateParams['tplParams'] = NULL;
     $templateParams['tplParams']['id'] = $contribution['id'];
     $alterInvoiceParams = new \Civi\Financeextras\Hook\AlterMailParams\InvoiceTemplate($templateParams, '');


### PR DESCRIPTION
## Overview  
The Multicompany accounting feature in this extension allows site administrators to select a message template for contribution invoices based on the contribution owner's organization (i.e., company).  

After upgrading to CiviCRM 5.75.1, this functionality broke because the underlying logic changed. Previously, the `alterMailParams` hook was triggered before rendering the template, allowing us to swap the message template ID dynamically. However, in the latest CiviCRM version, the hook is now called after the template has already been rendered, preventing this approach from working.  

Relevant changes:  
- Previous implementation (worked as expected): [[CiviCRM 5.39.1 - MessageTemplate.php#L418](https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Core/BAO/MessageTemplate.php#L418)](https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Core/BAO/MessageTemplate.php#L418)  
- Current implementation (issue introduced): [[CiviCRM 5.75.1 - MessageTemplate.php#L366](https://github.com/civicrm/civicrm-core/blob/9268df8ee7d8b3e31a46063fdd654792ff74661d/CRM/Core/BAO/MessageTemplate.php#L366)](https://github.com/civicrm/civicrm-core/blob/9268df8ee7d8b3e31a46063fdd654792ff74661d/CRM/Core/BAO/MessageTemplate.php#L366)  
- Our previous approach: [[FinanceExtras InvoiceTemplate.php#L81-L93](https://github.com/compucorp/io.compuco.financeextras/blob/cde41916f515f2a2aefd1670ee28a6cec55d559a/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php#L81-L93)](https://github.com/compucorp/io.compuco.financeextras/blob/cde41916f515f2a2aefd1670ee28a6cec55d559a/Civi/Financeextras/Hook/AlterMailParams/InvoiceTemplate.php#L81-L93)  

## Before   
- Users always received the default contribution invoice, regardless of the owner organization.  

## After
- Users receive the contribution invoice corresponding to the correct owner organization.  

## Technical Solution  
To adapt to the new CiviCRM behaviour, we have reworked the logic:  
1. In the `alterMailParams` hook, we now render the template manually and store it in a temporary cache.  
2. In the `alterMailContent` hook, we replace the email content with the cached, pre-rendered template.  

This ensures the correct invoice template is used while working within the constraints of the latest CiviCRM changes.