### PR TITLE
Default the 'create credit note' checkbox to checked on the refund form

### DIFF
--- a/CRM/Financeextras/Form/Payment/Refund.php
+++ b/CRM/Financeextras/Form/Payment/Refund.php
@@ -124,6 +124,24 @@ class CRM_Financeextras_Form_Payment_Refund extends CRM_Core_Form {
   }
 
   /**
+   * Sets the form's default values.
+   *
+   * Defaults the "create credit note" checkbox to checked so that, by default,
+   * a refund also creates and applies a matching credit note. Without this the
+   * contribution is left with an amount owing after the refund and its status
+   * drops to "Pending (Incomplete Transaction)". The checked state must come
+   * from the form defaults - a raw `checked` HTML attribute on the element is
+   * not honoured by CiviCRM's QuickForm checkbox.
+   *
+   * @return array
+   */
+  public function setDefaultValues() {
+    return [
+      'create_credit_note' => 1,
+    ];
+  }
+
+  /**
    * Gets the payment processor name.
    */
   public function getPaymentProcessorNameById(int $Id) {
@@ -199,7 +217,6 @@ class CRM_Financeextras_Form_Payment_Refund extends CRM_Core_Form {
       'create_credit_note' => [
         'type' => 'checkbox',
         'label' => 'Also automatically create a credit note for this amount and apply to this invoice',
-        'extra' => ['checked' => TRUE],
         'required' => FALSE,
       ],
     ];

--- a/tests/phpunit/CRM/Financeextras/Form/Payment/RefundTest.php
+++ b/tests/phpunit/CRM/Financeextras/Form/Payment/RefundTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Tests for the credit card refund form.
+ *
+ * @group headless
+ */
+class CRM_Financeextras_Form_Payment_RefundTest extends BaseHeadlessTest {
+
+  /**
+   * The "also automatically create a credit note" checkbox must default to
+   * checked. If it does not, a refund leaves the contribution with an amount
+   * owing and the contribution status drops to "Pending (Incomplete
+   * Transaction)".
+   *
+   * The checked state must come from the form's default values: a raw `checked`
+   * HTML attribute on the element is not honoured by CiviCRM's QuickForm
+   * checkbox, which is why the box previously rendered unticked.
+   */
+  public function testCreateCreditNoteCheckboxDefaultsToChecked() {
+    $form = new CRM_Financeextras_Form_Payment_Refund();
+
+    $defaults = $form->setDefaultValues();
+
+    $this->assertEquals(
+      1,
+      $defaults['create_credit_note'] ?? NULL,
+      'The "automatically create a credit note" checkbox must default to checked.'
+    );
+  }
+
+}


### PR DESCRIPTION
## Overview
When issuing a credit-card refund, the checkbox **"Also automatically create a credit note for this amount and apply to this invoice"** is meant to be ticked by default, so the refund also creates and applies a matching credit note. It was rendering **unticked**. Unless the user noticed and ticked it, the refunded contribution was left with a balance owing and its status dropped to **"Pending (Incomplete Transaction)"** — which is exactly what a client hit in support.

## Before
On the "Record a credit card refund" screen, the credit-note checkbox is **unticked by default**. Refunding without manually ticking it leaves the contribution as "Pending (Incomplete Transaction)".

_(Confirmed on a live client site via screen recording — the box is empty when the modal opens and stays empty through the flow.)_

## After
The checkbox **defaults to ticked**, so a refund creates and applies the matching credit note by default and the contribution stays "Completed". Users can still untick it if they don't want a credit note.

## Technical Details
Root cause: the field was defined with `'extra' => ['checked' => TRUE]` and added via `$this->add(...)`. A CiviCRM QuickForm checkbox does **not** take its checked state from a raw `checked` HTML attribute — it comes from the form's **default values**. The form had no `setDefaultValues()`, so the box rendered unticked and the `checked` attribute was a no-op.

Fix in `CRM/Financeextras/Form/Payment/Refund.php`:
- Add `setDefaultValues()` returning `['create_credit_note' => 1]`.
- Remove the no-op `'extra' => ['checked' => TRUE]`.

The form is routed via `xml/Menu/financeextras.xml` (`page_callback = CRM_Financeextras_Form_Payment_Refund`) — the standard QuickForm controller, which applies `setDefaultValues()`. The idiomatic pattern is already used elsewhere in this extension (e.g. `CRM/Financeextras/Form/ExchangeRate/Settings.php`).

Present since `68d920d` (PROD-156, 2024-02-19); affects `master` and all releases since.

### Core overrides
None.

## Comments
Added a headless test `tests/phpunit/CRM/Financeextras/Form/Payment/RefundTest.php` asserting the checkbox defaults to checked. It needs **no Stripe / no payment processor** — it checks the form's default value directly. The test is committed **before** the fix (`test:` commit) so it is red without the fix and green with it (reviewers can check out the test commit alone to see it fail). CI runs it.
