### PR TITLE
CIVIMM-352: Disable Contact Field On Create Credit Note Form

### DIFF
--- a/ang/fe-creditnote/directives/creditnote-create.directive.html
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.html
@@ -25,7 +25,8 @@
               }"
               required
               ng-minlength="1"
-              ng-disabled="isView || isUpdate"
+              ng-disabled="isView || isUpdate || isContactFieldDisabled"
+              ng-class="{'cn-disabled-dropdown': isView || isUpdate || isContactFieldDisabled}"
             />
             <span class="crm-inline-error" ng-show="creditnotesForm.contact.$dirty && creditnotesForm.contact.$invalid && creditnotesForm.contact.$error.required">Contact is required</span>
           </div>

--- a/ang/fe-creditnote/directives/creditnote-create.directive.js
+++ b/ang/fe-creditnote/directives/creditnote-create.directive.js
@@ -59,6 +59,7 @@
     $scope.handleFinancialTypeChange = handleFinancialTypeChange;
     $scope.hs = crmUiHelp({ file: 'CRM/Financeextras/CreditNoteCtrl' });
     $scope.currencySymbol = CurrencyCodes.getSymbol(defaultCurrency);
+    $scope.isContactFieldDisabled = false;
 
     (function init () {
       initializeCreditnotes();
@@ -138,6 +139,7 @@
         $scope.creditnotes.currency = contribution.currency
         $scope.disableCurrency = true
         $scope.currencySymbol = CurrencyCodes.getSymbol(contribution.currency);
+        $scope.isContactFieldDisabled = true;
 
         const lineItems = contribution.items;
         // Ensure the due amount is not less than zero
@@ -395,6 +397,7 @@
     function setDefaultContactID () {
       if (!parseInt($scope.contributionId) && parseInt($scope.contactId)) {
         $scope.creditnotes.contact_id = $scope.contactId
+        $scope.isContactFieldDisabled = true;
       }
     }
 

--- a/css/fe-creditnote.css
+++ b/css/fe-creditnote.css
@@ -41,3 +41,14 @@
   border-bottom: 1px solid #eee;
 }
 
+.cn-disabled-dropdown {
+  background-color: #f3f6f7 !important;
+  cursor: not-allowed;
+  border-color: #ccc;
+}
+
+.cn-disabled-dropdown .select2-chosen {
+  color: #c2cfd8 !important;
+}
+
+


### PR DESCRIPTION
## Overview
This PR disables contact field when creating a credit note from an invoice or from a contact record.

## Before
<img width="1792" alt="Screenshot 2025-07-04 at 3 39 23 PM" src="https://github.com/user-attachments/assets/07b62bb0-bce5-40c8-895a-a98986972528" />


## After
<img width="1792" alt="Screenshot 2025-07-04 at 3 38 15 PM" src="https://github.com/user-attachments/assets/ce07c8b0-7d42-4474-b887-c5cc31bcef7f" />

