### PR TITLE
COMCL-1470: Restrict Cache Clear To A Particular Scope

### DIFF
--- a/Civi/Financeextras/Hook/AlterMailContent/ContributionTemplate.php
+++ b/Civi/Financeextras/Hook/AlterMailContent/ContributionTemplate.php
@@ -23,7 +23,7 @@ class ContributionTemplate {
     }
 
     $this->content = json_decode(base64_decode($templateContent), TRUE);
-    \Civi::cache('session')->clear('fe_org_message_template');
+    \Civi::cache('session')->delete('fe_org_message_template');
   }
 
   public static function shouldHandle($content) {

--- a/tests/phpunit/Civi/Financeextras/Hook/AlterMailContent/ContributionTemplateTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/AlterMailContent/ContributionTemplateTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Civi\Financeextras\Hook\AlterMailContent;
+
+use BaseHeadlessTest;
+
+/**
+ * @group headless
+ */
+class ContributionTemplateTest extends BaseHeadlessTest {
+
+  private const CACHE_KEY = 'fe_org_message_template';
+
+  public function tearDown(): void {
+    \Civi::cache('session')->delete(self::CACHE_KEY);
+    parent::tearDown();
+  }
+
+  public function testHandleReplacesContentWithOrganisationTemplate(): void {
+    $fakeContent = ['subject' => 'Test Subject', 'body_html' => '<p>Hello</p>', 'body_text' => 'Hello'];
+    \Civi::cache('session')->set(self::CACHE_KEY, base64_encode(json_encode($fakeContent)));
+
+    $content = ['workflow_name' => 'contribution_invoice_receipt', 'subject' => 'Original', 'body_html' => ''];
+    $hook = new ContributionTemplate($content);
+    $hook->handle();
+
+    $this->assertEquals($fakeContent, $content);
+  }
+
+  public function testHandleDeletesOnlyTheTemplateKeyFromSessionCache(): void {
+    $fakeContent = ['subject' => 'Test', 'body_html' => '', 'body_text' => ''];
+    \Civi::cache('session')->set(self::CACHE_KEY, base64_encode(json_encode($fakeContent)));
+
+    // Store an unrelated key that must survive the call.
+    $sentinelKey = 'unrelated_session_key';
+    \Civi::cache('session')->set($sentinelKey, 'sentinel_value');
+
+    $content = ['workflow_name' => 'contribution_invoice_receipt'];
+    $hook = new ContributionTemplate($content);
+    $hook->handle();
+
+    // The template key must be gone.
+    $this->assertNull(\Civi::cache('session')->get(self::CACHE_KEY),
+      'fe_org_message_template should be deleted from the session cache after handle().'
+    );
+
+    // The unrelated key must still be present — clear() would have wiped it.
+    $this->assertEquals('sentinel_value', \Civi::cache('session')->get($sentinelKey),
+      'handle() must not wipe unrelated session cache entries (regression: clear() vs delete()).'
+    );
+
+    \Civi::cache('session')->delete($sentinelKey);
+  }
+
+  public function testHandleDoesNothingWhenCacheKeyIsAbsent(): void {
+    \Civi::cache('session')->delete(self::CACHE_KEY);
+
+    $originalContent = ['workflow_name' => 'contribution_invoice_receipt', 'subject' => 'Original'];
+    $content = $originalContent;
+    $hook = new ContributionTemplate($content);
+    $hook->handle();
+
+    $this->assertEquals($originalContent, $content);
+  }
+
+  public function testShouldHandleReturnsTrueOnlyForInvoiceReceiptWorkflow(): void {
+    $this->assertTrue(ContributionTemplate::shouldHandle(['workflow_name' => 'contribution_invoice_receipt']));
+    $this->assertFalse(ContributionTemplate::shouldHandle(['workflow_name' => 'contribution_online_receipt']));
+    $this->assertFalse(ContributionTemplate::shouldHandle([]));
+  }
+
+}


### PR DESCRIPTION
## Overview

Fixes a bug where completing a contribution payment redirected the user back to the initial contribution page instead of the ThankYou page when the "Email Receipt to Contributor" setting was enabled on the contribution page. All contribution records were being created correctly in both cases.

## Before

When a contribution page had "Email Receipt to Contributor" enabled, a user completing a Stripe payment was unexpectedly redirected back to the first page of the contribution form instead of the ThankYou/confirmation page. Disabling the email receipt setting caused the correct ThankYou redirect to happen.
<img width="1777" height="857" alt="screen_recording_before" src="https://github.com/user-attachments/assets/eb348ad1-1966-4857-8fc0-9e5fd627edc8" />


## After

Users are correctly redirected to the ThankYou page after completing a payment regardless of whether the "Email Receipt to Contributor" setting is enabled.
<img width="1777" height="857" alt="screen_recording_after" src="https://github.com/user-attachments/assets/4b754c31-6497-4907-a24a-15f950f219d1" />


## Technical Details

The root cause was a one-word error in `Civi/Financeextras/Hook/AlterMailContent/ContributionTemplate.php` line 26.

When a contribution receipt email is sent, the `alterMailParams` hook (`InvoiceTemplate`) pre-renders the organisation-specific invoice template and stores it in `Civi::cache('session')` under the key `fe_org_message_template`. The `alterMailContent` hook (`ContributionTemplate`) then reads that value and was supposed to clean up only that single key afterwards.

However, the cleanup call was:

```php
\Civi::cache('session')->clear('fe_org_message_template');
```

`Civi::cache('session')` resolves to a `CRM_Utils_Cache_SqlGroup` instance backed by the **"CiviCRM Session"** group — the same storage that holds all QuickForm (QF) form state (confirmed by the comment in `Civi/Core/Container.php`: *"Putting session-cache in global scope means that QF form-state will endure"*).

`clear()` is a PSR-16 method that accepts **no arguments** and wipes **the entire cache group** — it calls `flush()` which executes `DELETE FROM civicrm_cache WHERE {group = 'CiviCRM Session'}`. The `'fe_org_message_template'` string passed as an argument was silently ignored.

This destroyed all QuickForm session data for the user mid-payment. When CiviCRM then tried to load the ThankYou page it could not find the session data for the `qfKey`, called `invalidKeyRedirect()`, and sent the user back to the initial contribution page.

The fix replaces `clear()` with the correct PSR-16 `delete($key)` method, which removes only the single named key:

```php
// Before (wipes entire session cache):
\Civi::cache('session')->clear('fe_org_message_template');

// After (removes only the specific key):
\Civi::cache('session')->delete('fe_org_message_template');
```

A new test class `ContributionTemplateTest` has been added covering:
- Content is correctly replaced when the cache key is present
- **Only** the `fe_org_message_template` key is removed — other session cache entries survive (direct regression test for this bug)
- Content is left unchanged when the cache key is absent
- `shouldHandle()` returns `true` only for the `contribution_invoice_receipt` workflow

### Core overrides

None.

## Comments

The bug only manifested when email receipts were enabled because the `alterMailContent` hook only fires during actual email sending. With receipts disabled, `clear()` was never called and the session was never wiped.

