### PR TITLE
CSTMM-273: Fix activity attachment

### DIFF
--- a/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
+++ b/Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php
@@ -52,26 +52,33 @@ class CreditNoteInvoiceSubscriber implements EventSubscriberInterface {
    * @param array $targetContactIds
    * @param string $type
    * @param string $subject
-   * @param array $attachment
+   * @param string $attachment
    * @param string $details
    */
   private function createActivity($targetContactIds, $type, $subject, $attachment, $details) {
     $now = (new DateTime())->format('YmdHis');
     $currentUser = \CRM_Core_Session::singleton()->get('userID');
-    \Civi\Api4\Activity::create(FALSE)
+    $activity = \Civi\Api4\Activity::create(FALSE)
       ->addValue('subject', $subject)
       ->addValue('target_contact_id', $targetContactIds)
       ->addValue('source_contact_id', $currentUser)
       ->addValue('activity_type_id:name', $type)
       ->addValue('activity_date_time', $now)
       ->addValue('details', $details)
-      ->addValue('attachFile_1', [
-        'uri' => $attachment,
-        'type' => 'application/pdf',
-        'location' => $attachment,
-        'upload_date' => date('YmdHis'),
-      ])
-      ->execute();
+      ->execute()
+      ->first();
+
+    if (!empty($attachment)) {
+      $attachmentParams = [
+        'attachFile_1' => [
+          'uri' => $attachment,
+          'type' => 'application/pdf',
+          'location' => $attachment,
+          'upload_date' => date('YmdHis'),
+        ],
+      ];
+      \CRM_Core_BAO_File::processAttachment($attachmentParams, 'civicrm_activity', $activity['id']);
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview

Fixes credit note PDF attachments no longer appearing on "Downloaded Credit Note" / "Emailed Credit Note" activities in the financeextras extension, after a recent CiviCRM security patch removed attachment processing from the Activity API/BAO.

## Before

- Downloading a credit note PDF creates the download activity, but the credit note PDF is missing from the activity's attachments.
- Emailing a credit note creates the email activity, but the credit note PDF is missing from the activity's attachments.

## After

- The credit note PDF is correctly attached to both the download and email credit note activities, as it was before the security patch.

## Technical Details

A recent CiviCRM security patch deliberately removed attachment processing (`attachFile_N` params) from the Activity API and BAO, to prevent API callers from manipulating the filesystem. Attachment processing was moved to the form layer — patched core forms now call `CRM_Core_BAO_File::processAttachment()` explicitly after creating the activity (see `CRM_Contact_Form_Task_EmailTrait::createEmailActivity()`).

`CreditNoteInvoiceSubscriber::createActivity()` was still relying on the old behaviour, passing `attachFile_1` as a value to APIv4 `Activity::create()`. APIv4 forwards extra values to the BAO, which no longer processes them, so the attachment was silently dropped.

Changes in `Civi/Financeextras/Event/Subscriber/CreditNoteInvoiceSubscriber.php`, `createActivity()`:

1. Removed the `attachFile_1` value from the APIv4 `Activity::create()` call — it is no longer processed there.
2. Captured the created activity (`->execute()->first()`) and processed the attachment explicitly, following the same pattern core now uses:

```php
if (!empty($attachment)) {
  $attachmentParams = [
    'attachFile_1' => [
      'uri' => $attachment,
      'type' => 'application/pdf',
      'location' => $attachment,
      'upload_date' => date('YmdHis'),
    ],
  ];
  \CRM_Core_BAO_File::processAttachment($attachmentParams, 'civicrm_activity', $activity['id']);
}
```

3. The `processAttachment()` call is guarded with `!empty($attachment)` because `storeFile()` can return an empty string if PDF generation fails — previously this would have silently created a broken attachment param.
4. Fixed an incorrect docblock type on `createActivity()` (`@param array $attachment` → `string`, it's a file path).

No `unlink()` handling is needed: the file written by `CRM_Utils_Mail::appendPDF()` is moved into the custom file upload directory by `processAttachment()` → `filePostProcess()`, and this subscriber never unlinked it.

### Core overrides

None. The change is confined to the financeextras extension.

## Comments

- Companion fixes for the same issue exist in separate PRs: the invoicehelper extension override and core's `CRM/Contribute/Form/Task/Invoice.php`.
- Both the download and email flows funnel through the single private `createActivity()` method, so one change covers both.