### PR TITLE
CIVIMM-315: Fix Owner Organization Filter Application

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/FinancialBatch.php
+++ b/Civi/Financeextras/Hook/BuildForm/FinancialBatch.php
@@ -33,6 +33,8 @@ class FinancialBatch {
     \CRM_Core_Region::instance('page-body')->add([
       'template' => "{$templatePath}/CRM/Financeextras/Hook/BuildForm/FinancialBatch.tpl",
     ]);
+
+    \Civi::resources()->addScriptFile('io.compuco.financeextras', 'js/financialbatch.js');
   }
 
   /**

--- a/js/financialbatch.js
+++ b/js/financialbatch.js
@@ -1,0 +1,3 @@
+CRM.$(function ($) {
+  $('.crm-financial_type-form-block .crm-accordion-body').append($('#financeextras_owner_org_table'));
+});


### PR DESCRIPTION
## Overview
This PR fixes the application of owner organization filter during the accounting batch creation as currently when user applies the owner organization filter it does not get applied to search criteria while filtering the transactions. Also this PR corrects the positioning of the field as the field is currently placed outside of the box.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/992ec60e-1c44-4333-b049-76fd72128c30)


## After
![screen_recording_after](https://github.com/user-attachments/assets/63efe124-da84-47ff-bac5-4221fe1f9c76)