### PR TITLE
CSTSPRT-288: Handle Contribution Transfer For Contact Merge

### DIFF
--- a/Civi/Financeextras/Hook/Merge/ContactMerge.php
+++ b/Civi/Financeextras/Hook/Merge/ContactMerge.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Civi\Financeextras\Hook\Merge;
+
+/**
+ * Preserves ownership of event and membership contributions when two contact records are merged.
+ */
+class ContactMerge {
+
+  /**
+   * @var string
+   *   The hook "type" – we only act when $type is 'sqls'.
+   */
+  private string $type;
+
+  /**
+   * @var array
+   *   Reference to the array of SQL statements that CiviCRM will execute.
+   */
+  private array $sqls;
+
+  /**
+   * @var int
+   *   The id of the contact that is being kept (merge target).
+   */
+  private int $mainId;
+
+  /**
+   * @var int
+   *   The id of the contact that is being deleted (merge source).
+   */
+  private int $otherId;
+
+  public function __construct(string $type, array &$sqls, int $mainId, int $otherId) {
+    $this->type = $type;
+    $this->sqls = &$sqls;
+    $this->mainId = $mainId;
+    $this->otherId = $otherId;
+  }
+
+  /**
+   * Determines whether the hook should run for the current invocation.
+   */
+  public static function shouldHandle(string $type, ?int $mainId, ?int $otherId): bool {
+    return $type === 'sqls' && !empty($mainId) && !empty($otherId);
+  }
+
+  /**
+   * Entry point for the hook.
+   *
+   * Appends UPDATE statements to $sqls that preserves the contribution contact_id.
+   */
+  public function handle(): void {
+    $contributions = array_merge(
+      $this->getEventContributionsOwnedByOrganisation(),
+      $this->getMembershipContributionsOwnedByOrganisation()
+    );
+
+    $this->appendRestoreOwnershipSqls($contributions);
+  }
+
+  /**
+   * Returns contributions that are linked to events.
+   *
+   * NOTE ON WHY APIv4 IS NOT USED HERE
+   * ----------------------------------
+   * The logical query we need is a three-hop join:
+   *
+   *   civicrm_contribution
+   *     -> civicrm_participant_payment (by contribution_id)
+   *     -> civicrm_participant         (by participant_id)
+   *     -> civicrm_contact             (contribution.contact_id must be an Organisation)
+   *
+   * But APIv4's query builder cannot express this graph reliably
+   *
+   * @return array
+   *   A list of ['id' => contributionId, 'contact_id' => organisationId].
+   */
+  private function getEventContributionsOwnedByOrganisation(): array {
+    $query = "
+      SELECT contribution.id          AS id,
+             contribution.contact_id  AS contact_id
+        FROM civicrm_contribution         contribution
+  INNER JOIN civicrm_participant_payment  pp          ON pp.contribution_id  = contribution.id
+  INNER JOIN civicrm_participant          participant ON participant.id      = pp.participant_id
+  INNER JOIN civicrm_contact              org         ON org.id              = contribution.contact_id
+                                                    AND org.contact_type   = 'Organization'
+       WHERE participant.contact_id = %1
+         AND contribution.contact_id <> %1
+    ";
+
+    return $this->fetchContributionRows($query);
+  }
+
+  /**
+   * Returns contributions that are linked to memberships.
+   *
+   * @return array
+   *   A list of ['id' => contributionId, 'contact_id' => organisationId].
+   */
+  private function getMembershipContributionsOwnedByOrganisation(): array {
+    $query = "
+      SELECT contribution.id          AS id,
+             contribution.contact_id  AS contact_id
+        FROM civicrm_contribution         contribution
+  INNER JOIN civicrm_membership_payment   mp          ON mp.contribution_id  = contribution.id
+  INNER JOIN civicrm_membership           membership  ON membership.id       = mp.membership_id
+  INNER JOIN civicrm_contact              org         ON org.id              = contribution.contact_id
+                                                     AND org.contact_type   = 'Organization'
+       WHERE membership.contact_id = %1
+         AND contribution.contact_id <> %1
+    ";
+
+    return $this->fetchContributionRows($query);
+  }
+
+  /**
+   * @param string $query
+   * @return array
+   */
+  private function fetchContributionRows(string $query): array {
+    $rows = [];
+    $dao = \CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->otherId, 'Integer'],
+    ]);
+
+    while ($dao->fetch()) {
+      $rows[] = [
+        'id' => $dao->id,
+        'contact_id' => $dao->contact_id,
+      ];
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Appends UPDATE statements to $sqls that reset each contribution's contact_id.
+   *
+   * @param array $contributions
+   */
+  private function appendRestoreOwnershipSqls(array $contributions): void {
+    foreach ($contributions as $contribution) {
+      $contributionId = (int) ($contribution['id'] ?? 0);
+      $organisationId = (int) ($contribution['contact_id'] ?? 0);
+
+      if ($contributionId <= 0 || $organisationId <= 0) {
+        continue;
+      }
+
+      $this->sqls[] = "UPDATE civicrm_contribution SET contact_id = {$organisationId} WHERE id = {$contributionId}";
+    }
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -219,6 +219,21 @@ function financeextras_civicrm_buildForm($formName, &$form) {
 }
 
 /**
+ * Implements hook_civicrm_merge().
+ */
+function financeextras_civicrm_merge($type, &$data, $mainId = NULL, $otherId = NULL, $tables = NULL) {
+  $hooks = [
+    \Civi\Financeextras\Hook\Merge\ContactMerge::class,
+  ];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($type, $mainId, $otherId)) {
+      (new $hook($type, $data, $mainId, $otherId))->handle();
+    }
+  }
+}
+
+/**
  * Implements hook_civicrm_alterMailParams().
  */
 function financeextras_civicrm_alterMailParams(&$params, $context) {

--- a/tests/phpunit/Civi/Financeextras/Hook/Merge/ContactMergeTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/Merge/ContactMergeTest.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Civi\Financeextras\Hook\Merge;
+
+use BaseHeadlessTest;
+use Civi\Financeextras\Test\Fabricator\ContactFabricator;
+use Civi\Financeextras\Test\Fabricator\MembershipFabricator;
+use Civi\Financeextras\Test\Fabricator\MembershipTypeFabricator;
+
+/**
+ * Tests for Civi\Financeextras\Hook\Merge\ContactMerge.
+ *
+ * @group headless
+ */
+class ContactMergeTest extends BaseHeadlessTest {
+
+  public function testShouldHandleReturnsFalseForNonSqlsType() {
+    $this->assertFalse(ContactMerge::shouldHandle('cidRefs', 1, 2));
+    $this->assertFalse(ContactMerge::shouldHandle('eidRefs', 1, 2));
+    $this->assertFalse(ContactMerge::shouldHandle('relTables', 1, 2));
+  }
+
+  public function testShouldHandleReturnsFalseWhenEitherIdIsMissing() {
+    $this->assertFalse(ContactMerge::shouldHandle('sqls', NULL, 2));
+    $this->assertFalse(ContactMerge::shouldHandle('sqls', 1, NULL));
+    $this->assertFalse(ContactMerge::shouldHandle('sqls', 0, 2));
+    $this->assertFalse(ContactMerge::shouldHandle('sqls', 1, 0));
+  }
+
+  public function testShouldHandleReturnsTrueForSqlsTypeWithBothIds() {
+    $this->assertTrue(ContactMerge::shouldHandle('sqls', 1, 2));
+  }
+
+  public function testHandleAppendsRestoreSqlForEventContributionPaidByOrganisation() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+    $employer = ContactFabricator::fabricateOrganization();
+
+    [$contributionId] = $this->createEventContributionLinkedToParticipant(
+      $otherContact['id'],
+      $employer['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertTrue(
+      in_array(
+        "UPDATE civicrm_contribution SET contact_id = {$employer['id']} WHERE id = {$contributionId}",
+        $sqls,
+        TRUE
+      ),
+      'Expected restore UPDATE for organisation-paid event contribution to be appended to $sqls.'
+    );
+  }
+
+  public function testHandleDoesNotAppendRestoreSqlForSelfPaidEventContribution() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+
+    $this->createEventContributionLinkedToParticipant(
+      $otherContact['id'],
+      $otherContact['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertEmpty(
+      $sqls,
+      'Self-paid event contribution must not trigger a restore UPDATE.'
+    );
+  }
+
+  public function testHandleDoesNotAppendRestoreSqlForEventContributionPaidByAnotherIndividual() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+    $thirdPartyIndividual = ContactFabricator::fabricate();
+
+    // Payer is an Individual (not an Organisation), so the employer-
+    // preservation rule does NOT apply and nothing should be appended.
+    $this->createEventContributionLinkedToParticipant(
+      $otherContact['id'],
+      $thirdPartyIndividual['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertEmpty(
+      $sqls,
+      'Event contribution paid by a non-Organisation must not trigger a restore UPDATE.'
+    );
+  }
+
+  public function testHandleAppendsRestoreSqlForMembershipContributionPaidByOrganisation() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+    $employer = ContactFabricator::fabricateOrganization();
+
+    [$contributionId] = $this->createMembershipContributionLinkedToMembership(
+      $otherContact['id'],
+      $employer['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertTrue(
+      in_array(
+        "UPDATE civicrm_contribution SET contact_id = {$employer['id']} WHERE id = {$contributionId}",
+        $sqls,
+        TRUE
+      ),
+      'Expected restore UPDATE for organisation-paid membership contribution to be appended to $sqls.'
+    );
+  }
+
+  public function testHandleDoesNotAppendRestoreSqlForSelfPaidMembershipContribution() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+
+    $this->createMembershipContributionLinkedToMembership(
+      $otherContact['id'],
+      $otherContact['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertEmpty(
+      $sqls,
+      'Self-paid membership contribution must not trigger a restore UPDATE.'
+    );
+  }
+
+  public function testHandleDoesNotAppendRestoreSqlForMembershipContributionPaidByAnotherIndividual() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+    $thirdPartyIndividual = ContactFabricator::fabricate();
+
+    // Payer is an Individual (not an Organisation), so the employer-
+    // preservation rule does NOT apply and nothing should be appended.
+    $this->createMembershipContributionLinkedToMembership(
+      $otherContact['id'],
+      $thirdPartyIndividual['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertEmpty(
+      $sqls,
+      'Membership contribution paid by a non-Organisation must not trigger a restore UPDATE.'
+    );
+  }
+
+  public function testHandleAppendsRestoreSqlsForBothEventAndMembershipContributionsInSameMerge() {
+    $mainContact = ContactFabricator::fabricate();
+    $otherContact = ContactFabricator::fabricate();
+    $employer = ContactFabricator::fabricateOrganization();
+
+    [$eventContributionId] = $this->createEventContributionLinkedToParticipant(
+      $otherContact['id'],
+      $employer['id']
+    );
+    [$membershipContributionId] = $this->createMembershipContributionLinkedToMembership(
+      $otherContact['id'],
+      $employer['id']
+    );
+
+    $sqls = $this->runHandle($mainContact['id'], $otherContact['id']);
+
+    $this->assertTrue(
+      in_array(
+        "UPDATE civicrm_contribution SET contact_id = {$employer['id']} WHERE id = {$eventContributionId}",
+        $sqls,
+        TRUE
+      ),
+      'Event contribution restore UPDATE missing from $sqls in combined merge scenario.'
+    );
+    $this->assertTrue(
+      in_array(
+        "UPDATE civicrm_contribution SET contact_id = {$employer['id']} WHERE id = {$membershipContributionId}",
+        $sqls,
+        TRUE
+      ),
+      'Membership contribution restore UPDATE missing from $sqls in combined merge scenario.'
+    );
+  }
+
+  public function testHandleDoesNotAppendRestoreSqlWhenOrganisationBeingMergedIsItsOwnPayer() {
+    // Edge case: CiviCRM allows merging two Organisations. If the "other"
+    // organisation paid for its own participant/membership record,
+    // contribution.contact_id equals $otherId and the contact_type IS
+    // 'Organization' – so the Organisation filter alone would match it.
+    // The explicit contact_id <> %1 guard must exclude this row so that
+    // core's behaviour (move the contribution to the surviving org) is
+    // preserved.
+    $mainOrganisation = ContactFabricator::fabricateOrganization();
+    $otherOrganisation = ContactFabricator::fabricateOrganization();
+
+    $this->createEventContributionLinkedToParticipant(
+      $otherOrganisation['id'],
+      $otherOrganisation['id']
+    );
+
+    $sqls = $this->runHandle($mainOrganisation['id'], $otherOrganisation['id']);
+
+    $this->assertEmpty(
+      $sqls,
+      'Contribution whose payer is the organisation being merged away must not be restored.'
+    );
+  }
+
+  /**
+   * Instantiates the hook with a fresh $sqls array and returns it after
+   * handle() has run.
+   */
+  private function runHandle(int $mainId, int $otherId): array {
+    $sqls = [];
+    (new ContactMerge('sqls', $sqls, $mainId, $otherId))->handle();
+    return $sqls;
+  }
+
+  /**
+   * @return array [contributionId, participantId]
+   */
+  private function createEventContributionLinkedToParticipant(int $participantContactId, int $payerContactId): array {
+    $eventId = civicrm_api3('Event', 'create', [
+      'title'         => 'Merge Test Event ' . uniqid(),
+      'event_type_id' => 1,
+      'start_date'    => date('Y-m-d'),
+      'is_active'     => 1,
+    ])['id'];
+
+    $participantId = civicrm_api3('Participant', 'create', [
+      'event_id'      => $eventId,
+      'contact_id'    => $participantContactId,
+      'status_id'     => 'Registered',
+      'role_id'       => 'Attendee',
+      'register_date' => date('Y-m-d H:i:s'),
+    ])['id'];
+
+    $contributionId = $this->insertContribution($payerContactId, 'Event Fee');
+
+    \CRM_Core_DAO::executeQuery(
+      'INSERT INTO civicrm_participant_payment (contribution_id, participant_id) VALUES (%1, %2)',
+      [
+        1 => [$contributionId, 'Integer'],
+        2 => [$participantId, 'Integer'],
+      ]
+    );
+
+    return [$contributionId, $participantId];
+  }
+
+  /**
+   * @return array [contributionId, membershipId]
+   */
+  private function createMembershipContributionLinkedToMembership(int $membershipContactId, int $payerContactId): array {
+    $membershipType = MembershipTypeFabricator::fabricate([
+      'name'        => 'Merge Test Membership ' . uniqid(),
+      'minimum_fee' => 100,
+    ]);
+
+    $membership = MembershipFabricator::fabricate([
+      'contact_id'         => $membershipContactId,
+      'membership_type_id' => $membershipType['id'],
+      'join_date'          => date('Y-m-d'),
+      'start_date'         => date('Y-m-d'),
+      'financial_type_id'  => 'Member Dues',
+      'skipLineItem'       => 1,
+    ]);
+
+    $contributionId = $this->insertContribution($payerContactId, 'Member Dues');
+
+    \CRM_Core_DAO::executeQuery(
+      'INSERT INTO civicrm_membership_payment (contribution_id, membership_id) VALUES (%1, %2)',
+      [
+        1 => [$contributionId, 'Integer'],
+        2 => [$membership['id'], 'Integer'],
+      ]
+    );
+
+    return [$contributionId, $membership['id']];
+  }
+
+  /**
+   * @retunr int
+   */
+  private function insertContribution(int $contactId, string $financialTypeName): int {
+    $statuses = array_flip(
+      \CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate')
+    );
+    $financialTypeId = (int) civicrm_api3('FinancialType', 'getvalue', [
+      'name'   => $financialTypeName,
+      'return' => 'id',
+    ]);
+
+    \CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_contribution
+         (contact_id, financial_type_id, receive_date, total_amount, payment_instrument_id, trxn_id, currency, contribution_status_id)
+       VALUES
+         (%1, %2, %3, 100, 1, %4, 'GBP', %5)",
+      [
+        1 => [$contactId, 'Integer'],
+        2 => [$financialTypeId, 'Integer'],
+        3 => [date('Y-m-d'), 'String'],
+        4 => [md5(uniqid('', TRUE)), 'String'],
+        5 => [$statuses['Completed'], 'Integer'],
+      ]
+    );
+
+    return (int) \CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()');
+  }
+
+}


### PR DESCRIPTION
## Overview
When two contacts are merged in CiviCRM, any event or membership fee that was paid by the "other" contact's relationship, was ending up attached to the surviving contact after the merge. This change keeps the contribution linked to the original contributor that actually paid for it.

## Before
After merging contact A (whose employer organisation C had paid for their event registration and membership) into contact B:

The event fee contribution's Paid by switched from C to B.
The membership fee contribution behaved the same way.
Financial reports stopped attributing those payments to C, breaking the audit trail for organisations that pay on behalf of their staff.

## After
After the same merge:

Event and membership contributions whose contact_id was originally an Organisation remain attached to that Organisation.
Contributions that the individual paid for themselves still follow core behaviour and move to the surviving contact (unchanged).
Contributions paid by a third-party individual (not an Organisation) are not affected — the employer-preservation rule only activates when the payer is an Organisation.

## Technical Details

Implements hook_civicrm_merge in the io.compuco.financeextras extension. The hook runs in the sqls phase and appends restore UPDATE statements to the $sqls array that CiviCRM's dedupe merger is about to execute — so our statements run after core's rewrite of civicrm_contribution.contact_id and effectively put the organisation back.
Root cause lives in core's CRM_Dedupe_Merger::relatedTablesSql(), which unconditionally rewrites civicrm_contribution.contact_id for every contribution whose participant / membership row belongs to the "other" contact, regardless of whether the current contact_id is that contact or their employer organisation.
New class — Civi\Financeextras\Hook\Merge\ContactMerge
Follows the existing dispatcher + shouldHandle() / handle() pattern used by every other hook in this extension (BuildForm, ValidateForm, PostProcess, …).

shouldHandle() restricts execution to $type === 'sqls' and requires both contact ids — CiviCRM fires hook_civicrm_merge multiple times per merge with different types; we only need the final SQL phase.
handle() runs two lookups (events via civicrm_participant_payment, memberships via civicrm_membership_payment), each filtered to payer = Organisation AND payer ≠ otherId (so merging an Organisation into another Organisation still follows core behaviour on its own self-paid rows). For each matching contribution it appends:

sql  UPDATE civicrm_contribution SET contact_id = {orgId} WHERE id = {contributionId}
### Registration in financeextras.php

New financeextras_civicrm_merge() that loops through a $hooks array and invokes the hook class, matching how buildForm, validateForm, postProcess etc. are already wired. Adding future merge-time behaviour is a one-line change.
### Why raw SQL instead of APIv4

The required query is a three-hop join: civicrm_contribution → civicrm_participant_payment → civicrm_participant → civicrm_contact (and the equivalent via civicrm_membership_payment). APIv4's query builder in the CiviCRM version this extension targets cannot express it reliably:

Stacking explicit addJoin() calls and referencing a prior join's alias inside a later ON condition fails validation ("Invalid field 'pp.participant_id'") because Api4SelectQuery::getField() in strict mode does not trigger the FK auto-join resolver for join ON clauses.
Keeping a single explicit join on ParticipantPayment and using dot-notation in addWhere (pp.participant_id.contact_id) also fails — chaining implicit FK joins off an explicit-join alias is not resolved by autoJoinFK() in this version.

Raw SQL via CRM_Core_DAO::executeQuery() is used instead, with $otherId bound as an Integer parameter — no user input reaches the query string unescaped. The rationale is captured in the docblock on getEventContributionsOwnedByOrganisation() so a future reader doesn't re-litigate the choice.

## Core overrides
None. Purely additive — implements a hook that core already provides.