### PR TITLE
ASESPRT-783: Fix Status For 0 Amount Contributions

### DIFF
--- a/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
+++ b/Civi/Financeextras/Event/Listener/ContributionPaymentUpdatedListener.php
@@ -19,6 +19,7 @@ class ContributionPaymentUpdatedListener {
     $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('id', '=', $contributionId)
       ->addWhere('contribution_status_id:name', 'IN', $allowedStatus)
+      ->addWhere('total_amount', '!=', 0)
       ->execute()
       ->first();
 

--- a/tests/phpunit/Civi/Financeextras/ApiWrapper/PaymentTest.php
+++ b/tests/phpunit/Civi/Financeextras/ApiWrapper/PaymentTest.php
@@ -28,7 +28,7 @@ class PaymentTest extends BaseHeadlessTest {
     self::$contribution = ContributionFabricator::fabricate($contributionParams);
   }
 
-  public function setUp() {
+  public function setUp(): void {
   }
 
   public function testMakingPartialPaymentUpdatesContributionToPartiallyPaid(): void {
@@ -52,6 +52,22 @@ class PaymentTest extends BaseHeadlessTest {
       'trxn_id' => self::$contribution['trxn_id'],
       'is_send_contribution_notification' => FALSE,
     ]);
+    $contribution = civicrm_api3('Contribution', 'getSingle', ['id' => self::$contribution['id']]);
+
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+  }
+
+  public function testZeroAmountContributionIsCreatedAsCompleted(): void {
+    $contact = ContactFabricator::fabricate();
+    self::$contribution = ContributionFabricator::fabricate([
+      'financial_type_id' => 'Donation',
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 0.00,
+      'contact_id' => $contact['id'],
+      'payment_instrument_id' => 'Credit Card',
+      'currency' => 'GBP',
+    ]);
+
     $contribution = civicrm_api3('Contribution', 'getSingle', ['id' => self::$contribution['id']]);
 
     $this->assertEquals('Completed', $contribution['contribution_status']);


### PR DESCRIPTION
## Overview
Currently when a contribution of amount 0 is created either through membership purchase or event registration it gets created with pending status. This PR fixes this issue and now 0 amount contributions will get created with completed status.

## Technical Details
In [this](https://github.com/compucorp/io.compuco.financeextras/pull/74/commits/f32b187d1dc9c601087e79730033cebc59d12e59) commit we added an event listener that runs whenever a payment is made or contribution is created or updated, it calculates and updates the contribution status based upon total amount and paid amount. But we dont want it to run for contributions that have amount as 0 so we don't update the status for 0 amount contributions as these should always be in completed status since there is no payment to be made.