### PR TITLE
COMCL-1391: Fix Handling Of Overpayment Financial Type Field

### DIFF
--- a/CRM/Financeextras/Form/Company/Add.php
+++ b/CRM/Financeextras/Form/Company/Add.php
@@ -173,7 +173,7 @@ class CRM_Financeextras_Form_Company_Add extends CRM_Core_Form {
     $params['creditnote_prefix'] = $submittedValues['creditnote_prefix'];
     $params['next_creditnote_number'] = $submittedValues['next_creditnote_number'];
     $params['receivable_payment_method'] = $submittedValues['receivable_payment_method'];
-    $params['overpayment_financial_type_id'] = !empty($submittedValues['overpayment_financial_type_id']) ? $submittedValues['overpayment_financial_type_id'] : NULL;
+    $params['overpayment_financial_type_id'] = !empty($submittedValues['overpayment_financial_type_id']) ? $submittedValues['overpayment_financial_type_id'] : 'NULL';
 
     CRM_Financeextras_BAO_Company::create($params);
 

--- a/tests/phpunit/CRM/Financeextras/Form/Company/AddTest.php
+++ b/tests/phpunit/CRM/Financeextras/Form/Company/AddTest.php
@@ -111,6 +111,29 @@ class CRM_Financeextras_Form_Company_AddTest extends BaseHeadlessTest {
     $this->assertEquals($params['next_invoice_number'], $records[0]['next_invoice_number']);
   }
 
+  public function testUpdatingCompanyRemovesOverpaymentFinancialTypeWhenCleared() {
+    $params = [
+      'contact_id' => 1,
+      'invoice_template_id' => 1,
+      'invoice_prefix' => 'INV_',
+      'next_invoice_number' => '000001',
+      'creditnote_template_id' => 1,
+      'creditnote_prefix' => 'CN_',
+      'next_creditnote_number' => '000002',
+      'receivable_payment_method' => 1,
+      'overpayment_financial_type_id' => 1,
+    ];
+    $company = CRM_Financeextras_BAO_Company::create($params);
+
+    $_REQUEST['id'] = $company->id;
+    $params['overpayment_financial_type_id'] = '';
+    $this->submitForm($params);
+    unset($_REQUEST['id']);
+
+    $updatedCompany = CRM_Financeextras_BAO_Company::getById($company->id);
+    $this->assertNull($updatedCompany->overpayment_financial_type_id);
+  }
+
   private function submitForm($formValues) {
     $form = new CRM_Financeextras_Form_Company_Add();
     $form->controller = new CRM_Core_Controller_Simple('CRM_Financeextras_Form_Company_Add', '');


### PR DESCRIPTION
## Overview
This Pr fixes an issue with overpayment financial type field in company add/update form due to which when user removed the value in this field and saved the form the old value was still persisted so users were not able to remove the value from this field for any company.

## Technical Details
This was due to the fact that when user removed the field and submitted the form we were explicitly setting the value for this field as null and civi was ignoring the value since it was null but now this PR handles this by providing the string 'null' in case if user submitted the form with empty value, which the CiviCRM DAO layer correctly interprets as a request to set the database field to NULL..