### PR TITLE
CIVIMM-318: Add ability to void contributions

### DIFF
--- a/CRM/Financeextras/Form/Contribute/ContributionVoid.php
+++ b/CRM/Financeextras/Form/Contribute/ContributionVoid.php
@@ -1,0 +1,65 @@
+<?php
+
+use CRM_Financeextras_ExtensionUtil as E;
+
+/**
+ * Contribution void Form controller class.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+class CRM_Financeextras_Form_Contribute_ContributionVoid extends CRM_Core_Form {
+
+  /**
+   * Contribution to void.
+   *
+   * @var int
+   */
+  public $id;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    CRM_Utils_System::setTitle('Void Contribution');
+
+    $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => E::ts('Void'),
+      ],
+      [
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+        'isDefault' => TRUE,
+      ],
+    ]);
+
+    parent::buildQuickForm();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function postProcess() {
+    if (!empty($this->id)) {
+      try {
+        \Civi\Api4\Contribution::update(FALSE)
+          ->addValue('id', $this->id)
+          ->addValue('contribution_status_id:label', 'Cancelled')
+          ->execute();
+        CRM_Core_Session::setStatus(E::ts('Contribution voided successfully.'), ts('Contribution Voided'), 'success');
+      }
+      catch (\Throwable $th) {
+        CRM_Core_Session::setStatus(E::ts($th->getMessage()), ts('Error voiding contribution'), 'error');
+      }
+    }
+  }
+
+}

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -18,6 +18,7 @@ class ContributionView {
   public function handle() {
     $this->addCreditNoteCancelAction();
     $this->handleButtons();
+    $this->addContributionVoidAction();
   }
 
   private function addCreditNoteCancelAction() {
@@ -33,6 +34,22 @@ class ContributionView {
     $url = \CRM_Utils_System::url('civicrm/contribution/creditnote', ['reset' => 1, 'action' => 'add', 'contribution_id' => $this->id]);
     \Civi::resources()->addVars('financeextras', ['is_contribution_view' => TRUE]);
     \Civi::resources()->addVars('financeextras', ['creditnote_btn_url' => $url]);
+  }
+
+  private function addContributionVoidAction() {
+    $havePayments = $this->getContributionPayments($this->id);
+    if (!$this->id || $this->contributionHasStatus(['Failed', 'Completed', 'Cancelled']) || $havePayments) {
+      return;
+    }
+
+    \Civi::resources()->add([
+      'scriptFile' => [E::LONG_NAME, 'js/addContributionVoidBtn.js'],
+      'region' => 'page-header',
+    ]);
+
+    $url = \CRM_Utils_System::url('civicrm/financeextras/contribution/void', ['reset' => 1, 'action' => 'void', 'id' => $this->id]);
+    \Civi::resources()->addVars('financeextras', ['is_contribution_view' => TRUE]);
+    \Civi::resources()->addVars('financeextras', ['contribution_void_btn_url' => $url]);
   }
 
   /**
@@ -64,6 +81,21 @@ class ContributionView {
    */
   public static function shouldHandle($form, $formName) {
     return $formName === "CRM_Contribute_Form_ContributionView" && ($form->getAction() & \CRM_Core_Action::VIEW);
+  }
+
+  /**
+   * Retrieves a contribution payments using APIv4
+   *
+   * @return array
+   *   Array of Contribution Payments
+   */
+  public function getContributionPayments(): array {
+    return \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addJoin('FinancialTrxn AS financial_trxn', 'INNER', ['financial_trxn_id', '=', 'financial_trxn.id'], ['financial_trxn.is_payment', '=', 1])
+      ->addWhere('entity_table', '=', 'civicrm_contribution')
+      ->addWhere('entity_id', '=', $this->id)
+      ->execute()
+      ->getArrayCopy() ?? [];
   }
 
   private function handleButtons(): void {

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -38,7 +38,8 @@ class ContributionView {
 
   private function addContributionVoidAction() {
     $havePayments = $this->getContributionPayments($this->id);
-    if (!$this->id || $this->contributionHasStatus(['Failed', 'Completed', 'Cancelled']) || $havePayments) {
+    $isAllowed = \CRM_Core_Permission::check('edit contributions');
+    if (!$this->id || $this->contributionHasStatus(['Failed', 'Completed', 'Cancelled']) || $havePayments || !$isAllowed) {
       return;
     }
 

--- a/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php
+++ b/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php
@@ -60,6 +60,32 @@ class CreditNote {
         'class' => 'no-popup',
       ];
     }
+
+    $havePayments = $this->getContributionPayments($this->contributionID);
+    if (!$this->contributionHasStatus(['Failed', 'Completed', 'Cancelled']) && \CRM_Core_Permission::check('edit contributions') &&!$havePayments) {
+      $this->links[] = [
+        'name' => 'Void Contribution',
+        'url' => 'civicrm/financeextras/contribution/void',
+        'qs' => 'reset=1&action=void&id=' . $this->contributionID,
+        'title' => 'Void Contribution',
+        'class' => 'small-popup',
+      ];
+    }
+  }
+
+  /**
+   * Retrieves a contribution payments using APIv4
+   *
+   * @return array
+   *   Array of Contribution Payments
+   */
+  public function getContributionPayments(): array {
+    return \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+      ->addJoin('FinancialTrxn AS financial_trxn', 'INNER', ['financial_trxn_id', '=', 'financial_trxn.id'], ['financial_trxn.is_payment', '=', 1])
+      ->addWhere('entity_table', '=', 'civicrm_contribution')
+      ->addWhere('entity_id', '=', $this->contributionID)
+      ->execute()
+      ->getArrayCopy() ?? [];
   }
 
 }

--- a/js/addContributionVoidBtn.js
+++ b/js/addContributionVoidBtn.js
@@ -1,0 +1,20 @@
+CRM.$(function ($) {
+  addContributionVoidBtn();
+
+  /**
+   * Add the Contribution void action button beside the contribution status
+   */
+  function addContributionVoidBtn() {
+    const btnUrl = CRM.vars.financeextras.contribution_void_btn_url.replace(/&amp;/g, '&');
+    const isView = CRM.vars.financeextras.is_contribution_view;
+    let statusRow = $('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)');
+    const contributionVoidActionBtn = $('<div>').css({ display: 'inline-flex', marginLeft: '10px' }).append($('<a>').addClass('button btn-creditnote-create btn btn-primary-outline small-popup').css({background:"#fff", border: '1px solid #2786c2', color: '#2786c2'}).attr('href', btnUrl).append($('<span>').text('Void Contribution')));
+    
+    if (isView) {
+      statusRow = $("tr:contains('Contribution Status') td:nth-child(2)");
+    }
+
+    statusRow.append(contributionVoidActionBtn)
+    $('#searchForm a.btn-creditnote-create').hide();
+  }
+});

--- a/templates/CRM/Financeextras/Form/Contribute/ContributionVoid.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/ContributionVoid.tpl
@@ -1,0 +1,21 @@
+<div id="bootstrap-theme">
+  <div class="alert alert-warning text-center">
+    <h1><i class="fa fa-question-circle"></i></h1>
+    <h3>{ts}Are you sure you would like to void this contribution?{/ts} </h3>
+    
+    <h4>{ts}This cannot be undone.{/ts}</h4>
+  </div>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>
+
+<script type="text/javascript">
+  {literal}
+    CRM.$(function($) {
+      $("a[target='crm-popup']").on('crmPopupFormSuccess', function (e) {
+        CRM.refreshParent(e);
+      });
+    });
+  {/literal}
+</script>

--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -93,4 +93,10 @@
     <title>Delete Exchange Rate Value</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/financeextras/contribution/void</path>
+    <page_callback>CRM_Financeextras_Form_Contribute_ContributionVoid</page_callback>
+    <title>Void Contribution</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR adds the ability for users to void a contribution. We add an extra link to the contribution list context menu, and also on the contribution view screen

## Before
The Void option doesn't exist on the context menu and contribution view screen

## After

![image](https://github.com/user-attachments/assets/02c450c3-af14-4b1b-80e1-afd527e5ed53)

![alololopocococo](https://github.com/user-attachments/assets/7a5f575a-7da5-431c-8346-226961b55bf4)



## Technical Details
The `Void Contribution` button is available for all contribution statuses except Failed, Completed, Cancelled, and when the contribution is not linked to any payment transaction.

The void is done by changing the contribution status to cancelled using the APIv4, allowing CiviCRM to perform every other necessary default actions for a cancelled contribution.