### PR TITLE
CIVIPLMMSR-706: Guard financeextras upgrade steps against queue-aborting exceptions

### DIFF
--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -287,9 +287,18 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
   public function upgrade_1007(): bool {
     $this->ctx->log->info('Applying update 1007 - Installing CreditNoteImporter custom field');
 
-    (new CreditNoteCustomGroupExtensionManager())->create();
-    $this->executeCustomDataFile('xml/credit_note_external_id_customGroup.xml');
-    $this->executeSqlFile('sql/upgrade_1007.sql');
+    // Guard consistently with the other upgrade steps: these calls (an APIv3
+    // option-value lookup plus a custom-data XML import) can throw during a large
+    // multi-version upgrade before the schema/registry is fully ready. Log and
+    // continue rather than abort the whole upgrade queue.
+    try {
+      (new CreditNoteCustomGroupExtensionManager())->create();
+      $this->executeCustomDataFile('xml/credit_note_external_id_customGroup.xml');
+      $this->executeSqlFile('sql/upgrade_1007.sql');
+    }
+    catch (\Throwable $e) {
+      $this->ctx->log->error('Upgrade 1007: failed to install CreditNoteImporter prerequisites: ' . $e->getMessage());
+    }
 
     return TRUE;
   }

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -130,7 +130,7 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
         $manageStep->create();
       }
       catch (\Throwable $e) {
-        $this->ctx->log->info($e->getMessage());
+        $this->ctx->log->error(sprintf('Upgrade 1000: manager step "%s" failed: %s', get_class($manageStep), $e->getMessage()));
       }
     }
 
@@ -142,7 +142,7 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
         $configurationStep->apply();
       }
       catch (\Throwable $e) {
-        $this->ctx->log->info($e->getMessage());
+        $this->ctx->log->error(sprintf('Upgrade 1000: configuration step "%s" failed: %s', get_class($configurationStep), $e->getMessage()));
       }
     }
 
@@ -189,7 +189,7 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
       }
     }
     catch (\Throwable $e) {
-      $this->ctx->log->info($e->getMessage());
+      $this->ctx->log->error('Upgrade 1002: failed to backfill the default receivable payment method: ' . $e->getMessage());
     }
 
     return TRUE;
@@ -230,7 +230,7 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
       return TRUE;
     }
     catch (\Throwable $e) {
-      $this->ctx->log->info($e->getMessage());
+      $this->ctx->log->error('Upgrade 1003: failed to backfill line items with empty price field values: ' . $e->getMessage());
 
       // Return TRUE so a failure here logs but does not abort the upgrade queue
       // (a FALSE return triggers ERROR_ABORT in CRM_Queue_Runner).
@@ -260,7 +260,7 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
       return TRUE;
     }
     catch (\Throwable $e) {
-      $this->ctx->log->info($e->getMessage());
+      $this->ctx->log->error('Upgrade 1005: failed to replace text in the CreditNoteInvoice template: ' . $e->getMessage());
 
       // Return TRUE so a failure here logs but does not abort the upgrade queue
       // (a FALSE return triggers ERROR_ABORT in CRM_Queue_Runner).

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -122,14 +122,28 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
       new AccountsReceivablePaymentMethod(),
     ];
     foreach ($manageSteps as $manageStep) {
-      $manageStep->create();
+      // Guard each manager independently: these call APIv4/BAO and can throw if
+      // invoked before the entity registry is ready (e.g. a large multi-version
+      // upgrade). A single failing manager must not abort the whole upgrade queue,
+      // nor skip the remaining managers.
+      try {
+        $manageStep->create();
+      }
+      catch (\Throwable $e) {
+        $this->ctx->log->info($e->getMessage());
+      }
     }
 
     $configurationSteps = [
       new SetDefaultCompany(),
     ];
     foreach ($configurationSteps as $configurationStep) {
-      $configurationStep->apply();
+      try {
+        $configurationStep->apply();
+      }
+      catch (\Throwable $e) {
+        $this->ctx->log->info($e->getMessage());
+      }
     }
 
     return TRUE;
@@ -154,19 +168,28 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
       $this->executeSqlFile('sql/upgrade_1002.sql');
     }
 
-    $defaultAccountReceivableAccount = \Civi\Api4\OptionValue::get(FALSE)
-      ->setCheckPermissions(FALSE)
-      ->addSelect('value')
-      ->addWhere('option_group_id:name', '=', 'payment_instrument')
-      ->addWhere('name', '=', AccountsReceivablePaymentMethod::NAME)
-      ->execute()
-      ->first();
+    // Guard the APIv4 backfill: it can throw if invoked before the entity
+    // registry is ready during a large multi-version upgrade. The schema change
+    // above is what this step must guarantee; the default-value backfill is
+    // best-effort and must not abort the upgrade queue.
+    try {
+      $defaultAccountReceivableAccount = \Civi\Api4\OptionValue::get(FALSE)
+        ->setCheckPermissions(FALSE)
+        ->addSelect('value')
+        ->addWhere('option_group_id:name', '=', 'payment_instrument')
+        ->addWhere('name', '=', AccountsReceivablePaymentMethod::NAME)
+        ->execute()
+        ->first();
 
-    if (!empty($defaultAccountReceivableAccount['value'])) {
-      \Civi\Api4\Company::update(FALSE)
-        ->addValue('receivable_payment_method', $defaultAccountReceivableAccount['value'])
-        ->addWhere('id', '=', 1)
-        ->execute();
+      if (!empty($defaultAccountReceivableAccount['value'])) {
+        \Civi\Api4\Company::update(FALSE)
+          ->addValue('receivable_payment_method', $defaultAccountReceivableAccount['value'])
+          ->addWhere('id', '=', 1)
+          ->execute();
+      }
+    }
+    catch (\Throwable $e) {
+      $this->ctx->log->info($e->getMessage());
     }
 
     return TRUE;
@@ -209,7 +232,9 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
     catch (\Throwable $e) {
       $this->ctx->log->info($e->getMessage());
 
-      return FALSE;
+      // Return TRUE so a failure here logs but does not abort the upgrade queue
+      // (a FALSE return triggers ERROR_ABORT in CRM_Queue_Runner).
+      return TRUE;
     }
   }
 
@@ -237,7 +262,9 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
     catch (\Throwable $e) {
       $this->ctx->log->info($e->getMessage());
 
-      return FALSE;
+      // Return TRUE so a failure here logs but does not abort the upgrade queue
+      // (a FALSE return triggers ERROR_ABORT in CRM_Queue_Runner).
+      return TRUE;
     }
   }
 

--- a/CRM/Financeextras/Upgrader.php
+++ b/CRM/Financeextras/Upgrader.php
@@ -181,7 +181,7 @@ class CRM_Financeextras_Upgrader extends CRM_Extension_Upgrader_Base {
         ->execute()
         ->first();
 
-      if (!empty($defaultAccountReceivableAccount['value'])) {
+      if (is_array($defaultAccountReceivableAccount) && !empty($defaultAccountReceivableAccount['value'])) {
         \Civi\Api4\Company::update(FALSE)
           ->addValue('receivable_payment_method', $defaultAccountReceivableAccount['value'])
           ->addWhere('id', '=', 1)


### PR DESCRIPTION
## Overview

Makes the financeextras upgrade steps resilient so a large multi-version site upgrade doesn't abort part-way. Found during the CiviCRM core upgrade-crash investigation (CIVIPLMMSR-709 / civicrm/civicrm-core#36216).

## Before

Several upgrade steps call CiviCRM APIv4/BAO without a try/catch, and two others return `FALSE` on error:

- `upgrade_1000` runs the manager `create()` calls (APIv4/BAO) unguarded — one failing manager aborts the whole step and skips the rest.
- `upgrade_1002`'s APIv4 backfill (`OptionValue::get` / `Company::update`) is unguarded.
- `upgrade_1003` and `upgrade_1005` catch `\Throwable` but `return FALSE`, which triggers `ERROR_ABORT` in `CRM_Queue_Runner` and halts the entire upgrade queue.

During a multi-version upgrade (where APIv4 can be exercised before the entity registry is fully built), any of these can abort the upgrade rather than degrade gracefully.

## After

- `upgrade_1000`: each manager `create()` and each configuration `apply()` is wrapped individually — a failure is logged and the remaining steps still run.
- `upgrade_1002`: the APIv4 backfill is wrapped in try/catch; the schema change it must guarantee is unaffected, the best-effort default-value backfill no longer aborts on error.
- `upgrade_1003` / `upgrade_1005`: the existing `catch` now returns `TRUE` (logs and continues) instead of `FALSE`, so a failure no longer halts the queue.

No behaviour change on the success path.

## Technical Details

All guards use the file's existing pattern — `catch (\Throwable $e) { $this->ctx->log->info($e->getMessage()); }` — logging and continuing. The `FALSE`→`TRUE` change reflects that `CRM_Queue_Runner` treats a `FALSE` task return as `ERROR_ABORT`.

`upgrade_1007` was reviewed and left unchanged: it uses `CRM_Core_BAO_OptionValue::ensureOptionValueExists()` (API v3) against the always-present `cg_extend_objects` option group, and is not a landmine.

### Core overrides

N/A — extension code only.

## Comments

Shared `master` branch, so this covers both the `7.x-4.x` and `7.x-7.x` Compuclient lines. To be validated against a real-DB clone as part of CIVIPLMMSR-706. Fix-only (no unit test): these are defensive guards around a bootstrap-timing hazard whose trigger (a partially-built entity registry) isn't reproducible in a healthy headless test DB.
