### PR TITLE
COMCL-1109: Ensure total can be calculated when tax component is not enabled

### DIFF
--- a/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
+++ b/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php
@@ -45,7 +45,7 @@ class ContributionCreate {
 
     if (empty($this->fields['total_amount']) && !empty($this->fields['fe_record_payment_amount'])) {
       $data = &$this->form->controller->container();
-      $total = array_sum($data['values']['Contribution']['item_line_total']) + array_sum($data['values']['Contribution']['item_tax_amount']);
+      $total = array_sum($data['values']['Contribution']['item_line_total']) + (array_sum($data['values']['Contribution']['item_tax_amount'] ?? []));
       $data['values']['Contribution']['total_amount'] = $total ?? $this->fields['fe_record_payment_amount'];
     }
 


### PR DESCRIPTION
## Overview

When the tax and invoicing component is not enabled, we want to ensure the line total is still calculated as expected.

Previously the error below is thrown

> Argument #1 ($array) must be of type array, null given in array_sum() (line 48 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/io.compuco.financeextras/Civi/Financeextras/Hook/ValidateForm/ContributionCreate.php)
