### PR TITLE
CIVIMM-353: Allow user to void completed contribution

### DIFF
--- a/CRM/Financeextras/Form/Contribute/ContributionVoid.php
+++ b/CRM/Financeextras/Form/Contribute/ContributionVoid.php
@@ -23,6 +23,19 @@ class CRM_Financeextras_Form_Contribute_ContributionVoid extends CRM_Core_Form {
     CRM_Utils_System::setTitle('Void Contribution');
 
     $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
+    $contributionStatus = \Civi\Api4\Contribution::get(TRUE)
+      ->addSelect('contribution_status_id:name')
+      ->addWhere('id', '=', $this->id)
+      ->execute()
+      ->first()['contribution_status_id:name'] ?? "";
+
+    $popupMessage = "Are you sure you want to void this contribution? Invoices cannot be downloaded for void contributions.";
+    if ($contributionStatus == "Completed") {
+      $popupMessage = "Are you sure you want to void this contribution? Invoices cannot be downloaded for void contributions. To credit this invoice, please create a credit note and apply the credit to this contribution instead.";
+    }
+
+    $this->assign("popupMessage", $popupMessage);
   }
 
   /**

--- a/CRM/Financeextras/Form/Contribute/ContributionVoid.php
+++ b/CRM/Financeextras/Form/Contribute/ContributionVoid.php
@@ -24,12 +24,13 @@ class CRM_Financeextras_Form_Contribute_ContributionVoid extends CRM_Core_Form {
 
     $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    $contributionStatus = \Civi\Api4\Contribution::get(TRUE)
+    $contributionResult = \Civi\Api4\Contribution::get(TRUE)
       ->addSelect('contribution_status_id:name')
       ->addWhere('id', '=', $this->id)
       ->execute()
-      ->first()['contribution_status_id:name'] ?? "";
+      ->first();
 
+    $contributionStatus = $contributionResult !== NULL ? $contributionResult['contribution_status_id:name'] : "";
     $popupMessage = "Are you sure you want to void this contribution? Invoices cannot be downloaded for void contributions.";
     if ($contributionStatus == "Completed") {
       $popupMessage = "Are you sure you want to void this contribution? Invoices cannot be downloaded for void contributions. To credit this invoice, please create a credit note and apply the credit to this contribution instead.";

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -39,8 +39,8 @@ class ContributionView {
   private function addContributionVoidAction() {
     $havePayments = !empty($this->getContributionPayments($this->id));
     $isAllowed = \CRM_Core_Permission::check('edit contributions');
-    $isEmptyContribution = !$this->contributionHasStatus(['Failed', 'Cancelled', 'Completed']) && !$havePayments;
-    $isVoidable = $isEmptyContribution || $this->contributionHasStatus(['Completed']);
+    $isPendingWithoutPayments = !$this->contributionHasStatus(['Failed', 'Cancelled', 'Completed']) && !$havePayments;
+    $isVoidable = $isPendingWithoutPayments || $this->contributionHasStatus(['Completed']);
     if (!$this->id || !$isVoidable || !$isAllowed) {
       return;
     }

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -39,7 +39,9 @@ class ContributionView {
   private function addContributionVoidAction() {
     $havePayments = !empty($this->getContributionPayments($this->id));
     $isAllowed = \CRM_Core_Permission::check('edit contributions');
-    if (!$this->id || $this->contributionHasStatus(['Failed', 'Completed', 'Cancelled']) || $havePayments || !$isAllowed) {
+    $isEmptyContribution = !$this->contributionHasStatus(['Failed', 'Cancelled', 'Completed']) && !$havePayments;
+    $isVoidable = $isEmptyContribution || $this->contributionHasStatus(['Completed']);
+    if (!$this->id || !$isVoidable || !$isAllowed) {
       return;
     }
 

--- a/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php
+++ b/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php
@@ -63,8 +63,8 @@ class CreditNote {
 
     $havePayments = $this->getContributionPayments($this->contributionID);
     $isAllowed = \CRM_Core_Permission::check('edit contributions');
-    $isEmptyContribution = !$this->contributionHasStatus(['Failed', 'Cancelled', 'Completed']) && !$havePayments;
-    $isVoidable = $isEmptyContribution || $this->contributionHasStatus(['Completed']);
+    $isPendingWithoutPayments = !$this->contributionHasStatus(['Failed', 'Cancelled', 'Completed']) && !$havePayments;
+    $isVoidable = $isPendingWithoutPayments || $this->contributionHasStatus(['Completed']);
     if ($isVoidable && $isAllowed) {
       $voidLink = [
         'name' => 'Void Contribution',

--- a/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php
+++ b/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php
@@ -62,7 +62,10 @@ class CreditNote {
     }
 
     $havePayments = $this->getContributionPayments($this->contributionID);
-    if (!$this->contributionHasStatus(['Failed', 'Completed', 'Cancelled']) && \CRM_Core_Permission::check('edit contributions') &&!$havePayments) {
+    $isAllowed = \CRM_Core_Permission::check('edit contributions');
+    $isEmptyContribution = !$this->contributionHasStatus(['Failed', 'Cancelled', 'Completed']) && !$havePayments;
+    $isVoidable = $isEmptyContribution || $this->contributionHasStatus(['Completed']);
+    if ($isVoidable && $isAllowed) {
       $voidLink = [
         'name' => 'Void Contribution',
         'url' => 'civicrm/financeextras/contribution/void',

--- a/templates/CRM/Financeextras/Form/Contribute/ContributionVoid.tpl
+++ b/templates/CRM/Financeextras/Form/Contribute/ContributionVoid.tpl
@@ -1,6 +1,6 @@
 <div id="bootstrap-theme" style="background-color: #fff;">
   <div class="alert alert-warning">
-    <i aria-hidden="true" class="crm-i fa-info-circle"></i> {ts} WARNING: Are you sure you want to void this contribution?{/ts}
+    <i aria-hidden="true" class="crm-i fa-info-circle"></i> {ts} {$popupMessage} {/ts}
   </div>
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
## Overview

This PR allows users to void completed contributions, a continuation of this [PR](https://github.com/compucorp/io.compuco.financeextras/pull/234).

## Before
No void contribution option on completed contributions

## After
 Users can now void completed contributions
![solitude](https://github.com/user-attachments/assets/0256d0ff-f715-4b3e-9e87-e1c4f8955212)
