### PR TITLE
CIVIMM-320: Remove Download Invoice And Email Invoice Buttons

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -17,6 +17,7 @@ class ContributionView {
 
   public function handle() {
     $this->addCreditNoteCancelAction();
+    $this->handleButtons();
   }
 
   private function addCreditNoteCancelAction() {
@@ -63,6 +64,23 @@ class ContributionView {
    */
   public static function shouldHandle($form, $formName) {
     return $formName === "CRM_Contribute_Form_ContributionView" && ($form->getAction() & \CRM_Core_Action::VIEW);
+  }
+
+  private function handleButtons(): void {
+    if (!$this->id || !$this->contributionHasStatus(['Cancelled', 'Failed'])) {
+      return;
+    }
+
+    $buttonsToRemove = [ts('Email Invoice'), ts('Download Invoice'), ts('Download Invoice and Credit Note')];
+    $buttons = $this->form->getTemplateVars('linkButtons');
+
+    foreach ($buttons as $key => $button) {
+      if (in_array($button['title'] ?? '', $buttonsToRemove)) {
+        unset($buttons[$key]);
+      }
+    }
+
+    $this->form->assign('linkButtons', $buttons);
   }
 
 }


### PR DESCRIPTION
## Overview
This PR remove **Download Invoice** and **Email Invoice** buttons from the view contribution screen if the contribution has a status equal to **Cancelled** or **Failed**

## Before
<img width="1792" alt="Screenshot 2025-05-29 at 5 11 35 PM" src="https://github.com/user-attachments/assets/c698976d-f89d-41d9-b7d1-1c7429e90105" />

## After
<img width="1792" alt="Screenshot 2025-05-29 at 5 11 19 PM" src="https://github.com/user-attachments/assets/aaf0bf3a-98a8-4889-bbcf-6d3daff6e4cf" />

