### PR TITLE
CIVIMM-530: Change Date Field Label

### DIFF
--- a/Civi/Financeextras/Hook/BuildForm/AdditionalPaymentDateLabel.php
+++ b/Civi/Financeextras/Hook/BuildForm/AdditionalPaymentDateLabel.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Civi\Financeextras\Hook\BuildForm;
+
+/**
+ * Renames the transaction date field label to 'Date' on the additional payment form.
+ */
+class AdditionalPaymentDateLabel {
+
+  /**
+   * @var \CRM_Contribute_Form_AdditionalPayment
+   *   Form object that is being altered.
+   */
+  private \CRM_Contribute_Form_AdditionalPayment $form;
+
+  /**
+   * AdditionalPaymentDateLabel constructor.
+   *
+   * @param \CRM_Contribute_Form_AdditionalPayment $form
+   */
+  public function __construct(\CRM_Contribute_Form_AdditionalPayment &$form) {
+    $this->form = $form;
+  }
+
+  public function handle(): void {
+    $element = $this->form->getElement('trxn_date');
+    if ($element->getLabel() === ts('Refund Date')) {
+      return;
+    }
+
+    $element->setLabel(ts('Date'));
+  }
+
+  public static function shouldHandle(\HTML_QuickForm $form, string $formName): bool {
+    if ($formName !== 'CRM_Contribute_Form_AdditionalPayment' || !$form->elementExists('trxn_date')) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/financeextras.php
+++ b/financeextras.php
@@ -208,6 +208,7 @@ function financeextras_civicrm_buildForm($formName, &$form) {
     \Civi\Financeextras\Hook\BuildForm\FinancialBatchSearch::class,
     \Civi\Financeextras\Hook\BuildForm\FinancialAccount::class,
     \Civi\Financeextras\Hook\BuildForm\AdditionalPaymentButton::class,
+    \Civi\Financeextras\Hook\BuildForm\AdditionalPaymentDateLabel::class,
     \Civi\Financeextras\Hook\BuildForm\PaymentCreate::class,
     \Civi\Financeextras\Hook\BuildForm\RefundCreditNotePaymentInformation::class,
   ];


### PR DESCRIPTION
Overview
----------------------------------------
This PR updates the date label on the additional payment form as the current labe 'Contribution date' is confusing because in reality its not the contribution date but the payment date. So this PR changes the label to 'Date'.

Before
----------------------------------------
<img width="1792" height="1120" alt="Screenshot 2026-06-12 at 6 04 16 PM" src="https://github.com/user-attachments/assets/e92713e4-9093-4222-808a-e09170d646e5" />


After
----------------------------------------
<img width="1792" height="1120" alt="Screenshot 2026-06-12 at 6 03 56 PM" src="https://github.com/user-attachments/assets/d6d77492-10bf-427e-8168-47aa39d45f6e" />


## Technical Details
This PR utilizes the build form hook that runs only for additional payment form and updates the label for **trxn_date** element.

### Core overrides
None

## Comments
None
