### PR TITLE
FOSFASPRT-38: Fix credit card contribution not recording tax

### DIFF
--- a/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
@@ -45,7 +45,8 @@ class ContributionCreate {
     $data = &$this->form->controller->container();
     if (empty($this->fields['total_amount']) && !empty($this->fields['fe_record_payment_amount'])) {
       $data = &$this->form->controller->container();
-      $data['values']['Contribution']['total_amount'] = array_sum($data['values']['Contribution']['item_line_total']) ?? $this->fields['fe_record_payment_amount'];
+      $total = array_sum($data['values']['Contribution']['item_line_total']) + array_sum($data['values']['Contribution']['item_tax_amount']);
+      $data['values']['Contribution']['total_amount'] = $total ?? $this->fields['fe_record_payment_amount'];
     }
 
   }


### PR DESCRIPTION
## Overview  
CiviCRM's live contribution functionality does not support the Line Item Editor extension by default. However, since the new Contribution form introduced in this extension defaults to the line-item view, PR (https://github.com/compucorp/io.compuco.financeextras/pull/135) ensures compatibility between live contributions and the Line Item Editor extension.  

But during a recent testing, an issue was identified: when tax amount specified by financial types for individual line items are ignored, and not reflected in the final credit card charge.  

For example, given a contribution of **£60** with **£12 tax (20%)**, the expected total charge should include the tax.  

### Before Fix  
The Stripe charge does not include the tax amount.  

<img width="679" alt="Screenshot 2025-04-01 at 10 24 47" src="https://github.com/user-attachments/assets/aaf61d4f-4d3f-4451-849f-3f5e9fcaa20d" />  

### After Fix  
The Stripe charge correctly includes the tax amount.  

<img width="662" alt="Screenshot 2025-04-01 at 10 24 33" src="https://github.com/user-attachments/assets/75615a8d-1a37-43c1-85ef-e3b26177e584" />  
