### PR TITLE
CIVIMM-309: Avoid contribution page transformation for pledge payment

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionCreate.php
@@ -156,8 +156,10 @@ class ContributionCreate {
    * @return bool
    */
   public static function shouldHandle($form, $formName) {
+    $context = \CRM_Utils_Request::retrieve('context', 'String');
+    $isPledgePayment = in_array($context, ['pledge', 'pledgeDashboard']);
     $addOrUpdate = ($form->getAction() & CRM_Core_Action::ADD) || ($form->getAction() & CRM_Core_Action::UPDATE);
-    return $formName === "CRM_Contribute_Form_Contribution" && $addOrUpdate;
+    return $formName === "CRM_Contribute_Form_Contribution" && $addOrUpdate && !$isPledgePayment;
   }
 
 }


### PR DESCRIPTION

## Overview  
Pledge payments use the contribution view but with additional options specific to pledges. We've customised the contribution page to default to a multi-line item view. However, this causes issues for pledge payments, where the system fails to set the financial type and amount correctly. Since pledge payments typically involve a single amount and require specific handling, we want to *disable* the multi-line item default for these cases.

## Before  
The contribution page defaults to line items, resulting in incorrect amounts and financial types.  
![image](https://github.com/user-attachments/assets/272dc671-25cf-44d3-9beb-68e827811ecb)

## After  
The page no longer defaults to line items when creating pledge payments, ensuring correct values are set.  
<img width="1234" alt="Screenshot 2025-04-29 at 08 58 00" src="https://github.com/user-attachments/assets/ac0574bd-94fc-41ba-8c62-d2cff6ec17dc" />

