### PR TITLE
CIVIPLMMSR-487: Fix Free Membership Creation

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/MembershipCreate.php
+++ b/Civi/Financeextras/Hook/BuildForm/MembershipCreate.php
@@ -6,6 +6,8 @@ use CRM_Financeextras_ExtensionUtil as E;
 
 class MembershipCreate {
 
+  const DIRECT_DEBIT_PAYMENT_METHOD_NAME = 'direct_debit';
+
   /**
    * @param \CRM_Member_Form_Membership $form
    */
@@ -34,6 +36,10 @@ class MembershipCreate {
 
       $accountsReceivablePaymentMethodId = array_search('accounts_receivable', \CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'validate'));
       \Civi::resources()->addVars('financeextras', ['accounts_receivable_payment_method' => $accountsReceivablePaymentMethodId]);
+
+      $defaultPaymentMethod = \CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1', 'name');
+      $defaultPaymentMethodName = array_values($defaultPaymentMethod)[0] ?? '';
+      \Civi::resources()->addVars('financeextras', ['is_direct_debit_default_payment_method' => $defaultPaymentMethodName === self::DIRECT_DEBIT_PAYMENT_METHOD_NAME]);
 
       \Civi::resources()->add([
         'scriptFile' => [E::LONG_NAME, 'js/modifyMemberForm.js'],

--- a/js/modifyMemberForm.js
+++ b/js/modifyMemberForm.js
@@ -1,5 +1,7 @@
 CRM.$(function ($) {
   const defaultPaymentMethod = CRM.$("#payment_instrument_id") && CRM.$("#payment_instrument_id").val() ? CRM.$("#payment_instrument_id").val() : null;
+  const isDirectDebitDefaultPaymentMethod = CRM.vars.financeextras.is_direct_debit_default_payment_method;
+  const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
 
   (function() {
     setTotalAmount();
@@ -22,8 +24,6 @@ CRM.$(function ($) {
   }
 
   function togglePaymentBlock() {
-    const accountsReceivablePaymentMethod = CRM.vars.financeextras.accounts_receivable_payment_method;
-
     $('input[name=fe_record_payment_check]').prop("checked", true).trigger('change');
 
     $('input[name=fe_record_payment_check]').on('change', () => {
@@ -43,8 +43,14 @@ CRM.$(function ($) {
     if (typeof membershipType !== 'undefined' && typeof membershipType['total_amount_numeric'] !== 'undefined') {
       if (membershipType['total_amount_numeric'] > 0) {
         $('.fe-membership_type').show()
+        if (isDirectDebitDefaultPaymentMethod && CRM.$("#payment_instrument_id").val() !== defaultPaymentMethod) {
+          CRM.$("#payment_instrument_id").val(defaultPaymentMethod).change();
+        }
       } else {
         $('.fe-membership_type').hide()
+        if (isDirectDebitDefaultPaymentMethod) {
+          CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
+        }
       }
     }
 
@@ -67,11 +73,21 @@ CRM.$(function ($) {
 
     $('input:radio[name=fe_member_type]').on('change', () => {
       const isPaid = $('input:radio[name=fe_member_type][value=paid_member]').is(':checked');
-      if ($('input#record_contribution').is(":checked") && !isPaid) {
-        $('input#record_contribution').prop("checked", !isPaid).trigger('click')
+      if (!isPaid) {
+        if ($('input#record_contribution').is(":checked")) {
+          $('input#record_contribution').prop("checked", !isPaid).trigger('click')
+        }
+        if (isDirectDebitDefaultPaymentMethod) {
+          CRM.$("#payment_instrument_id").val(accountsReceivablePaymentMethod).change();
+        }
       }
-      if (!$('input#record_contribution').is(":checked") && isPaid) {
-        $('input#record_contribution').prop("checked", !isPaid).trigger('click')
+      else {
+        if (!$('input#record_contribution').is(":checked")) {
+          $('input#record_contribution').prop("checked", !isPaid).trigger('click')
+        }
+        if (isDirectDebitDefaultPaymentMethod && CRM.$("#payment_instrument_id").val() !== defaultPaymentMethod) {
+          CRM.$("#payment_instrument_id").val(defaultPaymentMethod).change();
+        }
       }
 
     });


### PR DESCRIPTION
## Overview
This PR fixes the free membership creation when direct debit is the default payment method as currently admin users are unable to create the free membesrhip because they direct debit requires mandate to be selected so this restricts the creation of free membership.

This PR resolves the issue by working in a way that if user selects any free membership and payment block gets hidden so this PR changes the payment method from direct debit to accounts receivable hence user can successfully create any free membership and if user switches to paid membership this Pr again switches the payment method to default payment method.
