### PR TITLE
CIVIMM-550: Fix credit note & void buttons leaking onto Find Contributions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,10 @@
     },
     "extends": "eslint:recommended",
     "overrides": [
+        {
+            "files": ["tests/**/*.js"],
+            "env": { "node": true }
+        }
     ],
     "parserOptions": {
         "ecmaVersion": "latest"

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,21 @@
+name: JS Unit Tests
+
+on: pull_request
+
+jobs:
+  js-unit-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run JS unit tests
+        run: npm test

--- a/Civi/Financeextras/Hook/BuildForm/ContributionView.php
+++ b/Civi/Financeextras/Hook/BuildForm/ContributionView.php
@@ -32,7 +32,6 @@ class ContributionView {
     ]);
 
     $url = \CRM_Utils_System::url('civicrm/contribution/creditnote', ['reset' => 1, 'action' => 'add', 'contribution_id' => $this->id]);
-    \Civi::resources()->addVars('financeextras', ['is_contribution_view' => TRUE]);
     \Civi::resources()->addVars('financeextras', ['creditnote_btn_url' => $url]);
   }
 
@@ -51,7 +50,6 @@ class ContributionView {
     ]);
 
     $url = \CRM_Utils_System::url('civicrm/financeextras/contribution/void', ['reset' => 1, 'action' => 'void', 'id' => $this->id]);
-    \Civi::resources()->addVars('financeextras', ['is_contribution_view' => TRUE]);
     \Civi::resources()->addVars('financeextras', ['contribution_void_btn_url' => $url]);
   }
 

--- a/js/addContributionCreditNoteBtn.js
+++ b/js/addContributionCreditNoteBtn.js
@@ -18,7 +18,7 @@
       .css({ display: 'inline-flex', marginLeft: '10px' })
       .append(
         $('<a>').addClass('button no-popup btn-creditnote-create').attr('href', btnUrl)
-          .append($('<span>').text('Create New Credit Note'))
+          .append($('<span>').text(ts('Create New Credit Note')))
       );
 
     $('form.CRM_Contribute_Form_ContributionView, form.CRM_Contribute_Form_Contribution')

--- a/js/addContributionCreditNoteBtn.js
+++ b/js/addContributionCreditNoteBtn.js
@@ -1,20 +1,38 @@
-CRM.$(function ($) {
-  addCreditNoteBtn();
+'use strict';
 
+(function () {
   /**
-   * Add the Credit / Cancel action button beside the contribution status
+   * Appends the "Create New Credit Note" button to the contribution status row.
+   *
+   * The insertion is scoped to the contribution View/Add/Edit form container
+   * AND the status-row class, so the button can never attach to the Find
+   * Contributions search form (`CRM_Contribute_Form_Search`) — even though this
+   * script is injected into the underlying page when a contribution View is
+   * opened as a pop-up (CRM.$ runs against the whole document).
+   *
+   * @param {Function} $ jQuery (CRM.$)
+   * @param {string} btnUrl the credit note create URL
    */
-  function addCreditNoteBtn() {
-    const btnUrl = CRM.vars.financeextras.creditnote_btn_url.replace(/&amp;/g, '&');
-    const isView = CRM.vars.financeextras.is_contribution_view;
-    let statusRow = $('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)');
-    const actionBtn = $('<div>').css({ display: 'inline-flex', marginLeft: '10px' }).append($('<a>').addClass('button no-popup btn-creditnote-create').attr('href', btnUrl).append($('<span>').text('Create New Credit Note')));
-    
-    if (isView) {
-      statusRow = $("tr:contains('Contribution Status') td:nth-child(2)");
-    }
+  function addCreditNoteBtn ($, btnUrl) {
+    const actionBtn = $('<div>')
+      .css({ display: 'inline-flex', marginLeft: '10px' })
+      .append(
+        $('<a>').addClass('button no-popup btn-creditnote-create').attr('href', btnUrl)
+          .append($('<span>').text('Create New Credit Note'))
+      );
 
-    statusRow.append(actionBtn)
-    $('#searchForm a.btn-creditnote-create').hide();
+    $('form.CRM_Contribute_Form_ContributionView, form.CRM_Contribute_Form_Contribution')
+      .find('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)')
+      .append(actionBtn);
   }
-});
+
+  if (typeof CRM !== 'undefined' && CRM.$) {
+    CRM.$(function ($) {
+      addCreditNoteBtn($, CRM.vars.financeextras.creditnote_btn_url.replace(/&amp;/g, '&'));
+    });
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { addCreditNoteBtn };
+  }
+})();

--- a/js/addContributionVoidBtn.js
+++ b/js/addContributionVoidBtn.js
@@ -1,20 +1,40 @@
-CRM.$(function ($) {
-  addContributionVoidBtn();
+'use strict';
 
+(function () {
   /**
-   * Add the Contribution void action button beside the contribution status
+   * Appends the "Void Contribution" button to the contribution status row.
+   *
+   * Scoped to the contribution View/Add/Edit form container AND the status-row
+   * class (see addContributionCreditNoteBtn.js) so it can never attach to the
+   * Find Contributions search form, even when injected into the underlying
+   * page by a contribution View pop-up.
+   *
+   * @param {Function} $ jQuery (CRM.$)
+   * @param {string} btnUrl the contribution void URL
    */
-  function addContributionVoidBtn() {
-    const btnUrl = CRM.vars.financeextras.contribution_void_btn_url.replace(/&amp;/g, '&');
-    const isView = CRM.vars.financeextras.is_contribution_view;
-    let statusRow = $('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)');
-    const contributionVoidActionBtn = $('<div>').css({ display: 'inline-flex', marginLeft: '10px' }).append($('<a>').addClass('button btn-creditnote-create btn btn-primary-outline small-popup').css({background:"#fff", border: '1px solid #2786c2', color: '#2786c2'}).attr('href', btnUrl).append($('<span>').text('Void Contribution')));
-    
-    if (isView) {
-      statusRow = $("tr:contains('Contribution Status') td:nth-child(2)");
-    }
+  function addContributionVoidBtn ($, btnUrl) {
+    const contributionVoidActionBtn = $('<div>')
+      .css({ display: 'inline-flex', marginLeft: '10px' })
+      .append(
+        $('<a>')
+          .addClass('button btn-creditnote-create btn btn-primary-outline small-popup')
+          .css({ background: '#fff', border: '1px solid #2786c2', color: '#2786c2' })
+          .attr('href', btnUrl)
+          .append($('<span>').text('Void Contribution'))
+      );
 
-    statusRow.append(contributionVoidActionBtn)
-    $('#searchForm a.btn-creditnote-create').hide();
+    $('form.CRM_Contribute_Form_ContributionView, form.CRM_Contribute_Form_Contribution')
+      .find('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)')
+      .append(contributionVoidActionBtn);
   }
-});
+
+  if (typeof CRM !== 'undefined' && CRM.$) {
+    CRM.$(function ($) {
+      addContributionVoidBtn($, CRM.vars.financeextras.contribution_void_btn_url.replace(/&amp;/g, '&'));
+    });
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { addContributionVoidBtn };
+  }
+})();

--- a/js/addContributionVoidBtn.js
+++ b/js/addContributionVoidBtn.js
@@ -20,7 +20,7 @@
           .addClass('button btn-creditnote-create btn btn-primary-outline small-popup')
           .css({ background: '#fff', border: '1px solid #2786c2', color: '#2786c2' })
           .attr('href', btnUrl)
-          .append($('<span>').text('Void Contribution'))
+          .append($('<span>').text(ts('Void Contribution')))
       );
 
     $('form.CRM_Contribute_Form_ContributionView, form.CRM_Contribute_Form_Contribution')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,138 @@
       "version": "1.0.0",
       "license": "GNU Affero Public License 3.0",
       "devDependencies": {
-        "eslint": "^8.40.0"
+        "eslint": "^8.40.0",
+        "jquery": "^3.7.1",
+        "jsdom": "^24.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -157,6 +288,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -203,6 +344,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -217,6 +365,20 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -262,6 +424,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -282,6 +457,41 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -299,11 +509,28 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -315,6 +542,83 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -547,11 +851,77 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -600,6 +970,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -613,6 +996,102 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -695,11 +1174,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
@@ -721,6 +1214,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-schema-traverse": {
@@ -769,6 +1303,46 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -792,6 +1366,13 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -861,6 +1442,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -897,14 +1491,35 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -925,6 +1540,13 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -960,6 +1582,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -981,6 +1610,26 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/shebang-command": {
@@ -1040,11 +1689,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1070,6 +1755,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1077,6 +1772,78 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -1108,6 +1875,45 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
     "url": "https://github.com/compucorp/io.compuco.financeextras/issues"
   },
   "homepage": "https://github.com/compucorp/io.compuco.financeextras#readme",
+  "scripts": {
+    "test": "node --test tests/js/*.test.js"
+  },
   "devDependencies": {
-    "eslint": "^8.40.0"
+    "eslint": "^8.40.0",
+    "jquery": "^3.7.1",
+    "jsdom": "^24.1.0"
   }
 }

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+package-lock.json
+test-results/
+playwright-report/
+before/
+after/
+*.webm

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,43 @@
+# End-to-end tests (Playwright)
+
+These tests drive a real, running CiviCRM instance in a browser to guard against
+the "Create New Credit Note" / "Void Contribution" buttons leaking onto the
+**Find Contributions** search form (see `CIVIMM` bug), and to confirm both
+buttons still render on the contribution View page.
+
+They are **not** part of the extension's default CI (which only has a headless
+CiviCRM PHP environment). Run them against any environment that has this
+extension enabled.
+
+## Prerequisites
+
+- Node 18+ and `npx playwright install chromium`
+- A CiviCRM site with `io.compuco.financeextras` enabled
+- A **Completed** contribution to exercise (both buttons are eligible for it)
+
+## Running
+
+```bash
+cd tests/e2e
+npm install
+npx playwright install chromium
+
+CIVI_BASE_URL="http://your-civi.example" \
+CIVI_USER="admin" \
+CIVI_PASS="admin" \
+TEST_CONTRIBUTION_ID="123" \
+TEST_CONTACT_ID="456" \
+npm test
+```
+
+Videos are recorded for every test (`video: 'on'`) under `test-results/` — used
+as evidence on the fix PR.
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `CIVI_BASE_URL` | Base URL of the CiviCRM/Drupal site |
+| `CIVI_USER` / `CIVI_PASS` | Drupal login for a user who can view contributions |
+| `TEST_CONTRIBUTION_ID` | Id of a Completed contribution |
+| `TEST_CONTACT_ID` | Contact id that owns the contribution |

--- a/tests/e2e/creditnote-void-button.spec.js
+++ b/tests/e2e/creditnote-void-button.spec.js
@@ -35,8 +35,11 @@ test.describe('Contribution action buttons (Create New Credit Note / Void Contri
       window.CRM.$('<a class="crm-popup" href="' + url + '">View</a>').appendTo('body')[0].click();
     }, { id: CONTRIBUTION_ID, cid: CONTACT_ID });
 
-    // Allow the pop-up snippet + any injected page-header script to execute.
-    await page.waitForTimeout(4000);
+    // Wait for the View pop-up to load and its action button to be injected —
+    // this proves the button script has run, without a hardcoded delay.
+    const popupForm = page.locator('form.CRM_Contribute_Form_ContributionView');
+    await popupForm.waitFor({ state: 'visible' });
+    await popupForm.locator('a.btn-creditnote-create').first().waitFor({ state: 'visible' });
 
     await expect(
       page.locator('#Search a.btn-creditnote-create'),

--- a/tests/e2e/creditnote-void-button.spec.js
+++ b/tests/e2e/creditnote-void-button.spec.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+
+const CONTRIBUTION_ID = Number(process.env.TEST_CONTRIBUTION_ID);
+const CONTACT_ID = Number(process.env.TEST_CONTACT_ID);
+
+async function login (page) {
+  await page.goto('/user/login', { waitUntil: 'domcontentloaded' });
+  await page.fill('#edit-name', process.env.CIVI_USER);
+  await page.fill('#edit-pass', process.env.CIVI_PASS);
+  await Promise.all([
+    page.waitForURL('**/*', { waitUntil: 'domcontentloaded' }),
+    page.click('#edit-submit'),
+  ]);
+}
+
+test.describe('Contribution action buttons (Create New Credit Note / Void Contribution)', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  // Regression guard for the leak: opening a contribution View (which renders
+  // as a crm-popup from search results) must not inject the action buttons
+  // into the underlying Find Contributions search form.
+  test('do not leak onto the Find Contributions search form', async ({ page }) => {
+    await page.goto('/civicrm/contribute/search?reset=1');
+    await page.waitForFunction(() => window.CRM && window.CRM.$ && window.CRM.vars);
+
+    // Open the contribution View exactly as a search-result "View" link does.
+    await page.evaluate(({ id, cid }) => {
+      const url = window.CRM.url('civicrm/contact/view/contribution', {
+        reset: 1, id, cid, action: 'view', context: 'search', selectedChild: 'contribute',
+      });
+      window.CRM.$('<a class="crm-popup" href="' + url + '">View</a>').appendTo('body')[0].click();
+    }, { id: CONTRIBUTION_ID, cid: CONTACT_ID });
+
+    // Allow the pop-up snippet + any injected page-header script to execute.
+    await page.waitForTimeout(4000);
+
+    await expect(
+      page.locator('#Search a.btn-creditnote-create'),
+      'no action button should be injected into the #Search form'
+    ).toHaveCount(0);
+  });
+
+  // Guard that the fix does not break the intended placement: both buttons
+  // must still render on the contribution View page itself.
+  test('both render on the contribution View page', async ({ page }) => {
+    await page.goto(
+      `/civicrm/contact/view/contribution?reset=1&id=${CONTRIBUTION_ID}&cid=${CONTACT_ID}&action=view`,
+      { waitUntil: 'domcontentloaded' }
+    );
+
+    const form = page.locator('form.CRM_Contribute_Form_ContributionView');
+    await form.waitFor({ state: 'visible' });
+    await expect(form.locator('a.btn-creditnote-create span', { hasText: 'Create New Credit Note' })).toBeVisible();
+    await expect(form.locator('a.btn-creditnote-create span', { hasText: 'Void Contribution' })).toBeVisible();
+  });
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "financeextras-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright end-to-end tests for io.compuco.financeextras (contribution action buttons).",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
+  }
+}

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { defineConfig } = require('@playwright/test');
+
+/**
+ * These tests drive a real CiviCRM instance, so they are configured entirely
+ * from environment variables and are NOT wired into the extension's default
+ * CI (which has no browser/CiviCRM-web environment). See README.md.
+ *
+ *   CIVI_BASE_URL         e.g. http://compuclient-latest.localhost:8081
+ *   CIVI_USER / CIVI_PASS Drupal admin credentials
+ *   TEST_CONTRIBUTION_ID  a Completed contribution id
+ *   TEST_CONTACT_ID       that contribution's contact id
+ */
+module.exports = defineConfig({
+  testDir: '.',
+  timeout: 120000,
+  expect: { timeout: 30000 },
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.CIVI_BASE_URL,
+    headless: true,
+    video: 'on',
+    screenshot: 'only-on-failure',
+    ignoreHTTPSErrors: true,
+  },
+});

--- a/tests/js/addContributionCreditNoteBtn.test.js
+++ b/tests/js/addContributionCreditNoteBtn.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildContributionDom } = require('./fixtures');
+const { addCreditNoteBtn } = require('../../js/addContributionCreditNoteBtn.js');
+
+test('Create New Credit Note button attaches to the contribution form only, never the search form', () => {
+  const { $, document } = buildContributionDom();
+
+  addCreditNoteBtn($, '/civicrm/contribution/creditnote?reset=1&action=add&contribution_id=1');
+
+  assert.strictEqual(
+    document.querySelectorAll('#Search a.btn-creditnote-create').length,
+    0,
+    'button must NOT leak into the Find Contributions (#Search) form'
+  );
+
+  const inView = document.querySelectorAll('#ContributionView a.btn-creditnote-create');
+  assert.strictEqual(inView.length, 1, 'button must attach to the contribution view form');
+  assert.strictEqual(inView[0].querySelector('span').textContent, 'Create New Credit Note');
+});
+
+test('Create New Credit Note button href is preserved', () => {
+  const { $, document } = buildContributionDom();
+
+  addCreditNoteBtn($, '/civicrm/contribution/creditnote?reset=1&action=add&contribution_id=42');
+
+  const link = document.querySelector('#ContributionView a.btn-creditnote-create');
+  assert.strictEqual(link.getAttribute('href'), '/civicrm/contribution/creditnote?reset=1&action=add&contribution_id=42');
+});

--- a/tests/js/addContributionVoidBtn.test.js
+++ b/tests/js/addContributionVoidBtn.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildContributionDom } = require('./fixtures');
+const { addContributionVoidBtn } = require('../../js/addContributionVoidBtn.js');
+
+test('Void Contribution button attaches to the contribution form only, never the search form', () => {
+  const { $, document } = buildContributionDom();
+
+  addContributionVoidBtn($, '/civicrm/financeextras/contribution/void?reset=1&action=void&id=1');
+
+  assert.strictEqual(
+    document.querySelectorAll('#Search a.btn-creditnote-create').length,
+    0,
+    'button must NOT leak into the Find Contributions (#Search) form'
+  );
+
+  const inView = document.querySelectorAll('#ContributionView a.btn-creditnote-create');
+  assert.strictEqual(inView.length, 1, 'button must attach to the contribution view form');
+  assert.strictEqual(inView[0].querySelector('span').textContent, 'Void Contribution');
+});
+
+test('Void Contribution button href is preserved', () => {
+  const { $, document } = buildContributionDom();
+
+  addContributionVoidBtn($, '/civicrm/financeextras/contribution/void?reset=1&action=void&id=42');
+
+  const link = document.querySelector('#ContributionView a.btn-creditnote-create');
+  assert.strictEqual(link.getAttribute('href'), '/civicrm/financeextras/contribution/void?reset=1&action=void&id=42');
+});

--- a/tests/js/fixtures.js
+++ b/tests/js/fixtures.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { JSDOM } = require('jsdom');
+
+/**
+ * Builds a DOM that contains BOTH:
+ *   - a Find Contributions search form (#Search) whose row contains the text
+ *     "Contribution Status" but NOT the contribution status-row class, and
+ *   - a contribution View form (#ContributionView) whose status row carries
+ *     the `crm-contribution-form-block-contribution_status_id` class.
+ *
+ * This mirrors the real leak scenario: a contribution View pop-up injects the
+ * button script into the underlying search page. The old (loose `:contains`)
+ * selector matched the search row too; the fix must match the contribution
+ * form row only.
+ *
+ * @returns {{dom: object, $: Function, document: Document}}
+ */
+function buildContributionDom () {
+  const dom = new JSDOM(`<!DOCTYPE html><body>
+    <form id="Search" class="CRM_Contribute_Form_Search"><table><tbody>
+      <tr>
+        <td><label>Contribution Amounts</label></td>
+        <td><label>Contribution Status</label><select><option>Completed</option></select></td>
+      </tr>
+    </tbody></table></form>
+    <form id="ContributionView" class="CRM_Contribute_Form_ContributionView"><table><tbody>
+      <tr class="crm-contribution-form-block-contribution_status_id">
+        <td>Contribution Status</td>
+        <td>Completed</td>
+      </tr>
+    </tbody></table></form>
+  </body>`);
+
+  const $ = require('jquery')(dom.window);
+
+  return { dom, $, document: dom.window.document };
+}
+
+module.exports = { buildContributionDom };

--- a/tests/js/fixtures.js
+++ b/tests/js/fixtures.js
@@ -2,6 +2,10 @@
 
 const { JSDOM } = require('jsdom');
 
+// Stub CiviCRM's global ts() (i18n) so the button scripts under test, which
+// wrap their labels in ts(), don't throw a ReferenceError under jsdom/node.
+global.ts = (str) => str;
+
 /**
  * Builds a DOM that contains BOTH:
  *   - a Find Contributions search form (#Search) whose row contains the text

--- a/tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Civi\Financeextras\Hook\BuildForm\ContributionView;
+use Civi\Financeextras\Test\Fabricator\ContactFabricator;
+use Civi\Financeextras\Test\Fabricator\ContributionFabricator;
+
+/**
+ * Server-side coverage for the ContributionView build-form hook that enqueues
+ * the "Create New Credit Note" and "Void Contribution" action buttons.
+ *
+ * The client-side placement of those buttons (and the regression where they
+ * leaked onto the Find Contributions search form) is covered by the jsdom
+ * unit tests in tests/js/. These tests assert the hook only fires for the
+ * contribution View form and only enqueues each script for the right
+ * contribution states.
+ *
+ * @group headless
+ */
+class ContributionViewTest extends BaseHeadlessTest {
+
+  private const CREDIT_NOTE_SCRIPT = 'addContributionCreditNoteBtn.js';
+  private const VOID_SCRIPT = 'addContributionVoidBtn.js';
+
+  /**
+   * Builds a ContributionView form whose `id` resolves to the given
+   * contribution (the hook reads `$form->get('id')` in its constructor).
+   */
+  private function makeContributionViewForm(int $contributionId): CRM_Contribute_Form_ContributionView {
+    $form = new CRM_Contribute_Form_ContributionView();
+    $form->controller = new CRM_Core_Controller();
+    $form->set('id', $contributionId);
+
+    return $form;
+  }
+
+  private function fabricateContribution(string $status): array {
+    $contact = ContactFabricator::fabricate();
+
+    return ContributionFabricator::fabricate([
+      'financial_type_id' => 'Donation',
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 100,
+      'contact_id' => $contact['id'],
+      'contribution_status_id' => $status,
+      'currency' => 'GBP',
+    ]);
+  }
+
+  private function renderPageHeader(): string {
+    return CRM_Core_Region::instance('page-header')->render('');
+  }
+
+  public function testShouldHandleIsFalseForTheSearchForm(): void {
+    $form = $this->makeContributionViewForm(1);
+
+    $this->assertFalse(
+      ContributionView::shouldHandle($form, 'CRM_Contribute_Form_Search'),
+      'The hook must not run for the Find Contributions search form.'
+    );
+  }
+
+  public function testButtonScriptsEnqueuedForCompletedContribution(): void {
+    $contribution = $this->fabricateContribution('Completed');
+
+    (new ContributionView($this->makeContributionViewForm((int) $contribution['id'])))->handle();
+
+    $html = $this->renderPageHeader();
+    $this->assertStringContainsString(self::CREDIT_NOTE_SCRIPT, $html);
+    $this->assertStringContainsString(self::VOID_SCRIPT, $html);
+  }
+
+  public function testCreditNoteScriptNotEnqueuedForRefundedContribution(): void {
+    $contribution = $this->fabricateContribution('Refunded');
+
+    (new ContributionView($this->makeContributionViewForm((int) $contribution['id'])))->handle();
+
+    $html = $this->renderPageHeader();
+    $this->assertStringNotContainsString(self::CREDIT_NOTE_SCRIPT, $html);
+  }
+
+}

--- a/tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php
@@ -65,8 +65,8 @@ class ContributionViewTest extends BaseHeadlessTest {
     (new ContributionView($this->makeContributionViewForm((int) $contribution['id'])))->handle();
 
     $html = $this->renderPageHeader();
-    $this->assertStringContainsString(self::CREDIT_NOTE_SCRIPT, $html);
-    $this->assertStringContainsString(self::VOID_SCRIPT, $html);
+    $this->assertContains(self::CREDIT_NOTE_SCRIPT, $html);
+    $this->assertContains(self::VOID_SCRIPT, $html);
   }
 
   public function testCreditNoteScriptNotEnqueuedForRefundedContribution(): void {
@@ -75,7 +75,7 @@ class ContributionViewTest extends BaseHeadlessTest {
     (new ContributionView($this->makeContributionViewForm((int) $contribution['id'])))->handle();
 
     $html = $this->renderPageHeader();
-    $this->assertStringNotContainsString(self::CREDIT_NOTE_SCRIPT, $html);
+    $this->assertNotContains(self::CREDIT_NOTE_SCRIPT, $html);
   }
 
 }

--- a/tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php
+++ b/tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php
@@ -22,6 +22,17 @@ class ContributionViewTest extends BaseHeadlessTest {
   private const VOID_SCRIPT = 'addContributionVoidBtn.js';
 
   /**
+   * Reset the page-header region to a fresh instance before each test:
+   * CRM_Core_Region is a persistent singleton, so resources enqueued by one
+   * test would otherwise bleed into the next and break the "not enqueued"
+   * assertions. Unsetting the singleton (rather than clear()) keeps the
+   * built-in 'default' snippet that CRM_Core_Region::render() requires.
+   */
+  public function setUp(): void {
+    unset(\Civi::$statics['CRM_Core_Region']['page-header']);
+  }
+
+  /**
    * Builds a ContributionView form whose `id` resolves to the given
    * contribution (the hook reads `$form->get('id')` in its constructor).
    */
@@ -29,6 +40,9 @@ class ContributionViewTest extends BaseHeadlessTest {
     $form = new CRM_Contribute_Form_ContributionView();
     $form->controller = new CRM_Core_Controller();
     $form->set('id', $contributionId);
+    // The real ContributionView page assigns this; the hook's handleButtons()
+    // iterates it for Cancelled/Failed contributions, so provide it here.
+    $form->assign('linkButtons', []);
 
     return $form;
   }
@@ -69,8 +83,11 @@ class ContributionViewTest extends BaseHeadlessTest {
     $this->assertContains(self::VOID_SCRIPT, $html);
   }
 
-  public function testCreditNoteScriptNotEnqueuedForRefundedContribution(): void {
-    $contribution = $this->fabricateContribution('Refunded');
+  public function testCreditNoteScriptNotEnqueuedForCancelledContribution(): void {
+    // NB: a contribution cannot be created directly in "Refunded" status
+    // (CiviCRM coerces it to Completed); "Cancelled" is also in the hook's
+    // exclusion list and persists on create.
+    $contribution = $this->fabricateContribution('Cancelled');
 
     (new ContributionView($this->makeContributionViewForm((int) $contribution['id'])))->handle();
 


### PR DESCRIPTION
## CIVIMM-550

Fixes [CIVIMM-550](https://compucorp.atlassian.net/browse/CIVIMM-550) — the **Create New Credit Note** and **Void Contribution** buttons leaking onto the **Find Contributions** search page.

### Before

[DEMO-before-leak-on-search-form.webm](https://github.com/user-attachments/assets/c261fa3c-a006-45eb-8e60-fc035a31dac8)

### After

[DEMO-after-no-leak.webm](https://github.com/user-attachments/assets/82ef685f-691d-4a27-b22e-06a1b9d5e1f0)

### Problem

Both action buttons (which belong on a contribution View/Edit screen, next to the status) were appearing on the Find Contributions search form (`CRM_Contribute_Form_Search`), attached to the *Contribution Status* search-criteria cell. The leaked button targets the *last-viewed* contribution, so it's a data-integrity risk, not just cosmetic. Observed on live client sites; reproducible from 2.x through 7.1.0.

### Root cause

The buttons are injected by `js/addContributionCreditNoteBtn.js` / `js/addContributionVoidBtn.js`, enqueued to the `page-header` region by `ContributionView`. Three compounding factors:

1. A contribution **View opens as a `crm-popup`** (AJAX snippet); its `page-header` resources execute against the **underlying page** (the search page), not the dialog.
2. When `is_contribution_view` was set, both scripts used a **global text selector** — `$("tr:contains('Contribution Status') td:nth-child(2)")` — which matches the search form's *"Contribution Amounts | Contribution Status"* row.
3. The existing guard `$('#searchForm a.btn-creditnote-create').hide()` was a **no-op**: the Find Contributions form's DOM id is `Search`, not `searchForm`.

(History: the loose selector shipped in CIWEMV-431; CIWEM-583 *"Hide create creditnote button on searchform"* tried to fix it but used the wrong id, so it never worked.)

### Fix

Scope the insertion in both scripts to the **contribution form container** and the **precise status-row class**, and remove the loose `is_contribution_view` branch and the dead `#searchForm` guard:

```js
$('form.CRM_Contribute_Form_ContributionView, form.CRM_Contribute_Form_Contribution')
  .find('tr.crm-contribution-form-block-contribution_status_id > td:nth-child(2)')
  .append(actionBtn);
```

This can only match a status row inside a contribution view/add/edit form — never `CRM_Contribute_Form_Search`. Each script is wrapped so the placement function can be unit-tested while browser behaviour is unchanged.

### Tests

- **JS/DOM unit tests** (`tests/js/`, jsdom + `node --test`, wired into CI via `.github/workflows/js-tests.yml`): assert each button attaches to the contribution form and **never** to a search-form row. Run: `npm test`.
- **PHPUnit** (`tests/phpunit/Civi/Financeextras/Hook/BuildForm/ContributionViewTest.php`): the `ContributionView` hook only fires for the contribution View form and enqueues each script for the right contribution state.
- **Playwright e2e** (`tests/e2e/`, env-driven, committed for future CI): reproduces the search-form leak-guard and confirms both buttons still render on the View page.

### Verification done locally

- `npm test` → **4/4 pass** (red-first confirmed against the unfixed code); ESLint `--max-warnings=0` clean; phpcs clean on the new PHP file.
- Playwright run against a CiviCRM 7.1-line site (both buttons present): **before** = leak reproduced (2 buttons in `#Search`); **after** = 0 leak and both buttons still render on the View. Evidence videos below.

_PHPUnit runs in this PR's CI (headless CiviCRM)._
