### PR TITLE
ESEMM-25: Dont Fix Faulty Contributions If Financial Account Is Not Enabled

### DIFF
--- a/Civi/Financeextras/Service/IncompleteContributionFixService.php
+++ b/Civi/Financeextras/Service/IncompleteContributionFixService.php
@@ -8,6 +8,15 @@ class IncompleteContributionFixService {
     $contributionStatuses = array_flip(\CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate'));
     $affectedContributions = $this->fetchAffectedContributions($contributionStatuses);
     $processedContributions = [];
+    $financialAccount = civicrm_api3('FinancialAccount', 'get', [
+      'name' => 'Payment Processor Account',
+      'is_active' => TRUE,
+      'options' => ['limit' => 1],
+    ]);
+    // we need to have payment processor financial account active to fix faulty contributions
+    if (empty($financialAccount['id'])) {
+      return [];
+    }
 
     while ($affectedContributions->fetch()) {
       $affectedContribution = $affectedContributions->toArray();


### PR DESCRIPTION
## Overview
In one of the upgrader that was added [here](https://github.com/compucorp/io.compuco.financeextras/pull/217) we fix some faulty contribution records but to fix these records we need to have a financial account by the name of 'payment processor account' enabled to create financial transactions [here](https://github.com/compucorp/io.compuco.financeextras/blob/dae233c27e0dbc064d9acb7ba3141ded7a885dec/Civi/Financeextras/Service/IncompleteContributionFixService.php#L91) but if any client does not have this financial account then this same code throws an error so this PR handles this situation and if such financial account does not exist then we have decided to not to fix any record as we can't decide which account to use
