### PR TITLE
CIVIMM-519: Fix Void Contribution Permission

### DIFF
--- a/xml/Menu/financeextras.xml
+++ b/xml/Menu/financeextras.xml
@@ -97,7 +97,7 @@
     <path>civicrm/financeextras/contribution/void</path>
     <page_callback>CRM_Financeextras_Form_Contribute_ContributionVoid</page_callback>
     <title>Void Contribution</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>edit contributions</access_arguments>
   </item>
   <item>
     <path>civicrm/contribution/overpayment/allocate</path>


### PR DESCRIPTION
## Overview
This Pr fixes a permission issue due to which the users with correct contribution modification permissions were unable to access the void contribution page.

## Technical Details
For showing the void contribution link [here](https://github.com/compucorp/io.compuco.financeextras/blob/master/Civi/Financeextras/Hook/Links/Contribution/CreditNote.php#L65) we only check if the user has `edit contributions` permission but while defining the route for void contribution page we were wrongly checking `administer civicrm` permission which has been corrected by this PR